### PR TITLE
[Rust] remove line about DAG

### DIFF
--- a/languages/rust/reference/README.md
+++ b/languages/rust/reference/README.md
@@ -149,7 +149,6 @@ doing so is not entirely practical. For example, it would be difficult to design
 which taught what functions are without requiring any knowledge of primitives; likewise,
 it would be difficult to teach primitives, with a test suite, without any knowledge of functions.
 
-The exercises in this table should form a DAG which will eventually cover all concepts listed above.
 
 exercise | prerequisites | teaches | narrative
 --- | --- | --- | ---


### PR DESCRIPTION
Per the last conversation I believe we are not establishing dependency
graphs for Exercism concepts. We simply want to denote a few
connections.

## general thoughts
csharp's [concept reference guide](https://github.com/exercism/v3/blob/master/languages/csharp/reference/README.md) appears simpler and does not try to establish dependencies. I am still a bit fuzzy on how Exercism Concepts interlock. Though I expect to resolve that confusion as we create more concept issues and see them implemented.
In the meantime I would like to remove the DAG notion from the README and eventually task tracking (#1023).