### PR TITLE
Flesh out the concept files to include exercise info

### DIFF
--- a/reference/types/floating_point_number.md
+++ b/reference/types/floating_point_number.md
@@ -34,7 +34,7 @@ This exercise asks students to write code to analyse the production of an assemb
 
 | Track | Exercise                                         | Changes |
 | ----- | ------------------------------------------------ | ------- |
-| C#    | [Numbers][implementation-csharp-production-line] | None    |
+| C#    | [numbers][implementation-csharp-production-line] | None    |
 
 ### Savings Accounts
 
@@ -46,7 +46,9 @@ This exercise calculates interest on savings accounts. It teaches:
 
 #### Implementations
 
-- [C#][implementation-csharp-savings-accounts] (no significant changes made)
+| Track | Exercise                                                         | Changes |
+| ----- | ---------------------------------------------------------------- | ------- |
+| C#    | [numbers-floating-point][implementation-csharp-savings-accounts] | None    |
 
 [type-bit]: ./bit.md
 [type-double]: ./double.md

--- a/reference/types/floating_point_number.md
+++ b/reference/types/floating_point_number.md
@@ -23,7 +23,7 @@ A student may have no understanding of floating point numbers as more than numbe
 
 ### Production Line Analysis
 
-This exercise asks students to write code to analyse the production of an assembly line. It covers:
+This exercise asks students to write code to analyse the production of an assembly line. It teaches:
 
 - Arithmetic
 - Comparing numbers
@@ -36,10 +36,8 @@ This exercise asks students to write code to analyse the production of an assemb
 
 ### Savings Accounts
 
-This exercise calculates interest on savings accounts. It covers:
+This exercise calculates interest on savings accounts. It teaches:
 
-- Numeric comparison
-- Conditionals
 - Rounding
 - The importance of different precisions, using integers, 4 byte floating point numbers and 16 byte floating point numbers
 - Basic loops

--- a/reference/types/floating_point_number.md
+++ b/reference/types/floating_point_number.md
@@ -14,7 +14,7 @@ Programming languages may name their floating point type to the amount of _preci
 
 A student may have no understanding of floating point numbers as more than numbers with decimal points.
 
-- Explain that a floating point number is not *just* a number with a decimal place.
+- Explain that a floating point number is not _just_ a number with a decimal place.
 - Explain what floating point types are used in your langauge, and when to use them.
 - Ensure that type conversions are understood if appropriate (e.g. rounding, precision-changing)
 - Ensure that students know how to compare numbers to each other.
@@ -24,19 +24,25 @@ A student may have no understanding of floating point numbers as more than numbe
 ### Production Line Analysis
 
 This exercise asks students to write code to analyse the production of an assembly line. It covers:
-- arithmetic
-- numeric comparison / conditionals
-- parsing between integers and floating point numbers.
+
+- Arithmetic
+- Numeric comparison
+- Converting between integers and floating point numbers.
+- Conditionals
+
+#### Implementations
 
 - [C#][implementation-csharp-production-line]
 
 ### Savings Accounts
 
 This exercise calculates interest on savings accounts. It covers:
-- numeric comparison / conditionals
-- rounding
-- the importance of different precisions, using integers, 4 byte floating point numbers and 16 byte floating point numbers
-- basic loops.
+
+- Numeric comparison
+- Conditionals
+- Rounding
+- The importance of different precisions, using integers, 4 byte floating point numbers and 16 byte floating point numbers
+- Basic loops
 
 #### Implementations
 

--- a/reference/types/floating_point_number.md
+++ b/reference/types/floating_point_number.md
@@ -23,7 +23,7 @@ A student may have no understanding of floating point numbers as more than numbe
 
 ### Production Line Analysis
 
-This exercise asks students to write code to analyse the production of an assembly line. The original (C#) implementation teaches:
+This exercise asks students to write code to analyse the production of an assembly line. The reference implementation (C#) teaches:
 
 - Arithmetic
 - Comparing numbers
@@ -38,7 +38,7 @@ This exercise asks students to write code to analyse the production of an assemb
 
 ### Savings Accounts
 
-This exercise calculates interest on savings accounts. The original (C#) implementation teaches:
+This exercise calculates interest on savings accounts. The reference implementation (C#) teaches:
 
 - Rounding
 - The importance of different precisions, using integers, 4 byte floating point numbers and 16 byte floating point numbers

--- a/reference/types/floating_point_number.md
+++ b/reference/types/floating_point_number.md
@@ -26,13 +26,13 @@ A student may have no understanding of floating point numbers as more than numbe
 This exercise asks students to write code to analyse the production of an assembly line. It covers:
 
 - Arithmetic
-- Numeric comparison
+- Comparing numbers
 - Converting between integers and floating point numbers.
 - Conditionals
 
 #### Implementations
 
-- [C#][implementation-csharp-production-line]
+- [C#][implementation-csharp-production-line] (no significant changes made)
 
 ### Savings Accounts
 
@@ -46,7 +46,7 @@ This exercise calculates interest on savings accounts. It covers:
 
 #### Implementations
 
-- [C#][implementation-csharp-savings-accounts]
+- [C#][implementation-csharp-savings-accounts] (no significant changes made)
 
 [type-bit]: ./bit.md
 [type-double]: ./double.md

--- a/reference/types/floating_point_number.md
+++ b/reference/types/floating_point_number.md
@@ -32,7 +32,9 @@ This exercise asks students to write code to analyse the production of an assemb
 
 #### Implementations
 
-- [C#][implementation-csharp-production-line] (no significant changes made)
+| Track | Link                                              | Changes |
+| ----- | ------------------------------------------------- | ------- |
+| C#    | [Exercise][implementation-csharp-production-line] | None    |
 
 ### Savings Accounts
 

--- a/reference/types/floating_point_number.md
+++ b/reference/types/floating_point_number.md
@@ -32,9 +32,9 @@ This exercise asks students to write code to analyse the production of an assemb
 
 #### Implementations
 
-| Track | Link                                              | Changes |
-| ----- | ------------------------------------------------- | ------- |
-| C#    | [Exercise][implementation-csharp-production-line] | None    |
+| Track | Exercise                                         | Changes |
+| ----- | ------------------------------------------------ | ------- |
+| C#    | [Numbers][implementation-csharp-production-line] | None    |
 
 ### Savings Accounts
 

--- a/reference/types/floating_point_number.md
+++ b/reference/types/floating_point_number.md
@@ -16,7 +16,7 @@ A student may have no understanding of floating point numbers as more than numbe
 
 - Explain that a floating point number is not *just* a number with a decimal place.
 - Explain what floating point types are used in your langauge, and when to use them.
-- Ensure that type conversations are understood if appropriate (e.g. rounding, precision-changing)
+- Ensure that type conversions are understood if appropriate (e.g. rounding, precision-changing)
 - Ensure that students know how to compare numbers to each other.
 
 ## Exercises

--- a/reference/types/floating_point_number.md
+++ b/reference/types/floating_point_number.md
@@ -10,15 +10,42 @@ Programming languages may name their floating point type to the amount of _preci
 - Quadruple (occupying 128 [bits][type-bit])
 - Octuple (occupying 256 [bits][type-bit])
 
-# Implementations
+## What to cover
 
-- [C# (basic)][implementation-csharp-basic]
-- [C# (advanced)][implementation-csharp-advanced]
+A student may have no understanding of floating point numbers as more than numbers with decimal points.
+
+- Explain that a floating point number is not *just* a number with a decimal place.
+- Explain what floating point types are used in your langauge, and when to use them.
+- Ensure that type conversations are understood if appropriate (e.g. rounding, precision-changing)
+- Ensure that students know how to compare numbers to each other.
+
+## Exercises
+
+### Production Line Analysis
+
+This exercise asks students to write code to analyse the production of an assembly line. It covers:
+- arithmetic
+- numeric comparison / conditionals
+- parsing between integers and floating point numbers.
+
+- [C#][implementation-csharp-production-line]
+
+### Savings Accounts
+
+This exercise calculates interest on savings accounts. It covers:
+- numeric comparison / conditionals
+- rounding
+- the importance of different precisions, using integers, 4 byte floating point numbers and 16 byte floating point numbers
+- basic loops.
+
+#### Implementations
+
+- [C#][implementation-csharp-savings-accounts]
 
 [type-bit]: ./bit.md
 [type-double]: ./double.md
 [type-half]: ./half.md
 [type-single]: ./single.md
 [wiki-ieee754]: https://en.wikipedia.org/wiki/IEEE_754
-[implementation-csharp-basic]: ../../languages/csharp/exercises/concept/numbers/.docs/introduction.md
-[implementation-csharp-advanced]: ../../languages/csharp/exercises/concept/numbers-floating-point/.docs/introduction.md
+[implementation-csharp-production-line]: ../../languages/csharp/exercises/concept/numbers/.docs/introduction.md
+[implementation-csharp-savings-accounts]: ../../languages/csharp/exercises/concept/numbers-floating-point/.docs/introduction.md

--- a/reference/types/floating_point_number.md
+++ b/reference/types/floating_point_number.md
@@ -23,7 +23,7 @@ A student may have no understanding of floating point numbers as more than numbe
 
 ### Production Line Analysis
 
-This exercise asks students to write code to analyse the production of an assembly line. It teaches:
+This exercise asks students to write code to analyse the production of an assembly line. The original (C#) implementation teaches:
 
 - Arithmetic
 - Comparing numbers
@@ -38,7 +38,7 @@ This exercise asks students to write code to analyse the production of an assemb
 
 ### Savings Accounts
 
-This exercise calculates interest on savings accounts. It teaches:
+This exercise calculates interest on savings accounts. The original (C#) implementation teaches:
 
 - Rounding
 - The importance of different precisions, using integers, 4 byte floating point numbers and 16 byte floating point numbers

--- a/reference/types/string.md
+++ b/reference/types/string.md
@@ -17,7 +17,7 @@ Tell a student what a string is in your language, how strings can be manipulated
 
 ### Log Lines
 
-This exercise covers joining, triming, case-changing, and substring extraction. It is a great exercise for covering the most basic elements of Strings, and ensuring a student finds the docs for strings.
+This exercise covers joining, triming, case-changing, and substring extraction. It is a great exercise for covering the most basic elements of strings, and ensuring a student finds the docs for strings.
 
 #### Implementations
 - [C#][implementation-csharp]

--- a/reference/types/string.md
+++ b/reference/types/string.md
@@ -13,7 +13,7 @@ Tell a student what a string is in your language, how strings can be manipulated
 - **How are strings split apart?** How do I extract a bit of a string?
 - **Where do helper methods for strings live?** If I want to trim a string, or check it's length, how do I do that in your language? Are these string methods or functions that act on strings?
 
-## Example Exercises
+## Exercises
 
 ### Log Lines
 

--- a/reference/types/string.md
+++ b/reference/types/string.md
@@ -17,10 +17,18 @@ Tell a student what a string is in your language, how strings can be manipulated
 
 ### Log Lines
 
-This exercise covers joining, triming, case-changing, and substring extraction. It is a great exercise for covering the most basic elements of strings, and ensuring a student finds the docs for strings.
+This exercise extracts information from log lines. The reference implementation (C#) teaches:
+
+- String concatenation
+- Trimming
+- Changing casing
+- Extracting substrings
 
 #### Implementations
-- [C#][implementation-csharp]
+
+| Track | Exercise                         | Changes |
+| ----- | -------------------------------- | ------- |
+| C#    | [strings][implementation-csharp] | None    |
 
 [type-char]: ./char.md
 [implementation-csharp]: ../../languages/csharp/exercises/concept/strings/.docs/introduction.md

--- a/reference/types/string.md
+++ b/reference/types/string.md
@@ -1,13 +1,25 @@
 # String
 
+## The Concept
+
 A string is a sequence of [characters][type-char] (letters, digits, punctuation, etc.).
 
-# Teaching tactics
+## What to cover
 
-- Be explicit about what a string represents. Is it a sequence of bytes, UTF-8 characters or something else?
+Tell a student what a string is in your language, how strings can be manipulated, and ensure they understand where to look for docs on strings.
 
-# Implementations
+- **Explain what strings are in your language?** Is it a sequence of bytes, UTF-8 characters or something else? Are strings objects or primitives?
+- **How are strings brought together?** Do you join strings, add strings, concatenate strings, interpolate strings? It's worth giving a hint as to which is normal, or letting the user know all are ok!
+- **How are strings split apart?** How do I extract a bit of a string?
+- **Where do helper methods for strings live?** If I want to trim a string, or check it's length, how do I do that in your language? Are these string methods or functions that act on strings?
 
+## Example Exercises
+
+### Log Lines
+
+This exercise covers joining, triming, case-changing, and substring extraction. It is a great exercise for covering the most basic elements of Strings, and ensuring a student finds the docs for strings.
+
+#### Implementations
 - [C#][implementation-csharp]
 
 [type-char]: ./char.md


### PR DESCRIPTION
Once we've defined Concepts and start writing exercises we want to share as much of the load as is reasonably possible. 

There are two types of sharing here:
1. Sharing the various things that need to be taught about a Concept (part of this is helping maintainers understand how concepts might be wildly different in different languages)
2. Sharing the actual exercises that teach them, and the thinking behind those exercises.

I'm entirely open to suggestions on how best to structure these, but would like people to consider the goals above when working out what might be best.

My first attempt splits up the file into:
- The CS concept
- The teaching points
- Exercises and their implementations (that other tracks can learn from and/or fork)