### PR TITLE
[Go] add design documents for strings and numbers

### DIFF
--- a/languages/go/exercises/concept/basic-strings/.meta/design.md
+++ b/languages/go/exercises/concept/basic-strings/.meta/design.md
@@ -1,0 +1,31 @@
+# Design
+
+## Goal
+
+The goal of this exercise is to teach the student the basics of the Concept of Strings in Go.
+
+## Things to teach
+
+- Know of the existence of the `string` type.
+- Know how to create a string.
+- Know of some basic `strings` methods (like `Split`, `Index`, `TrimSpace`).
+- Know how to do basic string formatting: `fmt.Sprintf`
+
+## Things not to teach
+
+- iteration of strings
+- immutability of strings
+- advanced string formatting (e.g. formatting floats)
+- bytes and runes
+
+## Concepts
+
+- `basic-strings`
+
+## Prequisites
+
+- `slices`
+
+## Analyzer
+
+See https://github.com/exercism/v3/issues/355.

--- a/languages/go/exercises/concept/numbers/.meta/design.md
+++ b/languages/go/exercises/concept/numbers/.meta/design.md
@@ -1,0 +1,18 @@
+# Design
+
+## Goal
+
+The goal of this exercise is to teach the student how to deal with numbers in Go.
+
+## Things to teach
+
+- This should introduce the `int` and `float64` types (be basic number types in Go).
+- It should introduce operations with numbers like multiplication, division, etc.
+- Introduce basic type conversion between number types
+
+My suggestion is to copy C# `numbers` exercise: https://github.com/exercism/v3/tree/master/languages/csharp/exercises/concept/numbers
+
+## Concepts
+
+- `numbers`
+- `type-conversion`


### PR DESCRIPTION
Add the missing `design.md` documents to `strings` and `numbers` exercises for Go.