### PR TITLE
[Docs] Remove circular definition of methods

### DIFF
--- a/reference/concepts/functions.md
+++ b/reference/concepts/functions.md
@@ -2,6 +2,8 @@
 
 By "functions" we mean functions, procedures and sub-routines.
 
+A function is a named section of a program, consisting of one or more statements, that can be reused to perform the same action(s) at different points of a larger program.
+
 We do not aim to teach:
 
 - "functions" as the concept of self-contained pieces of functionality

--- a/reference/concepts/functions.md
+++ b/reference/concepts/functions.md
@@ -1,6 +1,6 @@
 ## Functions
 
-By "functions" we mean functions, methods and procedures.
+By "functions" we mean functions, procedures and sub-routines.
 
 We do not aim to teach:
 


### PR DESCRIPTION
Part of #183

The concept for [methods](https://github.com/exercism/v3/blob/master/reference/concepts/methods.md) links to this one for functions. Using the term "method" to describe functions then results in a circular definition.

This PR is to remove the circularity and provide a language-agnostic explanation of what a function is.