### PR TITLE
Reword information on concept exercises for clarity

### DIFF
--- a/docs/maintainers/determining-concepts.md
+++ b/docs/maintainers/determining-concepts.md
@@ -14,7 +14,7 @@ When starting this process, we **strongly** recommend you seek help from others 
 
 ## Concept Exercises
 
-Generally only **one new Concept** should be introduced per Concept Exercise. 
+Generally, only **one new Concept** should be introduced per Concept Exercise. 
 
 In order to keep the exercises interesting, maintainers may choose to introduce multiple _trivial_ Concepts in one exercise.
 A _trivial_ Concept is one where we can reasonably assume that most programmers will quickly grasp it, due to prior familiarity, albeit with differing syntax. Examples might be basic number usage (`+`, `-`, `*`, etc.), or conditionals (`if/else`).

--- a/docs/maintainers/determining-concepts.md
+++ b/docs/maintainers/determining-concepts.md
@@ -14,7 +14,7 @@ Filling out the concepts will be iterative, it is hard to get this right immedia
 
 Generally only **one new Concept** should be introduced per Concept Exercise. 
 
-In order to keep the exercises interesting, maintainers may choose to multiple _trivial_ Concepts in one exercise.
+In order to keep the exercises interesting, maintainers may choose to introduce multiple _trivial_ Concepts in one exercise.
 A _trivial_ Concept is one where we can reasonably assume that a programmer will quickly grasp it, because they will generally be learning a remapping of syntax for existing knowledge. Examples might be basic number usage (`+-/*`), or conditionals (`if/else`).
 
 Every new concept introducted, regardless of how _trivial_ it seems, must have some attention give to it in the exercise's introductions. Each should focus on how that Concept is applied in the given language, with links to learn more on the topic. If there is nothing special about it, a language-agnostic link is helpful.

--- a/docs/maintainers/determining-concepts.md
+++ b/docs/maintainers/determining-concepts.md
@@ -15,7 +15,7 @@ Filling out the concepts will be iterative, it is hard to get this right immedia
 Generally only **one new Concept** should be introduced per Concept Exercise. 
 
 In order to keep the exercises interesting, maintainers may choose to introduce multiple _trivial_ Concepts in one exercise.
-A _trivial_ Concept is one where we can reasonably assume that a programmer will quickly grasp it, because they will generally be learning a remapping of syntax for existing knowledge. Examples might be basic number usage (`+-/*`), or conditionals (`if/else`).
+A _trivial_ Concept is one where we can reasonably assume that most programmers will quickly grasp it, due to prior familiarity, albeit with differing syntax. Examples might be basic number usage (`+`, `-`, `*`, etc.), or conditionals (`if/else`).
 
 Every new concept introducted, regardless of how _trivial_ it seems, must have some attention give to it in the exercise's introductions. Each should focus on how that Concept is applied in the given language, with links to learn more on the topic. If there is nothing special about it, a language-agnostic link is helpful.
 

--- a/docs/maintainers/determining-concepts.md
+++ b/docs/maintainers/determining-concepts.md
@@ -12,7 +12,7 @@ Filling out the concepts will be iterative, it is hard to get this right immedia
 
 ## Concept Exercises
 
-Generally only **one new concept** should be introduced per concept exercise. 
+Generally only **one new concept** should be introduced per Concept Exercise. 
 
 In order to keep the exercises interesting, maintainers may choose to multiple _trivial_ Concepts in one exercise.
 A _trivial_ Concept is one where we can reasonably assume that a programmer will quickly grasp it, because they will generally be learning a remapping of syntax for existing knowledge. Examples might be basic number usage (`+-/*`), or conditionals (`if/else`).

--- a/docs/maintainers/determining-concepts.md
+++ b/docs/maintainers/determining-concepts.md
@@ -2,13 +2,15 @@
 
 It is worth reading the start of the [Concept Exercises](../concept-exercises.md) file to familiarise yourself with Concept Exercises and why writing out concepts is important.
 
