### PR TITLE
[CI] Run concept CI on a schedule to prevent stale cache

### DIFF
--- a/.github/workflows/concept-ci.yml
+++ b/.github/workflows/concept-ci.yml
@@ -15,6 +15,10 @@ on:
     - 'languages/julia/reference/concepts.csv'
     - 'languages/julia/reference/exercise-concepts/**'
     - 'languages/julia/exercises/concept/**'
+  schedule:
+    # To prevent sysimage cache from expiring after not being accessed for 7 days, run the workflow every 6 days.
+    # Due to the long time needed to build the sysimage, this should overall save time.
+    - cron: 13 7 */6 * *
 
 jobs:
   concept-test:
@@ -31,6 +35,8 @@ jobs:
         id: track-detection
         run: |
           TRACK=$(git diff --name-only origin/master... | grep -oP 'languages\/\K([a-z0-9-]+)' | head -1)
+          # default fallback for scheduled builds
+          [ -z "$TRACK" ] && TRACK="julia"
           echo "::set-output name=track::$TRACK"
         shell: bash
 


### PR DESCRIPTION
To prevent sysimage cache from expiring after not being accessed for 7 days, run the workflow every 6 days. Due to the long time needed to build the sysimage, this should overall save time.