### PR TITLE
[Docs] Render mermaid graph code blocks

### DIFF
--- a/docs/maintainers/README.md
+++ b/docs/maintainers/README.md
@@ -28,6 +28,106 @@ The final step to preparing your language to accept contributions is to provide 
 
 We recommend choosing a Concept that involves working with basic types, like strings and numbers. Having chosen a Concept, look for the Concept's description in this reference part of this repository. This file should have references to all tracks that have implemented the exercise. You can use these existing implementations as a starting point for your first concept exercise, which you can then tailor to your specific language.
 
+### Planning the track structure
+
+You may find it helpful to create a graph that shows the unlock progression of the exercises for planning which exercises you need, which prerequisites they have and which exercises are closely related to each other.
+
+The website supports flowcharts rendered by [mermaid](https://mermaid-js.github.io/mermaid/#/flowchart). Every code block with the language set to `mermaid` will be rendered as a graph:
+
+    ```mermaid
+        graph LR
+            basic-numbers --> advanced-numbers
+    ```
+
+```mermaid
+    graph LR
+        basic-numbers --> advanced-numbers
+```
+
+Please refer to the [mermaid documentation](https://mermaid-js.github.io/mermaid/#/flowchart) for detailed instructions. Below you can find a few examples of basic mermaid syntax to get you started. The Julia track's [progression.md](./../../languages/julia/reference/progression.md) can also be used as a reference.
+
+*Note: to keep the page short, the example use left-to-right graphs (`LR`). For a track progression path you want to replace `graph LR` with `graph TD` for a top-to-bottom graph.*
+
+These will only be rendered on the website or in a markdown editor that supports mermaid rendering, e.g. [Typora](https://www.typora.io/). See [website.md](./website.md) for instructions to run the website locally. 
+
+#### Nodes and links
+
+    ```mermaid
+        graph LR
+            basic-numbers --> advanced-numbers
+    ```
+
+```mermaid
+    graph LR
+        basic-numbers --> advanced-numbers
+```
+
+#### Custom labels
+
+    ```mermaid
+        graph LR
+            basic-functions["basic-functions (hello-world)"] --> basic-numbers
+    ```
+
+```mermaid
+    graph LR
+        basic-functions["basic-functions (hello-world)"] --> advanced-numbers
+```
+
+#### Groups
+
+    ```mermaid
+    graph LR
+        functions --> composite-types
+        subgraph Type System
+            composite-types --> abstract-types
+        end
+        abstract-types --> finish((finish))
+    ```
+
+```mermaid
+graph LR
+    functions --> composite-types
+    subgraph Type System
+        composite-types --> abstract-types
+    end
+    abstract-types --> finish((finish))
+```
+
+#### Styling
+
+    ```mermaid
+        graph LR
+            basic-numbers -.-> advanced-numbers
+    ```
+
+```mermaid
+    graph LR
+        basic-numbers -.-> advanced-numbers
+```
+
+Different styles can, for example, be used for different exercises. E.g. the Julia track uses dotted lines and rounded corners for practice exercises:
+
+    ```mermaid
+    graph LR
+        subgraph Numbers
+            numbers --> complex-numbers
+            numbers --> rational-numbers
+        end
+        complex-numbers -.-> practice-complex-numbers(practice-complex-numbers)
+        rational-numbers -.-> practice-rational-numbers(practice-rational-numbers)
+    ```
+
+```mermaid
+graph LR
+    subgraph Numbers
+        numbers --> complex-numbers
+        numbers --> rational-numbers
+    end
+    complex-numbers -.-> practice-complex-numbers(practice-complex-numbers)
+    rational-numbers -.-> practice-rational-numbers(practice-rational-numbers)
+```
+
 ### Read more
 
 - [More about Concepts and Concept Exercises](../concept-exercises.md)

--- a/docs/maintainers/README.md
+++ b/docs/maintainers/README.md
@@ -28,7 +28,7 @@ The final step to preparing your language to accept contributions is to provide 
 
 We recommend choosing a Concept that involves working with basic types, like strings and numbers. Having chosen a Concept, look for the Concept's description in this reference part of this repository. This file should have references to all tracks that have implemented the exercise. You can use these existing implementations as a starting point for your first concept exercise, which you can then tailor to your specific language.
 
-### Planning the track structure
+### Visualizing the planned track structure
 
 You may find it helpful to create a graph that shows the unlock progression of the exercises for planning which exercises you need, which prerequisites they have and which exercises are closely related to each other.
 

--- a/docs/maintainers/README.md
+++ b/docs/maintainers/README.md
@@ -44,89 +44,9 @@ The website supports flowcharts rendered by [mermaid](https://mermaid-js.github.
         basic-numbers --> advanced-numbers
 ```
 
-Please refer to the [mermaid documentation](https://mermaid-js.github.io/mermaid/#/flowchart) for detailed instructions. Below you can find a few examples of basic mermaid syntax to get you started. The Julia track's [progression.md](./../../languages/julia/reference/progression.md) can also be used as a reference.
-
-*Note: to keep the page short, the example use left-to-right graphs (`LR`). For a track progression path you want to replace `graph LR` with `graph TD` for a top-to-bottom graph.*
+Please refer to the [mermaid documentation](https://mermaid-js.github.io/mermaid/#/flowchart) for detailed instructions. The Julia track's [progression planning document](./../../languages/julia/reference/progression.md) can also be used as a reference.
 
 These will only be rendered on the [repo website](https://exercism.github.io/v3) or in a markdown editor that supports mermaid rendering, e.g. [Typora](https://www.typora.io/). See [website.md](./website.md) for instructions to run the website locally. 
-
-#### Nodes and links
-
-    ```mermaid
-        graph LR
-            basic-numbers --> advanced-numbers
-    ```
-
-```mermaid
-    graph LR
-        basic-numbers --> advanced-numbers
-```
-
-#### Custom labels
-
-    ```mermaid
-        graph LR
-            basic-functions["basic-functions (hello-world)"] --> basic-numbers
-    ```
-
-```mermaid
-    graph LR
-        basic-functions["basic-functions (hello-world)"] --> advanced-numbers
-```
-
-#### Groups
-
-    ```mermaid
-    graph LR
-        functions --> composite-types
-        subgraph Type System
-            composite-types --> abstract-types
-        end
-        abstract-types --> finish((finish))
-    ```
-
-```mermaid
-graph LR
-    functions --> composite-types
-    subgraph Type System
-        composite-types --> abstract-types
-    end
-    abstract-types --> finish((finish))
-```
-
-#### Styling
-
-    ```mermaid
-        graph LR
-            basic-numbers -.-> advanced-numbers
-    ```
-
-```mermaid
-    graph LR
-        basic-numbers -.-> advanced-numbers
-```
-
-Different styles can, for example, be used for different exercises. E.g. the Julia track uses dotted lines and rounded corners for practice exercises:
-
-    ```mermaid
-    graph LR
-        subgraph Numbers
-            numbers --> complex-numbers
-            numbers --> rational-numbers
-        end
-        complex-numbers -.-> practice-complex-numbers(practice-complex-numbers)
-        rational-numbers -.-> practice-rational-numbers(practice-rational-numbers)
-    ```
-
-```mermaid
-graph LR
-    subgraph Numbers
-        numbers --> complex-numbers
-        numbers --> rational-numbers
-    end
-    complex-numbers -.-> practice-complex-numbers(practice-complex-numbers)
-    rational-numbers -.-> practice-rational-numbers(practice-rational-numbers)
-```
 
 ### Read more
 

--- a/docs/maintainers/README.md
+++ b/docs/maintainers/README.md
@@ -48,7 +48,7 @@ Please refer to the [mermaid documentation](https://mermaid-js.github.io/mermaid
 
 *Note: to keep the page short, the example use left-to-right graphs (`LR`). For a track progression path you want to replace `graph LR` with `graph TD` for a top-to-bottom graph.*
 
-These will only be rendered on the website or in a markdown editor that supports mermaid rendering, e.g. [Typora](https://www.typora.io/). See [website.md](./website.md) for instructions to run the website locally. 
+These will only be rendered on the [repo website](https://exercism.github.io/v3) or in a markdown editor that supports mermaid rendering, e.g. [Typora](https://www.typora.io/). See [website.md](./website.md) for instructions to run the website locally. 
 
 #### Nodes and links
 

--- a/index.html
+++ b/index.html
@@ -31,7 +31,8 @@
           code: function(code, lang) {
             if (lang === "mermaid") {
               return (
-                '<div class="mermaid">' + mermaid.render('mermaid-svg-' + num++, code) + "</div>"
+                // Random ID generator based on https://stackoverflow.com/a/13403498
+                '<div class="mermaid">' + mermaid.render('mermaid-svg-' + Math.random().toString(36).substring(2, 15), code) + "</div>"
               );
             }
             return this.origin.code.apply(this, arguments);
@@ -39,7 +40,6 @@
         }
       }
     }
-    var num = 0;
     mermaid.initialize({ logLevel:0, startOnLoad: false, flowchart: { useMaxWidth:false, htmlLabels:true }, themeCSS: '.label { font-family: Source Sans Pro,Helvetica Neue,Arial,sans-serif; }' })
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -7,9 +7,6 @@
   <meta name="description" content="Description">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css">
-
-  <!-- Render triple backtick mermaid blocks as a mermaid graph -->
-  <script src="//unpkg.com/mermaid@8.4.6/dist/mermaid.min.js"></script>
 </head>
 <body>
   <div id="app"></div>
@@ -43,6 +40,8 @@
     mermaid.initialize({ logLevel:0, startOnLoad: false, flowchart: { useMaxWidth:false, htmlLabels:true }, themeCSS: '.label { font-family: Source Sans Pro,Helvetica Neue,Arial,sans-serif; }' })
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+  <!-- Render triple backtick mermaid blocks as a mermaid graph -->
+  <script src="//unpkg.com/mermaid@8.4.6/dist/mermaid.min.js"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
   <meta name="description" content="Description">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css">
+
+  <!-- Render triple backtick mermaid blocks as a mermaid graph -->
+  <script src="//unpkg.com/mermaid@8.4.6/dist/mermaid.min.js"></script>
 </head>
 <body>
   <div id="app"></div>
@@ -22,7 +25,22 @@
       //plugins: [
       //  EditOnGithubPlugin.create("https://github.com/exercism/v3/blob/master/")
       //]
+
+      markdown: {
+        renderer: {
+          code: function(code, lang) {
+            if (lang === "mermaid") {
+              return (
+                '<div class="mermaid">' + mermaid.render('mermaid-svg-' + num++, code) + "</div>"
+              );
+            }
+            return this.origin.code.apply(this, arguments);
+          }
+        }
+      }
     }
+    var num = 0;
+    mermaid.initialize({ logLevel:0, startOnLoad: false, flowchart: { useMaxWidth:false, htmlLabels:true }, themeCSS: '.label { font-family: Source Sans Pro,Helvetica Neue,Arial,sans-serif; }' })
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Document</title>
+  <title>Exercism v3</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="Description">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">

--- a/index.html
+++ b/index.html
@@ -37,11 +37,14 @@
         }
       }
     }
-    mermaid.initialize({ logLevel:0, startOnLoad: false, flowchart: { useMaxWidth:false, htmlLabels:true }, themeCSS: '.label { font-family: Source Sans Pro,Helvetica Neue,Arial,sans-serif; }' })
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+
   <!-- Render triple backtick mermaid blocks as a mermaid graph -->
   <script src="//unpkg.com/mermaid@8.4.6/dist/mermaid.min.js"></script>
+  <script>
+    mermaid.initialize({ logLevel:0, startOnLoad: false, flowchart: { useMaxWidth:false, htmlLabels:true }, themeCSS: '.label { font-family: Source Sans Pro,Helvetica Neue,Arial,sans-serif; }' })
+  </script>
 
 </body>
 </html>

--- a/languages/julia/reference/progression.md
+++ b/languages/julia/reference/progression.md
@@ -3,7 +3,7 @@
 This is a working document to keep track of ideas and thoughts on how the progression through the Concept Exercises on the Julia track could work.
 
 ```mermaid
-graph LR
+graph TD
 A((A)) --> robots
 subgraph Multiple Dispatch
 	robots --> encounters


### PR DESCRIPTION
Codeblocks with the language set to mermaid will be rendered as mermaid graphs.

For example, 

    ```mermaid
    graph TD
    A((A)) --> robots
    subgraph Multiple Dispatch
	    robots --> encounters
	    robots -.-> abstract-types
	    abstract-types[abstract types] -.-> modules
	    modules -.-> encounters
	    encounters -.-> extension[extending/glueing together modules]
    end
    extension --> B
    B --> performance
    performance --> Z((Z))
    ```

is rendered as the following graph: https://user-images.githubusercontent.com/20866761/73282965-abe4a180-41f2-11ea-8968-54faaaf7c91e.png

This can be quite useful when visualising and planning the progression. Unfortunately, it requires adding a dependency/external script to the website.
