### PR TITLE
[Python] Remove paparomeo from maintainers.md

### DIFF
--- a/languages/python/maintainers.md
+++ b/languages/python/maintainers.md
@@ -11,7 +11,6 @@ These awesome people help maintain the Python track.
 
 - Sebastian Borza (Slack: `@sebito91`, Github: [sebito91](https://github.com/sebito91))
 - Bethany Garcia (Slack: `@bethanyg`, Github: [bethanyg](https://github.com/BethanyG))
-- Pedro Romano (Slack: `@paparomeo`, GitHub: [paparomeo](https://github.com/paparomeo))
 - David Gervasoni (Slack: `@david`, GitHub: [davidgerva](https://github.com/davidgerva))
 - Ashley Drake (Slack: `@ash`, Github: [aldraco](https://github.com/aldraco))
 - Khoi Van (Slack: `@Khoi`, Github: [khoivan88](https://github.com/khoivan88))


### PR DESCRIPTION
Removes @paparomeo from maintainers.md, per https://github.com/exercism/python/pull/2185.