### PR TITLE
[Rust] Add out-of-scope.md, remove some concepts

### DIFF
--- a/languages/rust/reference/README.md
+++ b/languages/rust/reference/README.md
@@ -69,7 +69,6 @@ These concepts are more advanced than the fundamentals, but may be familiar from
 - [x] Scopes and Expressions (implicit return)
 - [x] Explicit `return`
 - [x] [Methods](../../../reference/concepts/methods.md) / `impl` blocks
-- [ ] [Composition](../../../reference/concepts/composition.md)
 - [x] Basics of [Generics](https://doc.rust-lang.org/book/ch10-00-generics.html)
 - [ ] Using External Crates / Libraries
   - [ ] `use` statement for importing
@@ -77,7 +76,6 @@ These concepts are more advanced than the fundamentals, but may be familiar from
 - [ ] Destructuring (in `match`, in `let`)
 - [ ] [`match` with Pattern matching](https://doc.rust-lang.org/book/ch06-02-match.html)
 - [ ] [Anonymous functions](../../../reference/concepts/anonymous_functions.md)
-- [ ] [Recursion](../../../reference/concepts/recursion.md)
 - [ ] Ranges
 - [ ] Closures
 - [ ] Visibility / `pub`

--- a/languages/rust/reference/concepts.csv
+++ b/languages/rust/reference/concepts.csv
@@ -35,7 +35,6 @@ scopes-and-expressions,
 explicit-return,
 methods,
 impl-blocks,
-composition,
 generics,
 external-crates,
 use,
@@ -46,7 +45,6 @@ functions,functions
 functions.anonymous,functions
 functions.closures,functions
 functions.higher-order,functions
-recursion,functions
 ranges,
 visibility,
 typedefs,

--- a/languages/rust/reference/out-of-scope.md
+++ b/languages/rust/reference/out-of-scope.md
@@ -1,0 +1,53 @@
+# What is Out Of Scope for Exercism's Rust track?
+
+This file is intended to explain what Exercism's Rust track can and cannot
+teach within the bounds of the Rust language, community, and ecosystem.
+
+Where material is covered under "What not to teach" in _design.md_ for a
+particular exercise it should not be repeated here unless it is felt that the
+topic otherwise has insufficient prominence.
+
+### The Limits of Web UI
+
+A student using the web UI is limited to whatever is permitted by the web
+interface and the test runner, so the web UI's capabilities effectively serve
+as an outer limit for the Rust's track.
+
+A student may:
+- Edit a single `.rs` file
+- Receive output from `stdout` (e.g. from `dbg!`)
+
+Notably, this means they may not edit Cargo.toml so any exercises that depend
+on an external crate must include all dependencies in Cargo.toml already.
+
+### What Exercism Is Not About
+
+Exercism is about acquiring fluency in a programming language, not teaching
+more abstract skills like software design or computer science. So any subject
+that is not particularly relevant to the Rust programming language is not
+within the scope of the Rust track.
+
+
+## Examples of Excluded Subjects
+
+Some examples of excluded subjects include:
+
+### Cargo
+
+- editing Cargo.toml
+- CLI commands e.g. `new`, `update`, `bench`
+
+### Frameworks
+
+- Amethyst
+- Yew, Iced, Sauron, etc.
+
+### Interop
+
+- CFFI
+- `asm!`
+
+### Generally:
+
+- File handling
+- Networking


### PR DESCRIPTION
This PR reflects _many_ discussions, on Slack and in issues, e.g. #695 
It is intended to parallel PR #681.

The test runner referred to is here: https://github.com/exercism/rust-test-runner/blob/master/Dockerfile
And the student UI can, as of this writing, be witnessed here: https://research.exercism.io/

Inclusion of this document is intended to resolve many questions that have been raised about what is and is not teachable, what should and should not be taught, within the Rust track. It documents the complications such as the web UI and Exercism's intended focus within the context of Rust, and names some examples of beyond-scope topics as a result (e.g. the Cargo CLI, FFI with C, etc.)

In addition, this PR nominates some out-of-scope ("CS-y" or software-design-related) concepts for deletion, without prejudice to their later readdition if it is thought desirable on review. Namely:
- recursion
- composition