### PR TITLE
[C++] Catch testing lib is now downloaded automatically

### DIFF
--- a/languages/cpp/exercises/concept/strings/CMakeLists.txt
+++ b/languages/cpp/exercises/concept/strings/CMakeLists.txt
@@ -17,6 +17,13 @@ else()
     set(exercise_cpp "")
 endif()
 
+# Downloads Catch library used for testing
+set(CATCH_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/test/catch.hpp")
+set(CATCH_DOWNLOAD_URL "https://github.com/catchorg/Catch2/releases/download/v2.11.3/catch.hpp")
+if (NOT EXISTS "${CATCH_HEADER}")
+    file(DOWNLOAD "${CATCH_DOWNLOAD_URL}" "${CATCH_HEADER}")
+endif()
+
 # Use the common Catch library?
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only

--- a/languages/cpp/reference/implementing-a-concept-exercise.md
+++ b/languages/cpp/reference/implementing-a-concept-exercise.md
@@ -30,7 +30,6 @@ languages
               ├── &lt;NAME&gt;.h
               ├── &lt;NAME&gt;_test.cpp
               └── test
-                  ├── catch.hpp
                   └── tests_main.cpp
 </pre>
 
@@ -87,7 +86,6 @@ These files are specific to the C++ track:
 - `CMakeLists.txt`: the C++ project file.
 - `<NAME>_test.cpp`: the test suite.
 - `.meta/example.h` and `.meta/example.cpp`: an example implementation that passes all the tests.
-- `test/catch.hpp`: single-header testing library.
 - `test/tests_main.cpp`: generates test main from test library
 
 ## Step 7: updating list of implemented exercises


### PR DESCRIPTION
When running CMake configure step for an exercise the library is downloaded automatically, this prevents the need to store the header in every single exercise.