### PR TITLE
[CI] Use system Julia instead of installing it

### DIFF
--- a/.github/workflows/concept-ci.yml
+++ b/.github/workflows/concept-ci.yml
@@ -34,9 +34,6 @@ jobs:
           echo "::set-output name=track::$TRACK"
         shell: bash
 
-      - name: Set up Julia
-        uses: julia-actions/setup-julia@v1
-
       - name: Install dependencies
         run: julia --color=yes --project=.github/bin/concept-checks -e "using Pkg; Pkg.instantiate()"
 

--- a/languages/julia/reference/concepts.csv
+++ b/languages/julia/reference/concepts.csv
@@ -2,7 +2,7 @@ concept,category
 multiple-dispatch,
 mutability,
 immutability,
-type-inference,
+type-inference,type-system
 repl,
 package-management,
 unicode-identifiers,


### PR DESCRIPTION
Since [release 20200308](https://github.com/actions/virtual-environments/releases/tag/ubuntu18%2F20200308.0) of the GH Actions environments, the latest version of Julia is preinstalled on the GH Actions VMs.