### PR TITLE
[Docs] Describe config.json file usage

### DIFF
--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -83,6 +83,12 @@ It exists in order to inform future maintainers or contributors about the scope 
 
 See the C# floating-point-numbers exercise's [design.md file][csharp-docs-design.md] for an example.
 
+### `.meta/config.json`
+
+This file contains meta information on the exercise, which currently only includes the exercise's contributors.
+
+See the C# floating-point-numbers exercise's [config.json file][csharp-docs-config.json] for an example.
+
 ## Track Structure
 
 ### `exercises/shared/.docs/cli.md`
@@ -103,3 +109,5 @@ See the C# track's [debug.md file][csharp-docs-debug.md] for an example.
 [csharp-docs-hints.md]: ../languages/csharp/exercises/concept/numbers-floating-point/.docs/hints.md
 [csharp-docs-introduction.md]: ../languages/csharp/exercises/concept/numbers-floating-point/.docs/introduction.md
 [csharp-docs-instructions.md]: ../languages/csharp/exercises/concept/numbers-floating-point/.docs/instructions.md
+[csharp-docs-design.md]: ../languages/csharp/exercises/concept/numbers-floating-point/.meta/design.md
+[csharp-docs-config.json]: ../languages/csharp/exercises/concept/numbers-floating-point/.meta/config.json

--- a/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+++ b/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
@@ -21,6 +21,7 @@ languages
                 |   ├── hints.md
                 |   └── after.md (optional)
                 └── .meta
+                    ├── config.json
                     └── design.md
 </pre>
 
@@ -93,6 +94,10 @@ Skip this step if your track does not have a representer.
 
 This file contains information on the exercise's design, which includes things like its goal, its teaching goals, what not to teach, and more ([example][meta-design]). This information can be extracted from the exercise's corresponding GitHub issue.
 
+## Step 11: add .meta/config.json:
+
+This file contains meta information on the exercise, which currently only includes the exercise's contributors ([example][meta-config-json]).
+
 ## Inspiration
 
 When implementing an exercise, it can be very useful to look at the exercises the track has already implemented. You can also check the exercise's [general concepts documents][reference] to see if other languages that have already an exercise for that concept.
@@ -104,3 +109,4 @@ If you have any questions regarding implementing this exercise, please post them
 [docs-concept-exercises]: ../concept-exercises.md
 [reference]: ../../reference/concepts/README.md
 [meta-design]: ../../languages/csharp/exercises/concept/enums-advanced/.meta/design.md
+[meta-config-json]: ../../languages/csharp/exercises/concept/enums-advanced/.meta/config.json

--- a/languages/clojure/docs/implementing-a-concept-exercise.md
+++ b/languages/clojure/docs/implementing-a-concept-exercise.md
@@ -21,6 +21,7 @@ languages
                 |   ├── hints.md
                 |   └── after.md (optional)
                 ├── .meta
+                |   |── config.json
                 |   |── design.md
                 |   └── Example.clj
                 ├── &lt;NAME&gt;.clj

--- a/languages/common-lisp/docs/implementing-a-concept-exercise.md
+++ b/languages/common-lisp/docs/implementing-a-concept-exercise.md
@@ -26,6 +26,7 @@ languages
                 |   ├── hints.md
                 |   └── after.md (optional)
                 ├── .meta
+                |   |── config.json
                 |   |── design.md
                 |   └── example.lisp
                 ├── &lt;SLUG&gt;.asd

--- a/languages/cpp/docs/implementing-a-concept-exercise.md
+++ b/languages/cpp/docs/implementing-a-concept-exercise.md
@@ -21,6 +21,7 @@ languages
             │   ├── instructions.md
             │   └── introduction.md
             ├── .meta
+            |   |── config.json
             │   ├── design.md
             │   ├── example.cpp
             │   └── example.h

--- a/languages/csharp/docs/implementing-a-concept-exercise.md
+++ b/languages/csharp/docs/implementing-a-concept-exercise.md
@@ -21,6 +21,7 @@ languages
                 |   ├── hints.md
                 |   └── after.md (optional)
                 ├── .meta
+                |   |── config.json
                 |   |── design.md
                 |   └── Example.cs
                 ├── &lt;NAME&gt;.cs

