### PR TITLE
[CI] Run link check regularly

### DIFF
--- a/.github/workflows/valid-links.yml
+++ b/.github/workflows/valid-links.yml
@@ -1,6 +1,10 @@
 name: Check for dead links
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 3 * * *'
 
 jobs:
   verify-links:


### PR DESCRIPTION
> TBH I don't care that much about external links _at time of merge_, but we should check it periodically.

_Originally posted by @SleeplessByte in https://github.com/exercism/v3/issues/102#issuecomment-575100267_

---

Regardless of the other changes requested in #102, running it regularly is a good idea.

In its current state, it sends a notification in case the build breaks, but it might also be possible to open an issue instead if that's preferred