### PR TITLE
[Julia] Only run CI when exercises are touched

### DIFF
--- a/.github/workflows/julia-ci.yml
+++ b/.github/workflows/julia-ci.yml
@@ -4,11 +4,13 @@ on:
   push:
     paths:
     - '**.jl'
-    - 'languages/julia/**'
+    - 'languages/julia/exercises/concept/**'
+    - 'languages/julia/exercises/practice/**'
   pull_request:
     paths:
     - '**.jl'
-    - 'languages/julia/**'
+    - 'languages/julia/exercises/concept/**'
+    - 'languages/julia/exercises/practice/**'
 
 jobs:
   test:


### PR DESCRIPTION
PRs that change the documentation (like #436) don't need to run the exercise test suite.