### PR TITLE
[PureScript] Strikethrough "Kick off discussion" in readme

### DIFF
--- a/languages/purescript/README.md
+++ b/languages/purescript/README.md
@@ -12,7 +12,7 @@ This area will contain everything needed to launch the PureScript track, includi
 
 Before we publicize requesting contribution for this language, the following steps should be done.
 
-- [ ] Have a kick-off discussion between track maintainers
+- [x] ~~Have a kick-off discussion between track maintainers~~
 - [x] Fill out the [maintainers.md](./maintainers.md) file (e.g. [C#](../csharp/maintainers.md))
 - [x] Ensure there is a link to your track's GitHub issues on the [main README.md](../../README.md)
 - [ ] [Write a Concept Exercise implementation guide](../../docs/maintainers/writing-a-concept-exercise-github-issue.md)

--- a/languages/purescript/README.md
+++ b/languages/purescript/README.md
@@ -13,7 +13,7 @@ This area will contain everything needed to launch the PureScript track, includi
 Before we publicize requesting contribution for this language, the following steps should be done.
 
 - [ ] Have a kick-off discussion between track maintainers
-- [ ] Fill out the [maintainers.md](./maintainers.md) file (e.g. [C#](../csharp/maintainers.md))
+- [x] Fill out the [maintainers.md](./maintainers.md) file (e.g. [C#](../csharp/maintainers.md))
 - [x] Ensure there is a link to your track's GitHub issues on the [main README.md](../../README.md)
 - [ ] [Write a Concept Exercise implementation guide](../../docs/maintainers/writing-a-concept-exercise-github-issue.md)
 - [ ] [List out key Concepts for your language](../../docs/maintainers/determining-concepts.md)

--- a/languages/purescript/maintainers.md
+++ b/languages/purescript/maintainers.md
@@ -4,7 +4,7 @@ These awesome people help maintain the PureScript track.
 
 ## Senior Maintainers
 
-TODO: add senior maintainers
+None yet.
 
 ## Contributing Maintainers
 


### PR DESCRIPTION
Considering I am currently the only PureScript maintainer, I've removed the kick off discussion from the readme.