### PR TITLE
julia: add array indexing & link to doc

### DIFF
--- a/languages/julia/README.md
+++ b/languages/julia/README.md
@@ -52,7 +52,10 @@
 - Abstract type
 - Struct
 - Tuple
-- Array
+- [Array](../../types/array.md)
+  - 1-based indexing
+  - Arbitrary indexing
+  - Multidimensional arrays
 - Dict
 - Symbol
 - `Expr`ession


### PR DESCRIPTION
This is mostly to test if codeowners work but also an actual addition to the types because it's a common issue among beginners (see survey in the readme)