### PR TITLE
[all] add minimal editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# editorconfig.org
+root = true
+
+[*.md]
+# trailing whitespaces are converted to <br>
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,4 +4,4 @@ root = true
 [*.md]
 # trailing whitespaces are converted to <br>
 trim_trailing_whitespace = false
-insert_final_newline = false
+insert_final_newline = true


### PR DESCRIPTION
Close #863. I intially wanted to add this to remove trailing whitespace
from Markdown files but have since learned those have meaning. I still
want to introduce an editorconfig to nudge editors to respect Markdown
semantics. We can also expand this file for various other formats across
the repository.