### PR TITLE
[docs] introduce a Dockerfile for the website

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:12
+RUN npm install -g docsify-cli
+
+# https://github.com/docsifyjs/docsify-cli/issues/78
+RUN apt-get update \
+	&& apt-get install dos2unix \
+	&& dos2unix /usr/local/lib/node_modules/docsify-cli/bin/docsify
+
+EXPOSE 3005
+USER node
+
+WORKDIR /opt/exercism-docsify
+
+ENTRYPOINT docsify serve -p 3005 .

--- a/docs/maintainers/website.md
+++ b/docs/maintainers/website.md
@@ -3,7 +3,24 @@
 The contents of this repository can also be viewed using
 [a website with easier navigation][website]. The website is built using [docsify][docsify].
 
-## Running locally
+## Running locally with docker
+
+You need to have docker installed for your platform.
+
+
+1. From the root of this repository, build the docker image:
+
+```sh
+docker build . -t exercism-website-base:v1
+```
+
+2. Launch a container with the appropriate configuration:
+
+```
+docker run -it --rm --name exercism-website -p 3005:3005 -v "$PWD":/opt/exercism-docsify exercism-website-base:v1
+```
+
+## Running locally with a node.js toolchain
 
 To run the website on your local machine, open a command prompt in the root directory of this repository and run:
 


### PR DESCRIPTION
Happy to document this where appropriate. In the meantime, here are a few notes for using on a Unixy system where you have Docker installed.

## instructions

1. From the root of this repository, build the docker image:
```sh
 docker build . -t exercism-node:v1
```
2. Run the container that has everything configured:
```
docker run -it --rm --name exercism-website -p 3005:3005 -v "$PWD":/usr/src/app exercism-node:v1
```