### PR TITLE
[Rust] Link to concepts in the Book

### DIFF
--- a/languages/rust/reference/README.md
+++ b/languages/rust/reference/README.md
@@ -68,12 +68,12 @@ These concepts are more advanced than the fundamentals, but may be familiar from
 - [x] Explicit `return`
 - [x] [Methods](../../../reference/concepts/methods.md) / `impl` blocks
 - [ ] [Composition](../../../reference/concepts/composition.md)
-- [x] Basics of [Generics](../../../reference/concepts/generics.md)
+- [x] Basics of [Generics](https://doc.rust-lang.org/book/ch10-00-generics.html)
 - [ ] Using External Crates / Libraries
   [ ]   - `use` statement for importing
 - [x] `match` basics: ints and enums
 - [ ] Destructuring (in `match`, in `let`)
-- [ ] `match` with [Pattern matching](../../../reference/concepts/pattern_matching.md)
+- [ ] [`match` with Pattern matching](https://doc.rust-lang.org/book/ch06-02-match.html)
 - [ ] [Anonymous functions](../../../reference/concepts/anonymous_functions.md)
 - [ ] [Recursion](../../../reference/concepts/recursion.md)
 - [ ] Ranges


### PR DESCRIPTION
I linked the entire match section to the relevant chapter in the book
because it describes them  interchangeably.