### PR TITLE
Do not check absolute links

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https?:\/\/"
+    }
+  ]
+}

--- a/.github/workflows/valid-links.yml
+++ b/.github/workflows/valid-links.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Install markdown-link-check
         run: npm install -g markdown-link-check
       - name: Verify links
-        run: find . -name \*.md ! -iname _sidebar.md ! -ipath \*/ISSUE_TEMPLATE/\*.md -print0 | xargs -0 -n1 markdown-link-check -q
+        run: find . -name \*.md ! -iname _sidebar.md ! -ipath \*/ISSUE_TEMPLATE/\*.md -print0 | xargs -0 -n1 markdown-link-check -q -c .github/markdown-link-check-config.json


### PR DESCRIPTION
Absolute links are slow and problematic, so I'm blocking them for now. As we improve the link checker we can add this back, either as part of CI or a periodic check, long before v3 is launched.