### PR TITLE
[erlang] initial migration of config

### DIFF
--- a/languages/erlang/README.md
+++ b/languages/erlang/README.md
@@ -27,10 +27,10 @@ Before launch, we need all of the following parts to be completed:
 
 - [ ] Implemented 20+ Concept Exercises
 - [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
+  - [x] Added `version` key
+  - [x] Added online editor settings
+    - [x] Added `indent_style`
+    - [x] Added `indent_size`
   - [ ] Added Concept Exercises
   - [ ] Added Concepts for all Practice Exercises
 

--- a/languages/erlang/config.json
+++ b/languages/erlang/config.json
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "online_editor": {
+    "indent_style": "space",
+    "indent_size": 4
+  },
+  "exercises": {
+    "concept": [],
+    "practice": []
+  }
+}


### PR DESCRIPTION
The current settings for the online editor ar by far set in stone.

I've choosen them for now as those are the defaults in the emacs `erlang-mode` which seems to be pretty the standard editor for most Erlang developers.

Though on the other hand side, about every other Erlang project you take a look at, uses slightly different conventions.

Though an indent of either 2 or 4 seems to be quite common, but I've also seen projects that have an indent of 4 but do half indent for some language constructs.

