### PR TITLE
[Common Lisp] Add Initial Concepts for Discussion

### DIFF
--- a/languages/common-lisp/reference/README.md
+++ b/languages/common-lisp/reference/README.md
@@ -5,41 +5,41 @@ document][csharp-example] as an example to base my work off of.
 
 ## Concepts
 ### General
-  - [Anonymous Functions][anon]
-  - [Arithmetic][arit]
+  - [Anonymous Functions][anonymous-functions]
+  - [Arithmetic][arithmetic]
     - Prefix Notation
-  - [Assignment][assi]
+  - [Assignment][assignment]
     - Generic Setters
-  - [Comments][comm]
+  - [Comments][comments]
     - Line
     - Block
     - Conventions
-  - [Conditionals][cond]
+  - [Conditionals][conditionals]
     - One Branch (`and`, `or`, `when`, `unless`)
     - Two Branch (`if`)
     - More Branches (`cond`, `case`)
-  - [Constants][cons]
-  - [Enumeration][enum]
+  - [Constants][constants]
+  - [Enumeration][enumeration]
     - Loop Macro
     - Do (`do`, `do*`, `dotimes`, `dolist`)
-  - [Expressions][expr]
+  - [Expressions][expressions]
     - S-Expressions
-  - [Functions][func]
+  - [Functions][functions]
     - Default Arguments
     - Keyword Arguments
     - Optional Arguments
     - Rest Arguments
-  - [Higher Order Functions][high]
-  - [Nested Functions][nest]
+  - [Higher Order Functions][higher-order-functions]
+  - [Nested Functions][nested-functions]
   - Packages
-  - [Recursion][recu]
-  - [Sameness][same]
+  - [Recursion][recursion]
+  - [Sameness][sameness]
     - Same Memory (`eq`)
     - Same Value Primitives (`eql`)
     - Same Value Objects (`equal`)
     - Lenient Sameness (`equalp`)
     - Type Specific (`=`, `char=`, `string-equal`, etc)
-  - [Variables][vari]
+  - [Variables][variables]
     - Global (`defparameter`, `defvar`)
     - Local (`let`, `let*`)
 
@@ -60,12 +60,12 @@ document][csharp-example] as an example to base my work off of.
   - Sequences
 
 ### CLOS (Needs Some Work)
-  - [Classes][clas]
+  - [Classes][classes]
   - Generic Functions
-  - [Methods][meth]
-  - [Multiple Dispatch][mult]
-  - [Multiple Inheritance][inhe]
-  - [Objects][obje]
+  - [Methods][methods]
+  - [Multiple Dispatch][multiple-dispatch]
+  - [Multiple Inheritance][inheritance]
+  - [Objects][objects]
   - Slots
   
 ### Conditions & Restarts (Needs Some Work)
@@ -77,24 +77,24 @@ document][csharp-example] as an example to base my work off of.
 ### Types
   - [Booleans][bool]
   - [Characters][char]
-  - [Hash Tables][hash]
-  - [Numbers][numb]
+  - [Hash Tables][hash-map]
+  - [Numbers][number]
     - Complex
-    - [Floats][floa]
-    - [Integers][inte]
+    - [Floats][floating-point-number]
+    - [Integers][integer]
     - Rationals
   - Sequences
     - [Arrays][arra]
     - Conses
-      - [Association Lists][maps]
+      - [Association Lists][map]
       - [Lists][list]
       - Property Lists
-      - [Sets][sets]
+      - [set][set]
       - Trees
     - Vectors
   - Streams
-  - [Strings][stri]
-  - [Structures][stru]
+  - [Strings][string]
+  - [Structures][struct]
 
 ## Exercise Concepts
 We should put a table here that go into the specifics to teach for each
@@ -103,34 +103,34 @@ sub-concepts. So things like `format.numbers` or maybe
 `string-formatting.numbers`.
 
 [csharp-example]: ../../csharp/reference/README.md
