### PR TITLE
[TypeScript] Add implementing a concept docs

### DIFF
--- a/languages/javascript/docs/implementing-a-concept-exercise.md
+++ b/languages/javascript/docs/implementing-a-concept-exercise.md
@@ -16,7 +16,7 @@ To implement a Concept Exercise, the following files must be created:
 
 <pre>
 languages
-└── csharp
+└── javascript
     └── exercises
         └── concept
             └── &lt;slug&gt;
@@ -45,7 +45,7 @@ This file contains instructions for the exercise. It should explicitly explain w
 
 ## Step 3: add .docs/hints.md
 
-If the user gets stuck, we will allow them to click a button requesting a hint, which shows this file. We will softly discourage them using it. The file should contain both general and task-specific "hints". These hints should be enough to unblock almost any
+If the user gets stuck, we will allow them to click a button requesting a hint, which shows this file. We will softly discourage them using it. The file should contain both general and task-specific "hints". These hints should be enough to unblock almost any problem the user would face.
 
 ## Step 4: add .docs/after.md (optional):
 

--- a/languages/typescript/README.md
+++ b/languages/typescript/README.md
@@ -15,7 +15,7 @@ Before we publicize requesting contribution for this language, the following ste
 - [ ] Have a kick-off discussion between track maintainers
 - [ ] Fill out the [maintainers.md](./maintainers.md) file (e.g. [C#](../csharp/maintainers.md))
 - [x] Ensure there is a link to your track's GitHub issues on the [main README.md](../../README.md)
-- [ ] [Write a Concept Exercise implementation guide](../../docs/maintainers/writing-a-concept-exercise-github-issue.md)
+- [x] [Write a Concept Exercise implementation guide](../../docs/maintainers/writing-a-concept-exercise-github-issue.md)
 - [ ] [List out key Concepts for your language](../../docs/maintainers/determining-concepts.md)
 - [ ] [Add GitHub issues for 20 Concept Exercises](../../docs/maintainers/writing-a-concept-exercise-github-issue.md)
 

--- a/languages/typescript/docs/implementing-a-concept-exercise.md
+++ b/languages/typescript/docs/implementing-a-concept-exercise.md
@@ -25,12 +25,12 @@ languages
                 |   ├── introduction.md
                 |   ├── hints.md
                 |   └── after.md (optional)
+                ├── .eslintignore
                 ├── .eslintrc
-                ├── .gitignore
-                ├── babel.config.js
-                ├── example.js
-                ├── &lt;slug&gt;.js
-                ├── &lt;slug&gt;.spec.js
+                ├── jest.config.js
+                ├── example.ts
+                ├── &lt;slug&gt;.ts
+                ├── &lt;slug&gt;.spec.ts
                 ├── package.json
                 └── yarn.lock
 </pre>
@@ -85,6 +85,7 @@ The configuration files may be copied from another exercise. We aim to keep thes
 - `jest.config.js`
 - `package.json`
 - `tsconfig.json`
+- `yarn.lock`
 
 The `package.json` file must be edited:
 

--- a/languages/typescript/docs/implementing-a-concept-exercise.md
+++ b/languages/typescript/docs/implementing-a-concept-exercise.md
@@ -1,5 +1,141 @@
-# How to implement an TypeScript concept exercise
+# How to implement a TypeScript Concept Exercise
 
-TODO: describe how to implement a concept exercise for the TypeScript track. For inspiration, check out the [C# version of this file][csharp-implementing].
+This document describes how to implement a Concept Exercise for the TypeScript track. As this document is generic, the following placeholders are used:
 
-[csharp-implementing]: ../../csharp/docs/implementing-a-concept-exercise.md
+- `<slug>`: the name of the exercise in snake_case (e.g. `anonymous-methods`).
+- `<concepts>`: the Concepts the exercise is about (e.g. `loops`),
+- `<concept-1>`: a single Concept slug,
+- `<prerequisite-n>`: a single Concept slug,
+- `<uuid>`: a _new_ v4 UUID (random!)
+- `<first-and-last-name>`: your first and last name (e.g. `John Doe`)
+- `<git-email>`: the email address you use for git (e.g. `johndoe@email.com`)
+
+Before implementing the exercise, please make sure you have a good understanding of what the exercise should be teaching (and what not). This information can be found in the exercise's GitHub issue. Having done this, please read the [TypeScript Concept exercises introduction][concept-exercises]. If you have come up with something completely new, create a new issue _first_ so we can discuss the Concept Exercise.
+
+To implement a Concept Exercise, the following files must be created:
+
+<pre>
+languages
+└── typescript
+    └── exercises
+        └── concept
+            └── &lt;slug&gt;
+                ├── .docs
+                |   ├── instructions.md
+                |   ├── introduction.md
+                |   ├── hints.md
+                |   └── after.md (optional)
+                ├── .eslintrc
+                ├── .gitignore
+                ├── babel.config.js
+                ├── example.js
+                ├── &lt;slug&gt;.js
+                ├── &lt;slug&gt;.spec.js
+                ├── package.json
+                └── yarn.lock
+</pre>
+
+## Step 1: add .docs/introduction.md
+
+This file contains an introduction to the Concept. It should be explicit about what the exercise teaches and maybe provide a brief introduction to the concepts, but not give away so much that the user doesn't have to do any work to solve the exercise.
+
+## Step 2: add .docs/instructions.md
+
+This file contains instructions for the exercise. It should explicitly explain what the user needs to do (define a method with the signature `X(...)` that takes an A and returns a Z), and provide at least one example usage of that function. If there are multiple tasks within the exercise, it should provide an example of each.
+
+## Step 3: add .docs/hints.md
+
+If the user gets stuck, we will allow them to click a button requesting a hint, which shows this file. We will softly discourage them using it. The file should contain both general and task-specific "hints". These hints should be enough to unblock almost any problem the user would face.
+
+## Step 4: add .docs/after.md (optional):
+
+Once the user completes the exercise they will be shown this file, which gives them any bonus information or further reading about the Concept taught.
+
+## Step 5: add .meta/config.json
+
+This file contains metadata for the exercise. The metadata includes paths to the test file and the solution files, as well as a list of all the tests and the method they are calling.
+
+## Step 6: update languages/javascript/config.json
+
+An entry should be added to the track's `config.json` file for the new Concept Exercise:
+
+```json
+{
+  ...
+  "exercises": {
+    "concept": [
+      ...
+      {
+        "slug": "<slug>",
+        "uuid": "<uuid>",
+        "concepts": ["<concept-1>"],
+        "prerequisites": ["<prerequisite-1>", "<prerequisite-2>"]
+      }
+    ]
+  }
+}
+```
+
+## Step 7: adding track-specific files
+
+The configuration files may be copied from another exercise. We aim to keep these in sync:
+
+- `.eslintignore`
+- `.eslintrc`
+- `jest.config.js`
+- `package.json`
+- `tsconfig.json`
+
+The `package.json` file must be edited:
+
+```diff
+-  "name": "@exercism/typescript-numbers",
++  "name": "@exercism/typescript-<slug>",
+-  "description": "Exercism Concept Exercise on <concepts>",
+-  "author": "Jane Doe <janedoe@email.info>",
++  "author": "<first-and-last-name> <<git-email>>"
+   "version": "1.0.0",
+   "license": "MIT",
+   "private": true,
+   "repository": {
+     "type": "git",
+     "url": "https://github.com/exercism/language-concepts.git",
+-    "directory": "languages/typescript/exercises/concept/numbers"
++    "directory": "languages/typescript/exercises/concept/<slug>"
+   },
+```
+
+Now create the following three files:
+
+- `<slug>.cs`. the stub implementation file, which is the starting point for students to work on the exercise.
+- `<slug>.spec.js`: the test suite.
+- `example.js`: an example implementation that passes all the tests.
+
+## Step 8: add analyzer (optional)
+
+Some exercises could benefit from having an exercise-specific [analyzer][analyzer]. If so, specify what analysis rules should be applied to this exercise and why.
+
+## Step 9: custom representation (optional)
+
+Some exercises could benefit from having an custom representation as generated by the [TypeScript representer][representer]. If so, specify what changes to the representation should be applied and why.
+
+## Inspiration
+
+When implementing an exercise, it can be very useful to look at the exercises the track has already implemented. You can also check the exercise's [general concepts documents][reference] to see if other languages that have already an exercise for that Concept.
+
+## Inspiration
+
+When implementing an exercise, it can be very useful to look at already implemented TypeScript exercises like the [strings][concept-exercise-strings], [numbers][concept-exercise-numbers] or [promises][concept-exercise-promises] exercises. You can also check the exercise's [general concepts documents][reference] to see if other languages have already implemented an exercise for that Concept.
+
+## Help
+
+If you have any questions regarding implementing the exercise, please post them as comments in the exercise's GitHub issue.
+
+[analyzer]: https://github.com/exercism/typescript-analyzer
+[representer]: https://github.com/exercism/typescript-representer
+[concept-exercises]: ../exercises/concept/README.md
+[how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[concept-exercise-strings]: ../exercises/concept/strings
+[concept-exercise-numbers]: ../exercises/concept/numbers
+[concept-exercise-promises]: ../exercises/concept/promises
+[reference]: ../../../reference/README.md

--- a/languages/typescript/docs/implementing-a-concept-exercise.md
+++ b/languages/typescript/docs/implementing-a-concept-exercise.md
@@ -26,6 +26,7 @@ languages
                 |   ├── hints.md
                 |   └── after.md (optional)
                 ├── .eslintignore
+                ├── .gitignore
                 ├── .eslintrc
                 ├── jest.config.js
                 ├── example.ts

--- a/languages/typescript/docs/implementing-a-concept-exercise.md
+++ b/languages/typescript/docs/implementing-a-concept-exercise.md
@@ -137,7 +137,7 @@ If you have any questions regarding implementing the exercise, please post them 
 [representer]: https://github.com/exercism/typescript-representer
 [concept-exercises]: ../exercises/concept/README.md
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
-[concept-exercise-strings]: ../exercises/concept/strings
-[concept-exercise-numbers]: ../exercises/concept/numbers
-[concept-exercise-promises]: ../exercises/concept/promises
+[concept-exercise-strings]: ../exercises/concept/strings.md
+[concept-exercise-numbers]: ../exercises/concept/numbers.md
+[concept-exercise-promises]: ../exercises/concept/promises.md
 [reference]: ../../../reference/README.md

--- a/languages/typescript/exercises/concept/README.md
+++ b/languages/typescript/exercises/concept/README.md
@@ -1,0 +1,1 @@
+# This is a stub

--- a/languages/typescript/exercises/concept/numbers.md
+++ b/languages/typescript/exercises/concept/numbers.md
@@ -1,0 +1,1 @@
+# This is a stub

--- a/languages/typescript/exercises/concept/promises.md
+++ b/languages/typescript/exercises/concept/promises.md
@@ -1,0 +1,1 @@
+# This is a stub

--- a/languages/typescript/exercises/concept/strings.md
+++ b/languages/typescript/exercises/concept/strings.md
@@ -1,0 +1,1 @@
+# This is a stub


### PR DESCRIPTION
- added `implementing-a-concept-exercise.md ` to the typescript track
- fixed minor issues I noticed on the javascript equivalent document.  
  