### PR TITLE
[Rust] add myself as a maintainer

### DIFF
--- a/languages/rust/maintainers.md
+++ b/languages/rust/maintainers.md
@@ -14,3 +14,4 @@ These awesome people help maintain the Rust track.
 
 - [@filalex77](https://github.com/filalex77)
 - [@lewisclement](https://github.com/lewisclement)
+- [@efx](https://github.com/efx)


### PR DESCRIPTION
I noticed other tracks encode maintainer identity differently (First
Name, Last Name, Handle on Github, etc). I like that idea but cannot
justify breaking the visual consistency on our page so kept it to my GH
handle.