### PR TITLE
[Common Lisp] correct typo of language name in sidebar.

### DIFF
--- a/languages/_sidebar.md
+++ b/languages/_sidebar.md
@@ -5,7 +5,7 @@
   - [C](/languages/c/README.md)
   - [C#](/languages/csharp/README.md)
   - [Clojure](/languages/clojure/README.md)
-  - [Common Lisp](/languages/common-list/README.md)
+  - [Common Lisp](/languages/common-lisp/README.md)
   - [Dart](/languages/dart/README.md)
   - [Elixir](/languages/elixir/README.md)
   - [Emacs LISP](/languages/emacs-lisp/README.md)


### PR DESCRIPTION
The `/languages/_sidebar.md` file had a typo in the slug of the language name.

Fixes #366.