-[anon]: ../../../reference/concepts/anonymous_functions.md
-[arit]: ../../../reference/concepts/arithmetic.md
-[assi]: ../../../reference/concepts/assignment.md
-[comm]: ../../../reference/concepts/comments.md
-[cond]: ../../../reference/concepts/conditionals.md
-[cons]: ../../../reference/concepts/constants.md
-[enum]: ../../../reference/concepts/enumeration.md
-[expr]: ../../../reference/concepts/expressions.md
-[func]: ../../../reference/concepts/functions.md
-[high]: ../../../reference/concepts/higher_order_functions.md
-[nest]: ../../../reference/concepts/nested_functions.md
-[recu]: ../../../reference/concepts/recursion.md
-[same]: ../../../reference/concepts/sameness.md
-[vari]: ../../../reference/concepts/variables.md
-[clas]: ../../../reference/concepts/classes.md
-[meth]: ../../../reference/concepts/methods.md
-[mult]: ../../../reference/concepts/multiple-dispatch.md
-[inhe]: ../../../reference/concepts/inheritance.md
-[obje]: ../../../reference/concepts/objects.md
+[anonymous-functions]: ../../../reference/concepts/anonymous_functions.md
+[arithmetic]: ../../../reference/concepts/arithmetic.md
+[assignment]: ../../../reference/concepts/assignment.md
+[comments]: ../../../reference/concepts/comments.md
+[conditionals]: ../../../reference/concepts/conditionals.md
+[constants]: ../../../reference/concepts/constants.md
+[enumeration]: ../../../reference/concepts/enumeration.md
+[expressions]: ../../../reference/concepts/expressions.md
+[functions]: ../../../reference/concepts/functions.md
+[higher-order-functions]: ../../../reference/concepts/higher_order_functions.md
+[nested-functions]: ../../../reference/concepts/nested_functions.md
+[recursion]: ../../../reference/concepts/recursion.md
+[sameness]: ../../../reference/concepts/sameness.md
+[variables]: ../../../reference/concepts/variables.md
+[classes]: ../../../reference/concepts/classes.md
+[methods]: ../../../reference/concepts/methods.md
+[multiple-dispatch]: ../../../reference/concepts/multiple-dispatch.md
+[inheritance]: ../../../reference/concepts/inheritance.md
+[objects]: ../../../reference/concepts/objects.md
 [bool]: ../../../reference/types/boolean.md
 [char]: ../../../reference/types/char.md
-[hash]: ../../../reference/types/hash_map.md
-[numb]: ../../../reference/types/number.md
-[floa]: ../../../reference/types/floating_point_number.md
-[inte]: ../../../reference/types/integer.md
-[arra]: ../../../reference/types/array.md
-[maps]: ../../../reference/types/map.md
+[hash-map]: ../../../reference/types/hash_map.md
+[number]: ../../../reference/types/number.md
+[floating-point-number]: ../../../reference/types/floating_point_number.md
+[integer]: ../../../reference/types/integer.md
+[array]: ../../../reference/types/array.md
+[map]: ../../../reference/types/map.md
 [list]: ../../../reference/types/list.md
-[sets]: ../../../reference/types/set.md
-[stri]: ../../../reference/types/string.md
-[stru]: ../../../reference/types/struct.md
+[set]: ../../../reference/types/set.md
+[string]: ../../../reference/types/string.md
+[struct]: ../../../reference/types/struct.md

--- a/languages/common-lisp/reference/README.md
+++ b/languages/common-lisp/reference/README.md
@@ -21,8 +21,8 @@ document][csharp-example] as an example to base my work off of.
   - Recursion
   - Higher Order Functions
   - Anonymous Functions
-  - String Formatting
   - Boolean Logic
+  - Packages
 
 ### Format
   - Basic

--- a/languages/common-lisp/reference/README.md
+++ b/languages/common-lisp/reference/README.md
@@ -5,75 +5,87 @@ document][csharp-example] as an example to base my work off of.
 
 ## Concepts
 ### General
-  - Constants
-  - Variables
-  - Strings
-  - Characters
+  - [Anonymous Functions][anon]
+  - [Arithmetic][arit]
+    - Prefix Notation
+  - [Assignment][assi]
+    - Generic Setters
+  - [Comments][comm]
+    - Line
+    - Block
+    - Conventions
+  - [Conditionals][cond]
+    - One Branch (`and`, `or`, `when`, `unless`)
+    - Two Branch (`if`)
+    - More Branches (`cond`, `case`)
+  - [Constants][cons]
+  - [Enumeration][enum]
+    - Loop Macro
+    - Do (`do`, `do*`, `dotimes`, `dolist`)
+  - [Expressions][expr]
+    - S-Expressions
   - Functions
-  - Sameness
-  - Comments
-  - Nested Functions
-  - Conditionals
-  - Expressions
-  - Map
-  - Generic Setters
-  - Enumeration
-  - Recursion
   - Higher Order Functions
-  - Anonymous Functions
-  - Boolean Logic
+  - Nested Functions
   - Packages
+  - Recursion
+  - Sameness
+  - Variables
+    - Global (`defparameter`, `defvar`)
+    - Local (`let`, `let*`)
 
 ### Format
   - Basic
-  - Numbers
-  - Language
-  - Tables
-  - Iteration
   - Conditionals
+  - Iteration
+  - Language
   - Miscellaneous
