### PR TITLE
Add config.json to structure of exercise file tree

### DIFF
--- a/languages/kotlin/docs/implementing-a-concept-exercise.md
+++ b/languages/kotlin/docs/implementing-a-concept-exercise.md
@@ -26,6 +26,7 @@ languages
                 |   └── after.md (optional)
                 ├── .meta
                 |   |── design.md
+                |   |── config.json
                 |   └── Example.kt
                 ├── src
                 |   ├── main


### PR DESCRIPTION
According to recent clarifications, there should be a `config.json` file under the `.meta` folder. If is intended to host information of contributors to the exercise. 
Sample: [C# - strings/.meta](https://github.com/exercism/v3/tree/master/languages/csharp/exercises/concept/strings/.meta)