### PR TITLE
[Java] add sshine, mirko, pdmoore and msomji as contributing maintainers

### DIFF
--- a/languages/java/maintainers.md
+++ b/languages/java/maintainers.md
@@ -2,10 +2,15 @@
 
 These awesome people help maintain the Java track.
 
+<!-- sorted alphabetically, lexographically -->
+
 ## Senior Maintainers
 
-TODO: add senior maintainers
+None yet.
 
 ## Contributing Maintainers
 
-TODO: add contributing maintainers
+- Maisam Somji (Slack: `@msomji`, GitHub: [msomji](https://github.com/msomji))
+- Mirko Perillo (Slack: `@mirko`, GitHub: [mirkoperillo](https://github.com/mirkoperillo))
+- Paul Moore (Slack: `@Paul Moore`, GitHub: [pdmoore](https://github.com/pdmoore))
+- Simon Shine (GitHub: [sshine](https://github.com/sshine))

--- a/languages/java/maintainers.md
+++ b/languages/java/maintainers.md
@@ -2,8 +2,6 @@
 
 These awesome people help maintain the Java track.
 
-<!-- sorted alphabetically, lexographically -->
-
 ## Senior Maintainers
 
 None yet.


### PR DESCRIPTION
@msomji: Since #184 seems to be stuck on a consistently failing "Pull Request Labeler", I'd like to see what happens if we follow the guidelines of prefixing the pull request with `[Java]` and naming the branch `java/...`. I don't know if these are what triggered it to fail, or if the error is to be found elsewhere, so consider this a test.