### PR TITLE
exclude .git/ from valid-link workflows

### DIFF
--- a/.github/workflows/valid-links.yml
+++ b/.github/workflows/valid-links.yml
@@ -30,7 +30,7 @@ jobs:
 
           if [ "$GITHUB_REF" = "master" ] || [ $deleted_or_renamed -ne 0 ]
           then
-              files=$(find . -name \*.md ! -iname _sidebar.md ! -ipath \*/ISSUE_TEMPLATE/\*.md)
+              files=$(find . -name \*.md ! -iname _sidebar.md ! -ipath \*/ISSUE_TEMPLATE/\*.md -not -path "./.git/*")
           else
               files=$(git diff --no-commit-id --name-only --diff-filter AM origin/master | grep  -i .md$ | grep -v -i _sidebar.md | grep -v -i ISSUE_TEMPLATE | cat)
           fi
@@ -38,6 +38,6 @@ jobs:
           for file in $files; do
             if [ -f "$file" ]
             then
-                markdown-link-check -q -c .github/markdown-link-check-config.json $file
+                markdown-link-check -q -c .github/markdown-link-check-config.json "$file"
             fi
           done


### PR DESCRIPTION
See https://github.com/exercism/v3/pull/222#issuecomment-580209054. 
Also my address part of the problem in #102.

I also double quoted "$file" variable to avoid globing surprises per [shellcheck.net](https://www.shellcheck.net/).

For the quick and easy way to test this,  [see my testing branch.](https://github.com/exercism/v3/compare/master...efx:polish-link-checker-testing?expand=1). I was only able to reproduce when running `action.sh` from #222.