### PR TITLE
julia: Add CI

### DIFF
--- a/.github/workflows/julia-ci.yml
+++ b/.github/workflows/julia-ci.yml
@@ -1,0 +1,34 @@
+name: Julia CI
+
+on:
+  push:
+    paths:
+    - '**.jl'
+    - 'languages/julia/**'
+  pull_request:
+    paths:
+    - '**.jl'
+    - 'languages/julia/**'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: ['1.0', '1.1', '1.2', '1.3', nightly]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    
+    steps:
+      - uses: actions/checkout@v1.0.0
+
+      - name: "Set up Julia ${{ matrix.julia-version }}"
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+
+      - name: Test exercises
+        run: |
+          cd languages/julia/
+          julia --color=yes runtests.jl
+        shell: bash


### PR DESCRIPTION
Preparation for adding more concept exercises. Runs the basic track CI to test the Julia concept exercises.

It only triggers builds if files ending in `.jl` or in the `languages/julia/` directory are changed, so it should not affect anyone else's work.