### PR TITLE
[Docs] Add syntax mention to after.md document description

### DIFF
--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -75,7 +75,7 @@ See the C# floating-point-numbers exercise's [hints.md file][csharp-docs-hints.m
 
 ### `.docs/after.md`
 
-Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
+Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. If the exercise introduced new syntax, syntax samples should be included. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
 
 See the C# floating-point-numbers exercise's [after.md file][csharp-docs-after.md] for an example.
 

--- a/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+++ b/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
@@ -45,7 +45,7 @@ The hints should not spell out the solution, but instead point to a resource des
 
 ## Step 4: add .docs/after.md (optional)
 
-Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
+Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. If the exercise introduced new syntax, syntax samples should be included. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
 
 _The aforementioned files are also described in the [concept exercises document][docs-concept-exercises]._
 

--- a/languages/csharp/reference/examples/new-concept-exercise-arrays.md
+++ b/languages/csharp/reference/examples/new-concept-exercise-arrays.md
@@ -112,7 +112,7 @@ The hints should not spell out the solution, but instead point to a resource des
 
 ## Step 4: add .docs/after.md
 
-Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
+Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. If the exercise introduced new syntax, syntax samples should be included. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
 
 The above four files are also all described in the [concept exercises document][concept-exercises].
 

--- a/languages/elixir/reference/implementing-a-concept-exercise.md
+++ b/languages/elixir/reference/implementing-a-concept-exercise.md
@@ -59,7 +59,7 @@ The hints should not spell out the solution, but instead point to a resource des
 
 ## Step 4: add .docs/after.md (optional)
 
-Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
+Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. If the exercise introduced new syntax, syntax samples should be included. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
 
 ## Step 5: add .meta/config.json
 

--- a/languages/elm/reference/implementing-a-concept-exercise.md
+++ b/languages/elm/reference/implementing-a-concept-exercise.md
@@ -51,7 +51,7 @@ The hints should not spell out the solution, but instead point to a resource des
 
 ## Step 4: add .docs/after.md (optional)
 
-Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
+Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. If the exercise introduced new syntax, syntax samples should be included. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
 
 ## Step 5: update languages/&lt;TRACK&gt;/config.json
 

--- a/languages/fsharp/reference/examples/new-concept-exercise-strings.md
+++ b/languages/fsharp/reference/examples/new-concept-exercise-strings.md
@@ -98,7 +98,7 @@ The hints should not spell out the solution, but instead point to a resource des
 
 ## Step 4: add .docs/after.md
 
-Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
+Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. If the exercise introduced new syntax, syntax samples should be included. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
 
 These files are also all described in the [concept exercises document][docs-concept-exercises].
 

--- a/languages/javascript/reference/implementing-a-concept-exercise.md
+++ b/languages/javascript/reference/implementing-a-concept-exercise.md
@@ -58,7 +58,7 @@ The hints should not spell out the solution, but instead point to a resource des
 
 ## Step 4: add .docs/after.md (optional)
 
-Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
+Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. If the exercise introduced new syntax, syntax samples should be included. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
 
 ## Step 5: update languages/javascript/config.json
 

--- a/languages/kotlin/reference/implementing-a-concept-exercise.md
+++ b/languages/kotlin/reference/implementing-a-concept-exercise.md
@@ -64,7 +64,7 @@ The hints should not spell out the solution, but instead point to a resource des
 
 ## Step 4: add .docs/after.md (optional)
 
-Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
+Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. If the exercise introduced new syntax, syntax samples should be included. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
 
 ~~These files are also all described in the [concept exercises document][docs-concept-exercises].~~
 

--- a/languages/typescript/reference/implementing-a-concept-exercise.md
+++ b/languages/typescript/reference/implementing-a-concept-exercise.md
@@ -56,7 +56,7 @@ The hints should not spell out the solution, but instead point to a resource des
 
 ## Step 4: add .docs/after.md (optional)
 
-Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
+Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. If the exercise introduced new syntax, syntax samples should be included. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
 
 ## Step 5: update languages/typescript/config.json
 


### PR DESCRIPTION
The after.md document should include newly introduced syntax.