### PR TITLE
[CI] Add workflow to make prevent work-in-progress PRs from being merged

### DIFF
--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -1,0 +1,12 @@
+name: WIP
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  wip:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: wip/action@950607d619136e6523c46ba3e3fbc7b90fc77fe8 # 1.0


### PR DESCRIPTION
This PR adds a workflow that will have a non-zero exit code if the word WIP is found in the title. We can discuss here what the actual rule should be (if it should start with "WIP", if it should be "[WIP]", or whatever.

@SaschaMann I've requested you as a reviewed as I seem to recall you having some experience with GH actions.