### PR TITLE
[Clojure] Add reference/progression.md

### DIFF
--- a/languages/clojure/_sidebar.md
+++ b/languages/clojure/_sidebar.md
@@ -3,6 +3,8 @@
 - [Languages](/languages/README.md)
   - [Clojure](/languages/clojure/README.md)
     - [Docs](/languages/clojure/docs/README.md)
+    - [Exercises](/languages/clojure/exercises/README.md)
+    - [Reference](/languages/clojure/reference/README.md)
 - Reference
   - [Concepts](/reference/concepts/README.md)
   - [Paradigms](/reference/paradigms/README.md)

--- a/languages/clojure/exercises/README.md
+++ b/languages/clojure/exercises/README.md
@@ -1,0 +1,9 @@
+# Clojure exercises
+
+There are two types of exercises:
+
+- [Concept exercises][concept-exercises] (WIP)
+- [Practice exercises][practice-exercises] (on hold)
+
+[concept-exercises]: ./concept/README.md
+[practice-exercises]: ./practice/README.md

--- a/languages/clojure/exercises/concept/README.md
+++ b/languages/clojure/exercises/concept/README.md
@@ -1,0 +1,20 @@
+# Clojure concept exercises
+
+The concept exercises are based on this [list of concepts][reference-shared].
+
+## Implemented exercises
+
+- [List][concept-exercise-list]
+
+## TODO
+
+Thanks for wanting to contribute to the Clojure track's concept exercises! Contributions are very welcome!
+
+To contribute, please find and work on one of the [new exercise issues][issues-new-exercise] or [improve exercise issues][issues-improve-exercise].
+
+[reference-shared]: ../../reference/README.md
+[reference]: ./reference.md
+[concept-exercises]: ./concept/README.md
+[concept-exercise-list]: ./list/.meta/design.md
+[issues-new-exercise]: https://github.com/exercism/v3/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Atrack%2Fclojure+label%3Atype%2Fnew-exercise+label%3Astatus%2Fhelp-wanted
+[issues-improve-exercise]: https://github.com/exercism/v3/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Atrack%2Fclojure+label%3Atype%2Fimprove-exercise+label%3Astatus%2Fhelp-wanted

--- a/languages/clojure/exercises/practice/README.md
+++ b/languages/clojure/exercises/practice/README.md
@@ -1,0 +1,9 @@
+# Clojure practice exercises
+
+Practice Exercises are exercises that help one dig a bit deeper into concepts that one has learnt through Concept Exercises.
+
+## To do
+
+Currently, we're not actively working on building practice exercises. This will change once the [concept exercises][exercises-concept] have been built.
+
+[exercises-concept]: ../concept/README.md

--- a/languages/clojure/reference/README.md
+++ b/languages/clojure/reference/README.md
@@ -1,0 +1,73 @@
+# Clojure reference
+
+## Concepts
+
+The Clojure concept exercises are based on concepts.
+The list below contains the concepts that have been identified for the Clojure language.
+
+See [progression.md](progression.md) for planning the progression order of the Clojure track.
+
+The core features a Clojure developer should know about are:
+
+- [REPL](../../../reference/concepts/repl.md)
+- [Evaluation](../../../reference/concepts/evaluation.md)
+- [Sameness](../../../reference/concepts/sameness.md)
+- [Truthy and falsy](../../../reference/concepts/truthy_and_falsy.md)
+- [Immutability](../../../reference/concepts/immutability.md)
+- [Functions](../../../reference/concepts/functions.md)
+- [Conditionals](../../../reference/concepts/conditionals.md)
+- [Higher-order functions](../../../reference/concepts/higher_order_functions.md)
+- [Sequence comprehensions](../../../reference/concepts/list_comprehension.md)
+- [Anonymous functions](../../../reference/concepts/anonymous_functions.md)
+- [Recursion](../../../reference/concepts/recursion.md)
+- [Destructuring](../../../reference/concepts/destructuring.md)
+- [State](../../../reference/concepts/state.md)
+- [Metaprogramming](../../../reference/concepts/metaprogramming.md)
+- [Macros](../../../reference/concepts/macros.md)
+- [Polymorphism](../../../reference/concepts/polymorphism.md)
+- [Multimethods](../../../reference/concepts/multiple-dispatch.md)
+- nil
+- varidic-arity and multi-arity
+- anonymous functions
+- laziness
+- quotation
+- namespaces
+- metadata
+- project structure
+- threading macros
+- transducers
+- prefix notation
+- function application
+- pure functions
+- local binding with let
+- regular expressions
+- function compostion
+- concurrency
+- parallelism
+- dynamic vars
+- records
+- comments and docstrings
+- variable shadowing
+- bitwise manipulation
+- comments
+- validation (with clojure.spec)
+
+### Types
+
+- Integers
+- Floating point numbers
+- [Strings][string]
+- [Characters][char]
+- [Booleans][bool]
+- [Vectors][array]
+- [Lists][list]
+- [Hashmaps][map]
+- [Sets][set]
+
+[array]: ../../../reference/types/array.md
+[bool]: ../../../reference/types/boolean.md
+[char]: ../../../reference/types/char.md
+[list]: ../../../reference/types/list.md
+[map]: ../../../reference/types/map.md
+[set]: ../../../reference/types/set.md
+[string]: ../../../reference/types/string.md

--- a/languages/clojure/reference/progression.md
+++ b/languages/clojure/reference/progression.md
@@ -1,0 +1,17 @@
+# Clojure Concept Exercise Progression
+
+This is a working document to keep track of ideas and thoughts on how the progression through the Concept Exercises on the Clojure track could work.
+
+```mermaid
+graph LR
+   Clojure --> Equality & g2[Special Forms] & Collections & Namespaces & Multimethods & g3[Reader Syntax] & Functions & Macros & g4[Reference Types] & Concurrency & g5[Error Handling] & REPL & Interop & IO
+   Collections --> Arrays & Transients & Seqs & Sets & Vectors & Lists & Stacks & Maps
+   Multimethods -->Heirarchies
+   g3 --> g6[Tagged Literals]
+   Functions --> g7[Higher-order Functions]
+   g4 --> Vars & Refs & Agents & Atoms & Concurrency
+   Concurrency --> Futures & Promises
+   REPL --> Documentation
+   Interop --> Records & Types & g8[Type Hints] & Subclassing & Interfaces & Protocols
+   IO --> Printing
+```


### PR DESCRIPTION
Includes mermaidjs Concepts graph based on Clojure Atlas, and updated sidebar with proper reference docs. Note: this PR replaces #271.