### PR TITLE
[Go] add links to existing exercises/documentation: 837

### DIFF
--- a/languages/go/exercises/concept/README.md
+++ b/languages/go/exercises/concept/README.md
@@ -9,6 +9,7 @@ These are the concept exercises that have currently been implemented, as well as
 | exercise                                                            | concepts                                                       | prerequisites                                                  |
 | ------------------------------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------- |
 | basic-strings                                                       | TODO                                                           | TODO                                                           |
+| basic-slices                                                       | TODO                                                           | TODO                                                           |
 
 **⚠ Note ⚠**: The idea here is to use a `concept` name for the exercise/folder, but perhaps use some sort of "progression", so they will naturally become a sort of path to traverse.
 

--- a/languages/go/reference/README.md
+++ b/languages/go/reference/README.md
@@ -79,10 +79,10 @@ Concepts that are special to Go or have key differences to a vast majority of ot
 
 - Structs (Classes)
 - Method Sets
-- Encapsulation
-- State
-- Mutation
-- Composition
+- [Encapsulation](../../../reference/concepts/encapsulation.md)
+- [State](../../../reference/concepts/state.md)
+- [Mutation](../../../reference/concepts/mutation.md)
+- [Composition](../../../reference/concepts/composition.md)
 - Polymorphism (?)
 - Interfaces
 
@@ -90,18 +90,18 @@ Concepts that are special to Go or have key differences to a vast majority of ot
 
 > Go is not a functional language but has a lot of features that enable us to apply functional principles. [Functional Go](https://medium.com/@geisonfgfg/functional-go-bc116f4c96a4)
 
-- Anonymous Functions
-- Function Composition
+- [Anonymous Functions](../../../reference/concepts/anonymous_functions.md)
+- [Function Composition](../../../reference/concepts/function_composition.md)
 - Higher Order Functions
 - Multiple Return Values
 - Named Returns
-- Nested Functions
-- Partial Application
+- [Nested Functions](../../../reference/concepts/nested_functions.md)
+- [Partial Application](../../../reference/concepts/partial_application.md)
 - Pipelines (?)
-- Pure Functions
-- Recursion
+- [Pure Functions](../../../reference/concepts/pure_functions.md)
+- [Recursion](../../../reference/concepts/recursion.md)
 - REPL (some community projects)
-- Type Inference
+- [Type Inference](../../../reference/concepts/type_inference.md)
 
 ## Advanced
 - Code generation (`go generate`)
@@ -134,7 +134,7 @@ Types are not really concepts but it might be helpful to have as list of types G
 - Numeric Types (`uint` types, `int` types, `float` types, `complex` types, `byte` and `rune`)
 - pointer
 - slice
-- string
+- [string](../../../reference/types/string.md)
 - struct
 - time.Duration
 - time.Time

--- a/reference/types/number.md
+++ b/reference/types/number.md
@@ -10,6 +10,7 @@ An number is a generic numeric type that often encompasses multiple more specifi
 # Implementations
 
 - [C#][implementation-csharp]
+- [Go][implementation-go]
 
 [language-javascript]: ../../languages/javascript/README.md
 [language-kotlin]: ../../languages/kotlin/README.md
@@ -23,3 +24,4 @@ An number is a generic numeric type that often encompasses multiple more specifi
 [type-unsigned]: ./unsigned.md
 [wiki-number]: https://en.wikipedia.org/wiki/Double-precision_floating-point_format
 [implementation-csharp]: ../../languages/csharp/exercises/concept/numbers/.docs/introduction.md
+[implementation-go]: ../../languages/go/exercises/concept/numbers/.docs/instructions.md

--- a/reference/types/slice.md
+++ b/reference/types/slice.md
@@ -1,0 +1,29 @@
+# Slice
+
+## The Concept
+
+A slice is a descriptor for a contiguous segment of an underlying [array][type-array] and provides access to a
+numbered sequence of elements from that array. A slice type denotes the set of all slices of arrays of its
+element type. The number of elements is called the length of the slice and is never negative. The value of
+an uninitialized slice is nil.
+
+## What to cover
+
+TBA
+
+## Exercises
+
+### Log Lines
+
+TBA
+
+#### Implementations
+
+| Track | Exercise                         | Changes |
+| ----- | -------------------------------- | ------- |
+| Go    | [slice][implementation-go] | None    |
+
+
+[type-array]: ./array.md
+[implementation-go]: ../../languages/go/exercises/concept/basic-slices/.docs/introduction.md
+

--- a/reference/types/string.md
+++ b/reference/types/string.md
@@ -32,9 +32,11 @@ This exercise extracts information from log lines. The reference implementation 
 | F#    | [strings][implementation-fsharp] | None    |
 | Ruby  | [strings][implementation-ruby]   | None    |
 | Python| [strings][implementation-python] | None    |
+| Go    | [strings][implementation-go]     | None    |
 
 [type-char]: ./char.md
 [implementation-csharp]: ../../languages/csharp/exercises/concept/strings/.docs/introduction.md
 [implementation-fsharp]: ../../languages/fsharp/exercises/concept/strings/.docs/introduction.md
 [implementation-ruby]: ../../languages/ruby/exercises/concept/strings/.docs/introduction.md
 [implementation-python]: ../../languages/python/exercises/concept/strings/.docs/introduction.md
+[implementation-go]: ../../languages/go/exercises/concept/basic-strings/.docs/introduction.md


### PR DESCRIPTION
part of #837 
I've added links for the following exercises:
numbers
basic-strings
+
extra links to general OOP concepts
