### PR TITLE
[CI] Fix rebase action not working

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+      with:
+        fetch-depth: 0
     - name: Automatic Rebase
       uses: cirrus-actions/rebase@cf2ad5908b365d40882ef06dab959717ec1aaf71 # 1.2
       env:


### PR DESCRIPTION
There was an issue where the rebase GH action did not work. This was due to only the latest commit being fetched. The fix was documented [here](https://github.com/cirrus-actions/rebase/issues/32#event-2960363002).