### PR TITLE
[CI] Apply correct label to ISSUE_TEMPLATE changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,7 @@ CI:
 
 documentation:
   - docs/**/*
+  - .github/ISSUE_TEMPLATE/**/*
 
 track/bash:
   - languages/bash/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,8 @@
 CI:
-  - .github/**/*
+  - .github/workflows/**/*
+  - .github/actions/**/*
+  - .github/**/*.yml
+  - .github/**/*.json
 
 documentation:
   - docs/**/*


### PR DESCRIPTION
Changes to the ISSUE_TEMPLATE are labelled as CI changes, see e.g. https://github.com/exercism/v3/pull/291