+  - Numbers
+  - Tables
 
 ### Loop (Needs Lots of Work)
+  - Collecting
+  - Hash Tables
+  - Miscellaneous
   - Ranges
   - Sequences
-  - Hash Tables
-  - Collecting
-  - Miscellaneous
 
 ### CLOS (Needs Some Work)
   - Classes
+  - Generic Functions
+  - Methods
+  - Multiple Dispatch
+  - Multiple Inheritance
   - Objects
   - Slots
-  - Multiple Inheritance
-  - Methods
-  - Generic Functions
-  - Multiple Dispatch
   
 ### Conditions & Restarts (Needs Some Work)
-  - Handlers
-  - Signalling
   - Conditions
+  - Handlers
   - Restarts
+  - Signalling
 
 ### Types
+  - Booleans
+  - Characters
   - Hash Tables
-  - Strings
+  - Numbers
+    - Complex
+    - Floats
+    - Integers
+    - Rationals
   - Sequences
+    - Arrays
     - Conses
+      - Association Lists
       - Lists
       - Property Lists
-      - Association Lists
-      - Trees
       - Sets
-    - Arrays
+      - Trees
     - Vectors
-  - Numbers
-    - Integers
-    - Floats
-    - Rationals
-    - Complex
-  - Structures
   - Streams
+  - Strings
+  - Structures
 
 ## Exercise Concepts
 We should put a table here that go into the specifics to teach for each
@@ -82,3 +94,12 @@ sub-concepts. So things like `format.numbers` or maybe
 `string-formatting.numbers`.
 
 [csharp-example]: ../../csharp/reference/README.md
+[anon]: ../../../reference/concepts/anonymous_functions.md
+[arit]: ../../../reference/concepts/arithmetic.md
+[assi]: ../../../reference/concepts/assignment.md
+[comm]: ../../../reference/concepts/comments.md
+[cond]: ../../../reference/concepts/conditionals.md
+[cons]: ../../../reference/concepts/constants.md
+[enum]: ../../../reference/concepts/enumeration.md
+[expr]: ../../../reference/concepts/expressions.md
+

--- a/languages/common-lisp/reference/README.md
+++ b/languages/common-lisp/reference/README.md
@@ -24,13 +24,22 @@ document][csharp-example] as an example to base my work off of.
     - Do (`do`, `do*`, `dotimes`, `dolist`)
   - [Expressions][expr]
     - S-Expressions
-  - Functions
-  - Higher Order Functions
-  - Nested Functions
+  - [Functions][func]
+    - Default Arguments
+    - Keyword Arguments
+    - Optional Arguments
+    - Rest Arguments
+  - [Higher Order Functions][high]
+  - [Nested Functions][nest]
   - Packages
-  - Recursion
-  - Sameness
-  - Variables
+  - [Recursion][recu]
+  - [Sameness][same]
+    - Same Memory (`eq`)
+    - Same Value Primitives (`eql`)
+    - Same Value Objects (`equal`)
+    - Lenient Sameness (`equalp`)
+    - Type Specific (`=`, `char=`, `string-equal`, etc)
+  - [Variables][vari]
     - Global (`defparameter`, `defvar`)
     - Local (`let`, `let*`)
 
@@ -51,12 +60,12 @@ document][csharp-example] as an example to base my work off of.
   - Sequences
 
 ### CLOS (Needs Some Work)
-  - Classes
+  - [Classes][clas]
   - Generic Functions
-  - Methods
-  - Multiple Dispatch
-  - Multiple Inheritance
-  - Objects
+  - [Methods][meth]
+  - [Multiple Dispatch][mult]
+  - [Multiple Inheritance][inhe]
+  - [Objects][obje]
   - Slots
   
 ### Conditions & Restarts (Needs Some Work)
@@ -66,26 +75,26 @@ document][csharp-example] as an example to base my work off of.
   - Signalling
 
 ### Types
-  - Booleans
-  - Characters
-  - Hash Tables
-  - Numbers
+  - [Booleans][bool]
+  - [Characters][char]
+  - [Hash Tables][hash]
+  - [Numbers][numb]
     - Complex
-    - Floats
-    - Integers
+    - [Floats][floa]
+    - [Integers][inte]
     - Rationals
   - Sequences
-    - Arrays
+    - [Arrays][arra]
     - Conses
-      - Association Lists
-      - Lists
+      - [Association Lists][maps]
+      - [Lists][list]
       - Property Lists
-      - Sets
+      - [Sets][sets]
       - Trees
     - Vectors
   - Streams
-  - Strings
-  - Structures
+  - [Strings][stri]
+  - [Structures][stru]
 
 ## Exercise Concepts
 We should put a table here that go into the specifics to teach for each
