### PR TITLE
[Haskell] v3 config.json stub

### DIFF
--- a/languages/haskell/README.md
+++ b/languages/haskell/README.md
@@ -27,10 +27,10 @@ Before launch, we need all of the following parts to be completed:
 
 - [ ] Implemented 20+ Concept Exercises
 - [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
+  - [x] Added `version` key
+  - [x] Added online editor settings
+    - [x] Added `indent_style`
+    - [x] Added `indent_size`
   - [ ] Added Concept Exercises
   - [ ] Added Concepts for all Practice Exercises
 

--- a/languages/haskell/config.json
+++ b/languages/haskell/config.json
@@ -1,5 +1,5 @@
 {
-  "language": "Elixir",
+  "language": "Haskell",
   "version": 3,
   "active": true,
   "blurb": "Haskell is a functional programming language which is pure and statically-typed. It's known for lazy evaluation, where evaluation is deferred until necessary, and its purity, where monads are used for working with side-effects.",

--- a/languages/haskell/config.json
+++ b/languages/haskell/config.json
@@ -1,0 +1,16 @@
+{
+  "language": "Elixir",
+  "version": 3,
+  "active": true,
+  "blurb": "Haskell is a functional programming language which is pure and statically-typed. It's known for lazy evaluation, where evaluation is deferred until necessary, and its purity, where monads are used for working with side-effects.",
+  "online_editor": {
+    "indent_style": "space",
+    "indent_size": 2
+  },
+  "ignore_pattern": "example",
+  "solution_pattern": "example.*[.]hs",
+  "exercises": {
+    "concept": [],
+    "practice": []
+  }
+}


### PR DESCRIPTION
This stub contains all things necessary but the list of exercises.

The example C# config.json did not contain the fields `ignore_pattern` and `solution_pattern` present in Haskell's config.json, but the [migration guide][1] also did not speak of deprecating any properties.

For this reason, this PR preserves those properties and adds new ones.

[1]: https://github.com/exercism/v3/blob/master/docs/maintainers/migrating-your-config-json-files.md