### PR TITLE
[CI] Only run link checker on changes to md files

### DIFF
--- a/.github/workflows/valid-links.yml
+++ b/.github/workflows/valid-links.yml
@@ -2,7 +2,11 @@ name: Check for dead links
 
 on:
   push:
+    paths:
+    - '**.md'
   pull_request:
+    paths:
+    - '**.md'
   schedule:
     - cron: "0 3 * * *"
 


### PR DESCRIPTION
The link checker runs on every push, even if no markdown files have been changed. This PR changes it so that the build only gets triggered if any markdown files `**.md` in the repo are touched by a change.