@@ -102,4 +111,26 @@ sub-concepts. So things like `format.numbers` or maybe
 [cons]: ../../../reference/concepts/constants.md
 [enum]: ../../../reference/concepts/enumeration.md
 [expr]: ../../../reference/concepts/expressions.md
-
+[func]: ../../../reference/concepts/functions.md
+[high]: ../../../reference/concepts/higher_order_functions.md
+[nest]: ../../../reference/concepts/nested_functions.md
+[recu]: ../../../reference/concepts/recursion.md
+[same]: ../../../reference/concepts/sameness.md
+[vari]: ../../../reference/concepts/variables.md
+[clas]: ../../../reference/concepts/classes.md
+[meth]: ../../../reference/concepts/methods.md
+[mult]: ../../../reference/concepts/multiple-dispatch.md
+[inhe]: ../../../reference/concepts/inheritance.md
+[obje]: ../../../reference/concepts/objects.md
+[bool]: ../../../reference/types/boolean.md
+[char]: ../../../reference/types/char.md
+[hash]: ../../../reference/types/hash_map.md
+[numb]: ../../../reference/types/number.md
+[floa]: ../../../reference/types/floating_point_number.md
+[inte]: ../../../reference/types/integer.md
+[arra]: ../../../reference/types/array.md
+[maps]: ../../../reference/types/map.md
+[list]: ../../../reference/types/list.md
+[sets]: ../../../reference/types/set.md
+[stri]: ../../../reference/types/string.md
+[stru]: ../../../reference/types/struct.md

--- a/languages/common-lisp/reference/README.md
+++ b/languages/common-lisp/reference/README.md
@@ -81,4 +81,4 @@ concept. Also give the concepts nice names. I think we are using `.` for
 sub-concepts. So things like `format.numbers` or maybe
 `string-formatting.numbers`.
 
-[csharp-example]: ../../languages/csharp/reference/README.md
+[csharp-example]: ../../csharp/reference/README.md

--- a/languages/common-lisp/reference/README.md
+++ b/languages/common-lisp/reference/README.md
@@ -1,0 +1,84 @@
+# Common Lisp Reference
+
+Please note that this is a *very* WIP document. I'm currently using [this
+document][csharp-example] as an example to base my work off of.
+
+## Concepts
+### General
+  - Constants
+  - Variables
+  - Strings
+  - Characters
+  - Functions
+  - Sameness
+  - Comments
+  - Nested Functions
+  - Conditionals
+  - Expressions
+  - Map
+  - Generic Setters
+  - Enumeration
+  - Recursion
+  - Higher Order Functions
+  - Anonymous Functions
+  - String Formatting
+  - Boolean Logic
+
+### Format
+  - Basic
+  - Numbers
+  - Language
+  - Tables
+  - Iteration
+  - Conditionals
+  - Miscellaneous
+
+### Loop (Needs Lots of Work)
+  - Ranges
+  - Sequences
+  - Hash Tables
+  - Collecting
+  - Miscellaneous
+
+### CLOS (Needs Some Work)
+  - Classes
+  - Objects
+  - Slots
+  - Multiple Inheritance
+  - Methods
+  - Generic Functions
+  - Multiple Dispatch
+  
+### Conditions & Restarts (Needs Some Work)
+  - Handlers
+  - Signalling
+  - Conditions
+  - Restarts
+
+### Types
+  - Hash Tables
+  - Strings
+  - Sequences
+    - Conses
+      - Lists
+      - Property Lists
+      - Association Lists
+      - Trees
+      - Sets
+    - Arrays
+    - Vectors
+  - Numbers
+    - Integers
+    - Floats
+    - Rationals
+    - Complex
+  - Structures
+  - Streams
+
+## Exercise Concepts
+We should put a table here that go into the specifics to teach for each
+concept. Also give the concepts nice names. I think we are using `.` for
+sub-concepts. So things like `format.numbers` or maybe
+`string-formatting.numbers`.
+
+[csharp-example]: ../../languages/csharp/reference/README.md


### PR DESCRIPTION
Hello fellow lispers!

Here are some first-draft concepts compiled from v2 PRs and the language standard.

This is [the sort of thing we are going for](https://github.com/exercism/v3/blob/master/languages/csharp/reference/README.md). There is a ways to go still, but I'm looking for feedback from the others before writing up the formal list of concepts (the `numbers-basic` sort of slugs).

Let me know what you think and please add the things that I've missed!

TODO:
- [x] Add links to general concepts
- [ ] ~~Add table of machine-ingestable concepts~~ (We can do this as we implement concepts)
- [x] Organize sub-concepts properly

Thanks!