### PR TITLE
[PureScript] cross off have a kick off discussion in readme

### DIFF
--- a/languages/purescript/README.md
+++ b/languages/purescript/README.md
@@ -12,7 +12,7 @@ This area will contain everything needed to launch the PureScript track, includi
 
 Before we publicize requesting contribution for this language, the following steps should be done.
 
-- [ ] Have a kick-off discussion between track maintainers
+- [x] ~~Have a kick-off discussion between track maintainers~~
 - [ ] Fill out the [maintainers.md](./maintainers.md) file (e.g. [C#](../csharp/maintainers.md))
 - [x] Ensure there is a link to your track's GitHub issues on the [main README.md](../../README.md)
 - [ ] [Write a Concept Exercise implementation guide](../../docs/maintainers/writing-a-concept-exercise-github-issue.md)


### PR DESCRIPTION
I am the only PureScript maintainer. So I've crossed it off in the readme. We can have the discussion once more maintainers appear.

EDIT: Just found out @spicydonuts is also still actively maintaining PureScript. Still not sure if the discussion should take place or not, though.