### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ package-lock.json
 # Ruby
 Gemfile
 Gemfile.lock
+
+# Rust
+Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # JavaScript
 yarn.lock
+package-lock.json
 
 # Ruby
 Gemfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+###
+# Lock files. Arrange alphabetically by language
+###
+
+# JavaScript
+yarn.lock
+
+# Ruby
+Gemfile
+Gemfile.lock


### PR DESCRIPTION
One consequence of the 10kb file limit we added to the v3 repo yesterday is that things like package lock files (e.g. `yarn.lock`, `Gemfile.lock`) won’t be committable to the repo. Please add them to this `.gitignore` file.