### PR TITLE
[Go] Add numbers concept exercise

### DIFF
--- a/languages/go/exercises/concept/numbers/.docs/after.md
+++ b/languages/go/exercises/concept/numbers/.docs/after.md
@@ -1,0 +1,9 @@
+# After
+
+### Type Conversion
+
+For more information on Type Conversion please see
+[A Tour of Go: Type Conversions][type-conversion]
+
+
+[type-conversion]:https://tour.golang.org/basics/13

--- a/languages/go/exercises/concept/numbers/.docs/hints.md
+++ b/languages/go/exercises/concept/numbers/.docs/hints.md
@@ -1,0 +1,27 @@
+# Hints
+
+### Arithmetic Operators in Go
+
+Below shows the set of arithmetic operators available in Go in use:
+
+```go
+fmt.Println("1 + 2  = ", 1 + 2)   // Addition
+// Output: 1 + 2 = 3
+
+fmt.Println("10 - 2 = ", 10 - 2)  // Subtraction
+// Output: 10 - 2 = 8
+
+fmt.Println("5 * 2  = ", 5 * 2)   // Multiplication
+// Output: 5 * 2 = 10
+
+fmt.Println("10 / 2 = ", 10 / 2)  // Division
+// Output: 10 / 2 = 5
+
+fmt.Println("10 % 2 = ", 10%2)    // Remainder
+// Output: 10 % 2 = 0
+```
+
+For more information please see the [Go language Spec][go-lang-spec-arithmetic-operators]
+
+
+[go-lang-spec-arithmetic-operators]:https://golang.org/ref/spec#Arithmetic_operators

--- a/languages/go/exercises/concept/numbers/.docs/instructions.md
+++ b/languages/go/exercises/concept/numbers/.docs/instructions.md
@@ -1,0 +1,44 @@
+# Instructions
+
+In this exercise you'll be writing code to analyse the production of an
+assembly line in a car factory. The assembly line's speed can range from `0`
+(off) to `10` (maximum).
+
+At its default speed (`1`), `221` cars are produced each hour. In principle,
+the production increases linearly. So with the speed set to `4`, it should
+produce `4 * 221 = 884` cars per hour. However, higher speeds increase the
+likelihood that faulty cars are produced, which then have to be discarded. The
+following table shows how speed influences the success rate:
+
+- `0`: 0% success rate.
+- `1` - `4`: 100% success rate.
+- `5` - `8`: 90% success rate.
+- `9` - `10`: 77% success rate.
+
+> Note that the calculation of the success rate has been provided already.
+
+You have two tasks:
+
+### 1. Calculate the production rate per hour
+
+Implement a function to calculate the assembly line's production rate per hour.
+
+```go
+rate := CalculateProductionRatePerHour(7)
+fmt.Println(rate)
+// Output: 10829.0
+```
+
+> Note that the value returned is of type `float64`
+
+### 2. Calculate the number of working items produced per minute
+
+Implement a function to calculate how many cars are produced each minute:
+
+```go
+rate := CalculateProductionRatePerMinute(5)
+fmt.Println(rate)
+// Output: 92
+```
+
+> Note that the value returned is of type `int`.

--- a/languages/go/exercises/concept/numbers/.docs/introduction.md
+++ b/languages/go/exercises/concept/numbers/.docs/introduction.md
@@ -1,0 +1,51 @@
+# Introduction
+
+### Numbers
+
+Go contains basic numeric types that can represent sets of either integer or
+floating-point values. There a different types depending on the size of value
+you require and the architecture of the computer where the application is
+running (e.g. 32-bit and 64-bit).
+
+For the sake of this exercise you will only be dealing with:
+
+- `int`: e.g. `0`, `255`, `2147483647`. A signed integer that is at least 32
+  bits in size (value range of: -2147483648 through 2147483647). But this will
+  depend on the systems architecture. Most modern computers are 64 bit,
+  therefore `int` will be 64 bits in size (value rate of:
+  -9223372036854775808 through 9223372036854775807).
+
+- `float64`: e.g. `0.0`, `3.14`. Contains the set of all 64-bit floating-point
+  numbers.
+
+For a full list of the available numeric types and more detail see the
+following resources:
+
+- [Go builtin type declarations][go-builtins]
+- [Digital Ocean - Understanding Data Types in Go][do-understanding-types]
+- [Arden Labs - Understanding Type in Go][arden-understanding-types]
+
+Go supports the standard set of arithmetic operators of `+`, `-`, `*`, `/`
+and `%` (remainder not modulo). 
+
+### Type Conversion
+
+In Go, assignment of a value between different types requires explicit
+conversion. For example, to convert an `int` to a `float64` you would need to
+do the following:
+
+```go
+var x int = 42
+f := float64(x)
+
+fmt.Printf("x is of type: %s\n", reflect.TypeOf(x))
+// Output: x is of type: int
+
+fmt.Printf("f is of type: %s\n", reflect.TypeOf(f))
+// Output: f is of type: float64
+```
+
+
+[go-builtins]:https://github.com/golang/go/blob/master/src/builtin/builtin.go
+[do-understanding-types]:https://www.digitalocean.com/community/tutorials/understanding-data-types-in-go
+[arden-understanding-types]:https://www.ardanlabs.com/blog/2013/07/understanding-type-in-go.html