-To know which Concept Exercises should exist, a list of the language's concepts should first be compiled. There are various resources to use when compiling this list: books, (official) documentation, your own experiences and the [concepts listed in this repository](../../reference/concepts/README.md).
+To determine which Concept Exercises should be written for your language, should should first compile a list of your language's Concepts. There are various resources to use when compiling this list: books, (official) documentation, your own experiences and the [concepts listed in this repository](../../reference/concepts/README.md).
 
 As many languages use the same concepts (but possibly implemented differently), it can greatly help to look at what other languages have already done in this regard. See the [C# concepts](../../languages/csharp/reference/README.md) for an example.
 
 It can also be helpful to group related concepts. For example, the Classes, Polymorphism and Inheritance concepts are all object-oriented concepts, which can then be grouped as "Object-oriented concepts".
 
 Filling out the concepts will be iterative, it is hard to get this right immediately. While creating concepts exercises, you'll probably find missing concepts or perhaps want to split out concepts.
+
+When starting this process, we **strongly** recommend you seek help from others who have defined Concepts, by asking questions on the [#v3 channel on Slack](https://exercism-team.slack.com/archives/CR91YFNG3).
 
 ## Concept Exercises
 

--- a/docs/maintainers/determining-concepts.md
+++ b/docs/maintainers/determining-concepts.md
@@ -17,6 +17,6 @@ Generally only **one new Concept** should be introduced per Concept Exercise.
 In order to keep the exercises interesting, maintainers may choose to introduce multiple _trivial_ Concepts in one exercise.
 A _trivial_ Concept is one where we can reasonably assume that most programmers will quickly grasp it, due to prior familiarity, albeit with differing syntax. Examples might be basic number usage (`+`, `-`, `*`, etc.), or conditionals (`if/else`).
 
-Every new concept introducted, regardless of how _trivial_ it seems, must have some attention give to it in the exercise's introductions. Each should focus on how that Concept is applied in the given language, with links to learn more on the topic. If there is nothing special about it, a language-agnostic link is helpful.
+Every new Concept introduced, regardless of how _trivial_ it may seem, must be explicitly mentioned in the exercise's introduction. Each mention should focus on how that Concept is applied in the given language, with links to learn more on the topic. If there is nothing special about it, a language-agnostic link is helpful.
 
 All Concepts covered in a Concept Exercise must either be taught by it, or must be marked as a prerequisite in the `config.json`.

--- a/docs/maintainers/determining-concepts.md
+++ b/docs/maintainers/determining-concepts.md
@@ -12,8 +12,11 @@ Filling out the concepts will be iterative, it is hard to get this right immedia
 
 ## Concept Exercises
 
-Generally there should be only one new concept introduced per concept exercise. There might be exceptions for _trivial_ concepts (like e.g. `int` in C#) that could be introduced in other concept exercises (e.g. `conditionals`).
-It should then get some attention in the introduction to that exercise with links on the topic -- even if it is basically just teaching operators `+.*/`.
-The focus in the introduction on _trivial_ concepts should be the same as on other concept introductions: how is it done in this language? If there is nothing special about it, a language-agnostic link is helpful.
+Generally only **one new concept** should be introduced per concept exercise. 
 
-Apart from trivial concepts, if a Concept Exercise requires another concept to solve it, that should be a prerequisite. For example, a Concept Exercise on floating point numbers that requires using loops should have the `loops` concept as a prerequisite.
+In order to keep the exercises interesting, maintainers may choose to multiple _trivial_ Concepts in one exercise.
+A _trivial_ Concept is one where we can reasonably assume that a programmer will quickly grasp it, because they will generally be learning a remapping of syntax for existing knowledge. Examples might be basic number usage (`+-/*`), or conditionals (`if/else`).
+
+Every new concept introducted, regardless of how _trivial_ it seems, must have some attention give to it in the exercise's introductions. Each should focus on how that Concept is applied in the given language, with links to learn more on the topic. If there is nothing special about it, a language-agnostic link is helpful.
+
+All Concepts covered in a Concept Exericse must either by taught by it, or must be marked as a prerequisite in the `config.json`.

--- a/docs/maintainers/determining-concepts.md
+++ b/docs/maintainers/determining-concepts.md
@@ -12,7 +12,7 @@ Filling out the concepts will be iterative, it is hard to get this right immedia
 
 ## Concept Exercises
 
-Generally only **one new concept** should be introduced per Concept Exercise. 
+Generally only **one new Concept** should be introduced per Concept Exercise. 
 
 In order to keep the exercises interesting, maintainers may choose to multiple _trivial_ Concepts in one exercise.
 A _trivial_ Concept is one where we can reasonably assume that a programmer will quickly grasp it, because they will generally be learning a remapping of syntax for existing knowledge. Examples might be basic number usage (`+-/*`), or conditionals (`if/else`).

--- a/docs/maintainers/determining-concepts.md
+++ b/docs/maintainers/determining-concepts.md
@@ -2,7 +2,7 @@
 
 It is worth reading the start of the [Concept Exercises](../concept-exercises.md) file to familiarise yourself with Concept Exercises and why writing out Concepts is important.
 
-To determine which Concept Exercises should be written for your language, should should first compile a list of your language's Concepts. There are various resources to use when compiling this list: books, (official) documentation, your own experiences and the [concepts listed in this repository](../../reference/concepts/README.md).
+To determine which Concept Exercises should be written for your language, you should first compile a list of your language's Concepts. There are various resources to use when compiling this list: books, (official) documentation, your own experiences and the [concepts listed in this repository](../../reference/concepts/README.md).
 
 As many languages use the same Concepts (but possibly implemented differently), it can greatly help to look at what other languages have already done in this regard. See the [C# concepts](../../languages/csharp/reference/README.md) for an example.
 

--- a/docs/maintainers/determining-concepts.md
+++ b/docs/maintainers/determining-concepts.md
@@ -19,4 +19,4 @@ A _trivial_ Concept is one where we can reasonably assume that most programmers 
 
 Every new concept introducted, regardless of how _trivial_ it seems, must have some attention give to it in the exercise's introductions. Each should focus on how that Concept is applied in the given language, with links to learn more on the topic. If there is nothing special about it, a language-agnostic link is helpful.
 
-All Concepts covered in a Concept Exericse must either by taught by it, or must be marked as a prerequisite in the `config.json`.
+All Concepts covered in a Concept Exercise must either be taught by it, or must be marked as a prerequisite in the `config.json`.

--- a/docs/maintainers/determining-concepts.md
+++ b/docs/maintainers/determining-concepts.md
@@ -1,14 +1,14 @@
 # Choosing and defining Concepts
 
-It is worth reading the start of the [Concept Exercises](../concept-exercises.md) file to familiarise yourself with Concept Exercises and why writing out concepts is important.
+It is worth reading the start of the [Concept Exercises](../concept-exercises.md) file to familiarise yourself with Concept Exercises and why writing out Concepts is important.
 
 To determine which Concept Exercises should be written for your language, should should first compile a list of your language's Concepts. There are various resources to use when compiling this list: books, (official) documentation, your own experiences and the [concepts listed in this repository](../../reference/concepts/README.md).
 
-As many languages use the same concepts (but possibly implemented differently), it can greatly help to look at what other languages have already done in this regard. See the [C# concepts](../../languages/csharp/reference/README.md) for an example.
+As many languages use the same Concepts (but possibly implemented differently), it can greatly help to look at what other languages have already done in this regard. See the [C# concepts](../../languages/csharp/reference/README.md) for an example.
 
-It can also be helpful to group related concepts. For example, the Classes, Polymorphism and Inheritance concepts are all object-oriented concepts, which can then be grouped as "Object-oriented concepts".
+It can also be helpful to group related Concepts. For example, the Classes, Polymorphism and Inheritance Concepts are all object-oriented Concepts, which can then be grouped as "Object-oriented concepts".
 
-Filling out the concepts will be iterative, it is hard to get this right immediately. While creating concepts exercises, you'll probably find missing concepts or perhaps want to split out concepts.
+Filling out the Concepts will be iterative, it is hard to get this right immediately. While creating concepts exercises, you'll probably find missing concepts or perhaps want to split out concepts.
 
 When starting this process, we **strongly** recommend you seek help from others who have defined Concepts, by asking questions on the [#v3 channel on Slack](https://exercism-team.slack.com/archives/CR91YFNG3).
 


### PR DESCRIPTION
I've reworded things slightly. My main aim was to give clear rules about all concepts/concept exercises, and have a distinctive paragraph about the multiple trivial ideas.

As a side note, we are capitalizing `Concept` and `Concept Exercise`, as I am treating both as Proper Nouns in the context of Exercism. (e.g. It helps when you have sentences like "I get the concept of Concepts")