### PR TITLE
[Go]: Update test cases for basic-strings

### DIFF
--- a/languages/go/exercises/concept/basic-strings/basic_strings_test.go
+++ b/languages/go/exercises/concept/basic-strings/basic_strings_test.go
@@ -42,6 +42,13 @@ func TestMessage(t *testing.T) {
 			},
 			want: "Timezone not set",
 		},
+		{
+			name: "Message with wrong format returns empty string",
+			args: args{
+				line: "exit status 1",
+			},
+			want: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
While working through the basic-strings exercise to see what the Analyzer should check (as part of #355) I noticed that students weren't required by the test cases to implement an if statement for the Message function. This test case means that they will need to.