--- a/languages/go/exercises/concept/numbers/.meta/example.go
+++ b/languages/go/exercises/concept/numbers/.meta/example.go
@@ -1,0 +1,35 @@
+package _meta
+
+// CalculateProductionRatePerHour for the assembly line, taking into account
+// its success rate
+func CalculateProductionRatePerHour(speed int) float64 {
+	const defaultRate = 221.0
+
+	rateForSpeed := defaultRate * float64(speed)
+
+	return rateForSpeed * successRate(speed)
+}
+
+// CalculateProductionRatePerMinute describes how many working items are
+// produced by the asembly line every minute
+func CalculateProductionRatePerMinute(speed int) int {
+	return int(CalculateProductionRatePerHour(speed) / 60)
+}
+
+// successRate is used to calculate the ratio of an item being created without
+// error for a given speed
+func successRate(speed int) float64 {
+	if speed == 0 {
+		return 0.0
+	}
+
+	if speed < 5 {
+		return 1.0
+	}
+
+	if speed >= 9 {
+		return 0.77
+	}
+
+	return 0.9
+}

--- a/languages/go/exercises/concept/numbers/go.mod
+++ b/languages/go/exercises/concept/numbers/go.mod
@@ -1,0 +1,3 @@
+module numbers
+
+go 1.13

--- a/languages/go/exercises/concept/numbers/numbers.go
+++ b/languages/go/exercises/concept/numbers/numbers.go
@@ -1,0 +1,31 @@
+package numbers
+
+// CalculateProductionRatePerHour for the assembly line, taking into account
+// its success rate
+func CalculateProductionRatePerHour(speed int) float64 {
+	panic("not implemented")
+}
+
+// CalculateProductionRatePerMinute describes how many working items are
+// produced by the assembly line every minute
+func CalculateProductionRatePerMinute(speed int) int {
+	panic("not implemented")
+}
+
+// successRate is used to calculate the ratio of an item being created without
+// error for a given speed
+func successRate(speed int) float64 {
+	if speed == 0 {
+		return 0.0
+	}
+
+	if speed < 5 {
+		return 1.0
+	}
+
+	if speed >= 9 {
+		return 0.77
+	}
+
+	return 0.9
+}

--- a/languages/go/exercises/concept/numbers/numbers_test.go
+++ b/languages/go/exercises/concept/numbers/numbers_test.go
@@ -1,0 +1,102 @@
+package numbers_test
+
+import (
+	"numbers"
+	"testing"
+)
+
+func TestCalculateProductionRatePerHour(t *testing.T) {
+	tests := []struct {
+		name  string
+		speed int
+		want  float64
+	}{
+		{
+			name:  "calculate production rate per hour for speed zero",
+			speed: 0,
+			want:  0.0,
+		},
+		{
+			name:  "calculate production rate per hour for speed one",
+			speed: 1,
+			want:  221.0,
+		},
+		{
+			name:  "calculate production rate per hour for speed four",
+			speed: 4,
+			want:  884.0,
+		},
+		{
+			name:  "calculate production rate per hour for speed seven",
+			speed: 7,
+			want:  1392.3,
+		},
+		{
+			name:  "calculate production rate per hour for speed nine",
+			speed: 9,
+			want:  1531.53,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := numbers.CalculateProductionRatePerHour(tt.speed)
+			if got != tt.want {
+				t.Errorf(
+					"CalculateProductionRatePerHour(%d) = %f, want %f",
+					tt.speed,
+					got,
+					tt.want,
+				)
+			}
+		})
+	}
+}
+
+func TestCalculateProductionRatePerMinute(t *testing.T) {
+	tests := []struct {
+		name  string
+		speed int
+		want  int
+	}{
+		{
+			name:  "calculate production rate per minute for speed zero",
+			speed: 0,
+			want:  0,
+		},
+		{
+			name:  "calculate production rate per minute for speed one",
+			speed: 1,
+			want:  3,
+		},
+		{
+			name:  "calculate production rate per minute for speed five",
+			speed: 5,
+			want:  16,
+		},
+		{
+			name:  "calculate production rate per minute for speed eight",
+			speed: 8,
+			want:  26,
+		},
+		{
+			name:  "calculate production rate per minute for speed ten",
+			speed: 10,
+			want:  28,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := numbers.CalculateProductionRatePerMinute(tt.speed)
+			if got != tt.want {
+				t.Errorf(
+					"CalculateWorkingItemsRate(%d) = %d, want %d",
+					tt.speed,
+					got,
+					tt.want,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I've taken the approach outlined in the C# example but I'm not entirely confident that this is the correct approach for an intro exercise as it requires type conversion. This may be OK but I'd like to others opinions on it.

As Go has quite a few different numeric types, I've limited it to just `int` and `float64` and given links in to the introduction if students want to dig in more.

This satisfies #371 