### PR TITLE
[Common Lisp] Update Some Documentation with the `sexpr` Exercise

### DIFF
--- a/languages/common-lisp/README.md
+++ b/languages/common-lisp/README.md
@@ -16,7 +16,7 @@ Before we publicize requesting contribution for this language, the following ste
 - [X] Fill out the [maintainers.md](./maintainers.md) file (e.g. [C#](../csharp/maintainers.md))
 - [x] Ensure there is a link to your track's GitHub issues on the [main README.md](../../README.md)
 - [X] [Write a Concept Exercise implementation guide](../../docs/maintainers/writing-a-concept-exercise-github-issue.md)
-- [ ] [List out key Concepts for your language](../../docs/maintainers/determining-concepts.md)
+- [X] [List out key Concepts for your language](../../docs/maintainers/determining-concepts.md)
 - [ ] [Add GitHub issues for 20 Concept Exercises](../../docs/maintainers/writing-a-concept-exercise-github-issue.md)
 
 ## Readiness for Launch

--- a/languages/common-lisp/reference/README.md
+++ b/languages/common-lisp/reference/README.md
@@ -1,7 +1,8 @@
 # Common Lisp Reference
 
-Please note that this is a *very* WIP document. I'm currently using [this
-document][csharp-example] as an example to base my work off of.
+This is a work-in-progress document listing the concepts comprising the Common
+Lisp programming language. I'm currently using [this document][csharp-example]
+as template.
 
 ## Concepts
 ### General
@@ -84,7 +85,7 @@ document][csharp-example] as an example to base my work off of.
     - [Integers][integer]
     - Rationals
   - Sequences
-    - [Arrays][arra]
+    - [Arrays][array]
     - Conses
       - [Association Lists][map]
       - [Lists][list]
@@ -97,10 +98,9 @@ document][csharp-example] as an example to base my work off of.
   - [Structures][struct]
 
 ## Exercise Concepts
-We should put a table here that go into the specifics to teach for each
-concept. Also give the concepts nice names. I think we are using `.` for
-sub-concepts. So things like `format.numbers` or maybe
-`string-formatting.numbers`.
+| Concept | Learning Objectives |
+| ------- | ------------------- |
+| [`sexpr`][sexpr] | Teach the student about S-expressions, the base unit of all Lisp code. The student should be able to distinguish an `atom` from a `cons` and know how to access the `car` and `cdr` of a cons pair. |
 
 [csharp-example]: ../../csharp/reference/README.md
 [anonymous-functions]: ../../../reference/concepts/anonymous_functions.md
@@ -134,3 +134,5 @@ sub-concepts. So things like `format.numbers` or maybe
 [set]: ../../../reference/types/set.md
 [string]: ../../../reference/types/string.md
 [struct]: ../../../reference/types/struct.md
+
+[sexpr]: ../exercises/concept/sexpr

--- a/languages/common-lisp/reference/README.md
+++ b/languages/common-lisp/reference/README.md
@@ -90,7 +90,7 @@ as template.
       - [Association Lists][map]
       - [Lists][list]
       - Property Lists
-      - [set][set]
+      - [Set][set]
       - Trees
     - Vectors
   - Streams

--- a/languages/common-lisp/reference/implementing-a-concept-exercise.md
+++ b/languages/common-lisp/reference/implementing-a-concept-exercise.md
@@ -65,7 +65,7 @@ specify what changes to the representation should be applied and why.
 ## Inspiration
 
 When implementing an exercise, it can be very useful to look at
-already implemented Common Lisp exercises like _TBD_.
+already implemented Common Lisp exercises like [`sexpr`][sexpr].
 
 You can also check the exercise's [general concepts
 documents][reference] to see if other languages have already
@@ -81,3 +81,4 @@ post them as comments in the exercise's GitHub issue.
 [concept-exercises]: ../exercises/concept/README.md
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
 [reference]: ../../../reference
+[sexpr]: ../exercises/concept/sexpr


### PR DESCRIPTION
Just some tiny updates to the documentation fixing some typos and adding links to our implemented exercise.