--- a/languages/fsharp/docs/implementing-a-concept-exercise.md
+++ b/languages/fsharp/docs/implementing-a-concept-exercise.md
@@ -21,6 +21,7 @@ languages
                 |   ├── hints.md
                 |   └── after.md (optional)
                 ├── .meta
+                |   |── config.json
                 |   |── design.md
                 |   └── Example.fs
                 ├── &lt;NAME&gt;.fs

--- a/languages/go/docs/implementing-a-concept-exercise.md
+++ b/languages/go/docs/implementing-a-concept-exercise.md
@@ -21,6 +21,7 @@ languages
                 |   ├── hints.md
                 |   └── after.md (optional)
                 ├── .meta
+                |   |── config.json
                 |   |── design.md
                 |   └── example.go
                 ├── &lt;NAME&gt;.go

--- a/languages/haskell/docs/implementing-a-concept-exercise.md
+++ b/languages/haskell/docs/implementing-a-concept-exercise.md
@@ -21,6 +21,7 @@ languages
                 |   ├── hints.md
                 |   └── after.md (optional)
                 ├── .meta
+                |   |── config.json
                 |   |── design.md
                 |   └── <SLUG>.hs (example solution)
                 ├── src

--- a/languages/javascript/docs/implementing-a-concept-exercise.md
+++ b/languages/javascript/docs/implementing-a-concept-exercise.md
@@ -26,6 +26,7 @@ languages
                 |   ├── hints.md
                 |   └── after.md (optional)
                 ├── .meta
+                |   |── config.json
                 |   └── design.md
                 ├── .eslintrc
                 ├── .gitignore
@@ -124,6 +125,10 @@ Some exercises could benefit from having an custom representation as generated b
 ## Step 10: add `.meta/design.md`
 
 This file contains information on the exercise's design, which includes things like its goal, its teaching goals, what not to teach, and more. This information can be extracted from the exercise's corresponding GitHub issue.
+
+## Step 11: add .meta/config.json:
+
+This file contains meta information on the exercise, which currently only includes the exercise's contributors.
 
 ## Inspiration
 

--- a/languages/julia/docs/implementing-a-concept-exercise.md
+++ b/languages/julia/docs/implementing-a-concept-exercise.md
@@ -21,6 +21,7 @@ languages
                 |   ├── hints.md
                 |   └── after.md (optional)
                 ├── .meta
+                |   |── config.json
                 |   |── design.md
                 |   └── example.jl
                 ├── $slug.jl

--- a/languages/kotlin/docs/implementing-a-concept-exercise.md
+++ b/languages/kotlin/docs/implementing-a-concept-exercise.md
@@ -123,6 +123,10 @@ Skip this step if your track does not have a representer.
 
 This file contains information on the exercise's design, which includes things like its goal, its teaching goals, what not to teach, and more. This information can be extracted from the exercise's corresponding GitHub issue.
 
+## Step 10: add .meta/config.json:
+
+This file contains meta information on the exercise, which currently only includes the exercise's contributors.
+
 ## Inspiration
 
 When implementing an exercise, it can be very useful to look at the exercises the track has already implemented. You can also check the exercise's [general concepts documents][reference] to see if other languages that have already an exercise for that concept.

--- a/languages/purescript/docs/implementing-a-concept-exercise.md
+++ b/languages/purescript/docs/implementing-a-concept-exercise.md
@@ -21,6 +21,7 @@ languages
                 |   ├── hints.md
                 |   └── after.md (optional)
                 ├── .meta
+                |   |── config.json
                 |   |── design.md
                 |   └── Example.purs
                 ├── src

--- a/languages/typescript/docs/implementing-a-concept-exercise.md
+++ b/languages/typescript/docs/implementing-a-concept-exercise.md
@@ -125,6 +125,10 @@ Some exercises could benefit from having an custom representation as generated b
 
 This file contains information on the exercise's design, which includes things like its goal, its teaching goals, what not to teach, and more. This information can be extracted from the exercise's corresponding GitHub issue.
 
+## Step 11: add .meta/config.json:
+
+This file contains meta information on the exercise, which currently only includes the exercise's contributors.
+
 ## Inspiration
 
 When implementing an exercise, it can be very useful to look at the exercises the track has already implemented. You can also check the exercise's [general concepts documents][reference] to see if other languages that have already an exercise for that Concept.


### PR DESCRIPTION
We've recently re-introduced the `config.json` file. It currently only lists the contributors to an exercise, but that might change in the future.