### PR TITLE
[CI] Merge instead of rebasing in link checker

### DIFF
--- a/.github/workflows/valid-links.yml
+++ b/.github/workflows/valid-links.yml
@@ -17,7 +17,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           git fetch origin master
-          git rebase origin/master
+          git merge origin/master
       - name: Setup Node
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
This makes the link checker work for PR's that have manually merged commits.