### PR TITLE
[CI] Don't run concept checks on pushes to master

### DIFF
--- a/.github/workflows/concept-ci.yml
+++ b/.github/workflows/concept-ci.yml
@@ -2,6 +2,8 @@ name: Concept CI
 
 on:
   push:
+    branches-ignore:
+    - master
     paths:
     - 'languages/julia/config.json'
     - 'languages/julia/reference/concepts.csv'


### PR DESCRIPTION
It will fail because the track detection would compare master to master