### PR TITLE
[Docs] Add reference to required reading in implementing guide

### DIFF
--- a/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+++ b/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise in any v3 track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+++ b/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise in any v3 track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+++ b/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise in any v3 track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+++ b/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise in any v3 track.
 
-Before diving into the implementation, please read up on the following documents:
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+++ b/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
@@ -1,6 +1,14 @@
 # How to implement a concept exercise
 
-This document describes the steps required to implement a concept exercise in any v3 track. As this document is generic, the following placeholders are used:
+This document describes the steps required to implement a concept exercise in any v3 track.
+
+Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<LANG>`: the name of the track in kebab-case (e.g. `ruby`).
 - `<SLUG>`: the name of the exercise in kebab-case (e.g. `anonymous-methods`).
@@ -114,6 +122,8 @@ When implementing an exercise, it can be very useful to look at the exercises th
 If you have any questions regarding implementing this exercise, please post them as comments in the exercise's GitHub issue.
 
 [docs-concept-exercises]: ../concept-exercises.md
+[docs-rationale-for-v3]: ../rationale-for-v3.md
+[docs-features-of-v3]: ../features-of-v3.md
 [reference]: ../../reference/concepts/README.md
 [meta-design]: ../../languages/csharp/exercises/concept/flag-enums/.meta/design.md
 [meta-config-json]: ../../languages/csharp/exercises/concept/flag-enums/.meta/config.json

--- a/languages/clojure/reference/implementing-a-concept-exercise.md
+++ b/languages/clojure/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement a Clojure concept exercise
 
-This document describes how to implement a concept exercise for the Clojure track. Before diving into the implementation, please read up on the following documents:
+This document describes how to implement a concept exercise for the Clojure track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/clojure/reference/implementing-a-concept-exercise.md
+++ b/languages/clojure/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the Clojure track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/clojure/reference/implementing-a-concept-exercise.md
+++ b/languages/clojure/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement a Clojure concept exercise
 
-This document describes how to implement a concept exercise for the Clojure track. As this document is generic, the following placeholders are used:
+This document describes how to implement a concept exercise for the Clojure track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<SLUG>`: the name of the exercise in kebab-case (e.g. `anonymous-methods`).
 - `<NAME>`: the name of the exercise in PascalCase (e.g. `AnonymousMethods`).
@@ -59,3 +65,6 @@ If you have any questions regarding implementing the exercise, please post them 
 //To-Add-More
 
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md

--- a/languages/clojure/reference/implementing-a-concept-exercise.md
+++ b/languages/clojure/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the Clojure track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/clojure/reference/implementing-a-concept-exercise.md
+++ b/languages/clojure/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the Clojure track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/common-lisp/reference/implementing-a-concept-exercise.md
+++ b/languages/common-lisp/reference/implementing-a-concept-exercise.md
@@ -3,7 +3,7 @@
 This document describes how to implement a concept exercise for the
 Common Lisp track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/common-lisp/reference/implementing-a-concept-exercise.md
+++ b/languages/common-lisp/reference/implementing-a-concept-exercise.md
@@ -1,7 +1,13 @@
 # How to implement a Common Lisp concept exercise
 
 This document describes how to implement a concept exercise for the
-Common Lisp track. As this document is generic, the following
+Common Lisp track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following
 placeholders are used:
 
 - `<SLUG>`: the name of the exercise in kebab-case (e.g. `anonymous-methods`).
@@ -81,5 +87,8 @@ post them as comments in the exercise's GitHub issue.
 [representer]: https://github.com/exercism/common-lisp-representer
 [concept-exercises]: ../exercises/concept/README.md
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md
 [reference]: ../../../reference
 [basics]: ../exercises/concept/basics

--- a/languages/common-lisp/reference/implementing-a-concept-exercise.md
+++ b/languages/common-lisp/reference/implementing-a-concept-exercise.md
@@ -3,7 +3,7 @@
 This document describes how to implement a concept exercise for the
 Common Lisp track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/common-lisp/reference/implementing-a-concept-exercise.md
+++ b/languages/common-lisp/reference/implementing-a-concept-exercise.md
@@ -3,7 +3,7 @@
 This document describes how to implement a concept exercise for the
 Common Lisp track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/common-lisp/reference/implementing-a-concept-exercise.md
+++ b/languages/common-lisp/reference/implementing-a-concept-exercise.md
@@ -1,7 +1,9 @@
 # How to implement a Common Lisp concept exercise
 
 This document describes how to implement a concept exercise for the
-Common Lisp track. Before diving into the implementation, please read up on the following documents:
+Common Lisp track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/cpp/reference/implementing-a-concept-exercise.md
+++ b/languages/cpp/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement a C++ concept exercise
 
-This document describes how to implement a concept exercise for the C++ track. Before diving into the implementation, please read up on the following documents:
+This document describes how to implement a concept exercise for the C++ track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].
@@ -118,3 +120,6 @@ If you have any questions regarding implementing the exercise, please post them 
 [implemented-exercises]: https://github.com/exercism/v3/blob/master/languages/cpp/exercises/concept/README.md
 [meta-design]: https://github.com/exercism/v3/blob/master/languages/cpp/exercises/concept/strings/.meta/design.md
 [meta-config-json]: https://github.com/exercism/v3/blob/master/languages/cpp/exercises/concept/strings/.meta/config.json
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md

--- a/languages/cpp/reference/implementing-a-concept-exercise.md
+++ b/languages/cpp/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the C++ track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/cpp/reference/implementing-a-concept-exercise.md
+++ b/languages/cpp/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement a C++ concept exercise
 
-This document describes how to implement a concept exercise for the C++ track. As this document is generic, the following placeholders are used:
+This document describes how to implement a concept exercise for the C++ track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<SLUG>`: the name of the exercise in kebab-case (e.g. `anonymous-methods`).
 - `<NAME>`: the name of the exercise in snake_case (e.g. `anonymous_methods`).

--- a/languages/cpp/reference/implementing-a-concept-exercise.md
+++ b/languages/cpp/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the C++ track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/cpp/reference/implementing-a-concept-exercise.md
+++ b/languages/cpp/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the C++ track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/csharp/reference/implementing-a-concept-exercise.md
+++ b/languages/csharp/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the C# track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/csharp/reference/implementing-a-concept-exercise.md
+++ b/languages/csharp/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the C# track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/csharp/reference/implementing-a-concept-exercise.md
+++ b/languages/csharp/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement a C# concept exercise
 
-This document describes how to implement a concept exercise for the C# track. As this document is generic, the following placeholders are used:
+This document describes how to implement a concept exercise for the C# track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<SLUG>`: the name of the exercise in kebab-case (e.g. `anonymous-methods`).
 - `<NAME>`: the name of the exercise in PascalCase (e.g. `AnonymousMethods`).
@@ -63,6 +69,9 @@ If you have any questions regarding implementing the exercise, please post them 
 [representer]: https://github.com/exercism/csharp-representer
 [concept-exercises]: ../exercises/concept/README.md
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md
 [concept-exercise-strings]: ../exercises/concept/strings
 [concept-exercise-datetimes]: ../exercises/concept/datetimes
 [concept-exercise-numbers-floating-point]: ../exercises/concept/floating-point-numbers

--- a/languages/csharp/reference/implementing-a-concept-exercise.md
+++ b/languages/csharp/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the C# track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/csharp/reference/implementing-a-concept-exercise.md
+++ b/languages/csharp/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement a C# concept exercise
 
-This document describes how to implement a concept exercise for the C# track. Before diving into the implementation, please read up on the following documents:
+This document describes how to implement a concept exercise for the C# track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/elixir/reference/implementing-a-concept-exercise.md
+++ b/languages/elixir/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement an Elixir Concept Exercise
 
-This document describes how to implement a Concept Exercise for the Elixir track. Before diving into the implementation, please read up on the following documents:
+This document describes how to implement a Concept Exercise for the Elixir track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/elixir/reference/implementing-a-concept-exercise.md
+++ b/languages/elixir/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a Concept Exercise for the Elixir track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/elixir/reference/implementing-a-concept-exercise.md
+++ b/languages/elixir/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a Concept Exercise for the Elixir track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/elixir/reference/implementing-a-concept-exercise.md
+++ b/languages/elixir/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement an Elixir Concept Exercise
 
-This document describes how to implement a Concept Exercise for the Elixir track. As this document is generic, the following placeholders are used:
+This document describes how to implement a Concept Exercise for the Elixir track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `$slug`: the name of the exercise in snake_case (e.g. `anonymous-methods`).
 - `$elixir_slug`: `$slug` converted to snake-case from kebab-case,
@@ -124,4 +130,7 @@ If you have any questions regarding implementing the exercise, please post them 
 [representer]: https://github.com/exercism/elixir-representer
 [concept-exercises]: ../exercises/concept/README.md
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md
 [reference]: ../../../reference/README.md

--- a/languages/elixir/reference/implementing-a-concept-exercise.md
+++ b/languages/elixir/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a Concept Exercise for the Elixir track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/elm/reference/implementing-a-concept-exercise.md
+++ b/languages/elm/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise for the Elm track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/elm/reference/implementing-a-concept-exercise.md
+++ b/languages/elm/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement an Elm concept exercise
 
-This document describes the steps required to implement a concept exercise for the Elm track. As this document is generic, the following placeholders are used:
+This document describes the steps required to implement a concept exercise for the Elm track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<SLUG>`: the name of the exercise in kebab-case (e.g. `anonymous-methods`).
 - `<NAME>`: the name of the exercise in PascalCase (e.g. `AnonymousMethods`).

--- a/languages/elm/reference/implementing-a-concept-exercise.md
+++ b/languages/elm/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise for the Elm track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/elm/reference/implementing-a-concept-exercise.md
+++ b/languages/elm/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement an Elm concept exercise
 
-This document describes the steps required to implement a concept exercise for the Elm track. Before diving into the implementation, please read up on the following documents:
+This document describes the steps required to implement a concept exercise for the Elm track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].
@@ -129,3 +131,6 @@ If you have any questions regarding implementing this exercise, please post them
 ### TODO: link to an elm concept, after the first one is done and available to reference.
 
 [meta-config-json]: ../../csharp/exercises/concept/flag-enums/.meta/config.json
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md

--- a/languages/elm/reference/implementing-a-concept-exercise.md
+++ b/languages/elm/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise for the Elm track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/fsharp/reference/implementing-a-concept-exercise.md
+++ b/languages/fsharp/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the F# track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/fsharp/reference/implementing-a-concept-exercise.md
+++ b/languages/fsharp/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the F# track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/fsharp/reference/implementing-a-concept-exercise.md
+++ b/languages/fsharp/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement an F# concept exercise
 
-This document describes how to implement a concept exercise for the F# track. As this document is generic, the following placeholders are used:
+This document describes how to implement a concept exercise for the F# track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<SLUG>`: the name of the exercise in kebab-case (e.g. `anonymous-methods`).
 - `<NAME>`: the name of the exercise in PascalCase (e.g. `AnonymousMethods`).
@@ -53,4 +59,7 @@ If you have any questions regarding implementing this exercise, please post them
 
 [concept-exercises]: ../exercises/concept/README.md
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md
 [reference]: ../../../reference

--- a/languages/fsharp/reference/implementing-a-concept-exercise.md
+++ b/languages/fsharp/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the F# track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/fsharp/reference/implementing-a-concept-exercise.md
+++ b/languages/fsharp/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement an F# concept exercise
 
-This document describes how to implement a concept exercise for the F# track. Before diving into the implementation, please read up on the following documents:
+This document describes how to implement a concept exercise for the F# track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/go/reference/implementing-a-concept-exercise.md
+++ b/languages/go/reference/implementing-a-concept-exercise.md
@@ -65,6 +65,9 @@ If you have any questions regarding implementing the exercise, please post them 
 [representer]: https://github.com/exercism/go-representer
 [concept-exercises]: ../exercises/concept/README.md
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md
 [concept-exercise-basic-strings]: ../exercises/concept/basic-strings
 [concept-exercise-numbers]: ../exercises/concept/numbers
 [reference]: ../../../reference

--- a/languages/haskell/reference/implementing-a-concept-exercise.md
+++ b/languages/haskell/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement a Haskell concept exercise
 
-This document describes the steps required to implement a concept exercise for the Haskell track. As this document is generic, the following placeholders are used:
+This document describes the steps required to implement a concept exercise for the Haskell track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<SLUG>`: the name of the exercise in kebab-case (e.g. `monad-transformers`).
 - `<NAME>`: the name of the exercise in PascalCase (e.g. `MonadTransformers`).
@@ -65,5 +71,8 @@ When implementing an exercise, it can be very useful to look at already implemen
 
 [reference]: ../../../reference
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md
 [spring-2013]: https://www.seas.upenn.edu/~cis194/spring13/
 [fall-2016]: https://www.seas.upenn.edu/~cis194/fall16/

--- a/languages/haskell/reference/implementing-a-concept-exercise.md
+++ b/languages/haskell/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise for the Haskell track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/haskell/reference/implementing-a-concept-exercise.md
+++ b/languages/haskell/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement a Haskell concept exercise
 
-This document describes the steps required to implement a concept exercise for the Haskell track. Before diving into the implementation, please read up on the following documents:
+This document describes the steps required to implement a concept exercise for the Haskell track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/haskell/reference/implementing-a-concept-exercise.md
+++ b/languages/haskell/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise for the Haskell track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/haskell/reference/implementing-a-concept-exercise.md
+++ b/languages/haskell/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise for the Haskell track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/java/reference/implementing-a-concept-exercise.md
+++ b/languages/java/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a Concept Exercise for the Java track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/java/reference/implementing-a-concept-exercise.md
+++ b/languages/java/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a Concept Exercise for the Java track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/java/reference/implementing-a-concept-exercise.md
+++ b/languages/java/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a Concept Exercise for the Java track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/java/reference/implementing-a-concept-exercise.md
+++ b/languages/java/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement a Java Concept Exercise
 
-This document describes how to implement a Concept Exercise for the Java track. Before diving into the implementation, please read up on the following documents:
+This document describes how to implement a Concept Exercise for the Java track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/java/reference/implementing-a-concept-exercise.md
+++ b/languages/java/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement a Java Concept Exercise
 
-This document describes how to implement a Concept Exercise for the Java track. As this document is generic, the following placeholders are used:
+This document describes how to implement a Concept Exercise for the Java track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<slug>`: the name of the exercise in snake_case (e.g. `anonymous-methods`).
 - `<concepts>`: the Concepts the exercise is about (e.g. `loops`),
@@ -132,4 +138,7 @@ If you have any questions regarding implementing the exercise, please post them 
 [representer]: https://github.com/exercism/java-representer
 [concept-exercises]: ../exercises/concept/README.md
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md
 [reference]: ../../../reference/README.md

--- a/languages/javascript/reference/implementing-a-concept-exercise.md
+++ b/languages/javascript/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a Concept Exercise for the JavaScript track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/javascript/reference/implementing-a-concept-exercise.md
+++ b/languages/javascript/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement a JavaScript Concept Exercise
 
-This document describes how to implement a Concept Exercise for the JavaScript track. As this document is generic, the following placeholders are used:
+This document describes how to implement a Concept Exercise for the JavaScript track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<slug>`: the name of the exercise in snake_case (e.g. `anonymous-methods`).
 - `<concepts>`: the Concepts the exercise is about (e.g. `loops`),
@@ -149,6 +155,9 @@ If you have any questions regarding implementing the exercise, please post them 
 [representer]: https://github.com/exercism/javascript-representer
 [concept-exercises]: ../exercises/concept/README.md
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md
 [concept-exercise-strings]: ../exercises/concept/strings
 [concept-exercise-numbers]: ../exercises/concept/numbers
 [concept-exercise-promises]: ../exercises/concept/promises

--- a/languages/javascript/reference/implementing-a-concept-exercise.md
+++ b/languages/javascript/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement a JavaScript Concept Exercise
 
-This document describes how to implement a Concept Exercise for the JavaScript track. Before diving into the implementation, please read up on the following documents:
+This document describes how to implement a Concept Exercise for the JavaScript track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/javascript/reference/implementing-a-concept-exercise.md
+++ b/languages/javascript/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a Concept Exercise for the JavaScript track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/javascript/reference/implementing-a-concept-exercise.md
+++ b/languages/javascript/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a Concept Exercise for the JavaScript track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/julia/reference/implementing-a-concept-exercise.md
+++ b/languages/julia/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement a Julia concept exercise
 
-This document describes how to implement a concept exercise for the Julia track. As this document is generic, the following placeholders are used:
+This document describes how to implement a concept exercise for the Julia track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `$slug`: the name of the exercise in kebab-case (e.g. `anonymous-methods`).
 
@@ -61,5 +67,8 @@ If you have any questions regarding implementing the exercise, please post them 
 
 [concept-exercises]: ../exercises/concept/README.md
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md
 [concept-exercise-strings]: ../exercises/concept/multiple-dispatch
 [reference]: ../../../reference

--- a/languages/julia/reference/implementing-a-concept-exercise.md
+++ b/languages/julia/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the Julia track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/julia/reference/implementing-a-concept-exercise.md
+++ b/languages/julia/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement a Julia concept exercise
 
-This document describes how to implement a concept exercise for the Julia track. Before diving into the implementation, please read up on the following documents:
+This document describes how to implement a concept exercise for the Julia track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/julia/reference/implementing-a-concept-exercise.md
+++ b/languages/julia/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the Julia track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/julia/reference/implementing-a-concept-exercise.md
+++ b/languages/julia/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the Julia track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/kotlin/reference/implementing-a-concept-exercise.md
+++ b/languages/kotlin/reference/implementing-a-concept-exercise.md
@@ -6,7 +6,7 @@
 
 This document describes the steps required to implement a concept exercise in any v3 track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/kotlin/reference/implementing-a-concept-exercise.md
+++ b/languages/kotlin/reference/implementing-a-concept-exercise.md
@@ -4,7 +4,9 @@
 ! WARNING! This document should be treated as a draft and will be actively changing. Sections that marked as WIP requires attention/rework from contributors.
 ```
 
-This document describes the steps required to implement a concept exercise in any v3 track. Before diving into the implementation, please read up on the following documents:
+This document describes the steps required to implement a concept exercise in any v3 track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].
@@ -149,3 +151,6 @@ When implementing an exercise, it can be very useful to look at the exercises th
 If you have any questions regarding implementing this exercise, please post them as comments in the exercise's GitHub issue.
 
 [reference]: ../reference/README.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md

--- a/languages/kotlin/reference/implementing-a-concept-exercise.md
+++ b/languages/kotlin/reference/implementing-a-concept-exercise.md
@@ -6,7 +6,7 @@
 
 This document describes the steps required to implement a concept exercise in any v3 track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/kotlin/reference/implementing-a-concept-exercise.md
+++ b/languages/kotlin/reference/implementing-a-concept-exercise.md
@@ -4,7 +4,13 @@
 ! WARNING! This document should be treated as a draft and will be actively changing. Sections that marked as WIP requires attention/rework from contributors.
 ```
 
-This document describes the steps required to implement a concept exercise in any v3 track. As this document is generic, the following placeholders are used:
+This document describes the steps required to implement a concept exercise in any v3 track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<exercise-slug>`: the name of the exercise in kebab-case (e.g. `functions-basic`).
 - `<ExerciseSlug>`: the name of the exercise in PascalCase (e.g. `FunctionsBasic`).

--- a/languages/kotlin/reference/implementing-a-concept-exercise.md
+++ b/languages/kotlin/reference/implementing-a-concept-exercise.md
@@ -6,7 +6,7 @@
 
 This document describes the steps required to implement a concept exercise in any v3 track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/purescript/reference/implementing-a-concept-exercise.md
+++ b/languages/purescript/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise for the PureScript track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/purescript/reference/implementing-a-concept-exercise.md
+++ b/languages/purescript/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement a PureScript concept exercise
 
-This document describes the steps required to implement a concept exercise for the PureScript track. Before diving into the implementation, please read up on the following documents:
+This document describes the steps required to implement a concept exercise for the PureScript track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/purescript/reference/implementing-a-concept-exercise.md
+++ b/languages/purescript/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement a PureScript concept exercise
 
-This document describes the steps required to implement a concept exercise for the PureScript track. As this document is generic, the following placeholders are used:
+This document describes the steps required to implement a concept exercise for the PureScript track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<SLUG>`: the name of the exercise in kebab-case (e.g. `anonymous-methods`).
 - `<NAME>`: the name of the exercise in PascalCase (e.g. `AnonymousMethods`).
@@ -51,3 +57,6 @@ When implementing an exercise, it can be very useful to look at already implemen
 
 [reference]: ../../../reference
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md

--- a/languages/purescript/reference/implementing-a-concept-exercise.md
+++ b/languages/purescript/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise for the PureScript track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/purescript/reference/implementing-a-concept-exercise.md
+++ b/languages/purescript/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise for the PureScript track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/python/reference/implementing-a-concept-exercise.md
+++ b/languages/python/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise for the Python track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/python/reference/implementing-a-concept-exercise.md
+++ b/languages/python/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise for the Python track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/python/reference/implementing-a-concept-exercise.md
+++ b/languages/python/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement a Python concept exercise
 
-This document describes the steps required to implement a concept exercise for the Python track. Before diving into the implementation, please read up on the following documents:
+This document describes the steps required to implement a concept exercise for the Python track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/python/reference/implementing-a-concept-exercise.md
+++ b/languages/python/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes the steps required to implement a concept exercise for the Python track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/python/reference/implementing-a-concept-exercise.md
+++ b/languages/python/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement a Python concept exercise
 
-This document describes the steps required to implement a concept exercise for the Python track. As this document is generic, the following placeholders are used:
+This document describes the steps required to implement a concept exercise for the Python track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<SLUG>`: the name of the exercise in kebab-case (e.g. `anonymous-methods`).
 - `<NAME>`: the name of the exercise in snake_case (e.g. `anonymous_methods`).
@@ -43,6 +49,7 @@ languages
 ## Step 1: add track-specific files
 
 These are files specific to the Python track:
+
 - `src/<NAME>.py`: the stub implementation file, which is the starting point for students to work on the exercise.
 - `test/<NAME>_test.py`: the test suite.
 - `.meta/example.py`: an example implementation that passes all the tests.
@@ -57,3 +64,6 @@ When implementing an exercise, it can be very useful to look at already implemen
 
 [reference]: ../../../reference
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md

--- a/languages/ruby/reference/implementing-a-concept-exercise.md
+++ b/languages/ruby/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the Ruby track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/ruby/reference/implementing-a-concept-exercise.md
+++ b/languages/ruby/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement a Ruby concept exercise
 
-This document describes how to implement a concept exercise for the Ruby track. As this document is generic, `<NAME>` will be use as the placeholder for the name of the exercise in underscore-case (e.g. `string_interpolation`)
+This document describes how to implement a concept exercise for the Ruby track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, `<NAME>` will be use as the placeholder for the name of the exercise in underscore-case (e.g. `string_interpolation`)
 
 Before implementing the exercise, please make sure you have a good understanding of what the exercise should be teaching (and what not). This information can be found in the exercise's GitHub issue. Having done this, please read the [Ruby concept exercises introduction][concept-exercises].
 
@@ -58,5 +64,8 @@ If you have any questions regarding implementing the exercise, please post them 
 [representer]: https://github.com/exercism/ruby-representer
 [concept-exercises]: ../exercises/concept/README.md
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md
 [concept-exercise-strings]: ../exercises/concept/strings
 [reference]: ../../../reference

--- a/languages/ruby/reference/implementing-a-concept-exercise.md
+++ b/languages/ruby/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the Ruby track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/ruby/reference/implementing-a-concept-exercise.md
+++ b/languages/ruby/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a concept exercise for the Ruby track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/ruby/reference/implementing-a-concept-exercise.md
+++ b/languages/ruby/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement a Ruby concept exercise
 
-This document describes how to implement a concept exercise for the Ruby track. Before diving into the implementation, please read up on the following documents:
+This document describes how to implement a concept exercise for the Ruby track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/rust/reference/implementing-a-concept-exercise.md
+++ b/languages/rust/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This issue describes how to implement a concept exercise for the Rust track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/rust/reference/implementing-a-concept-exercise.md
+++ b/languages/rust/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement a Rust concept exercise
 
-This issue describes how to implement a concept exercise for the Rust track. As this document is generic, the following placeholders are used:
+This issue describes how to implement a concept exercise for the Rust track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<SLUG>`: the name of the exercise in kebab-case (e.g. `anonymous-methods`).
 - `<NAME>`: the name of the exercise in snake_case (e.g. `anonymous_methods`).
@@ -66,5 +72,8 @@ If you have any questions regarding implementing the exercise, please post them 
 [representer]: https://github.com/exercism/v3/issues/new/choose
 [concept-exercises]: ../exercises/concept/README.md
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md
 [concept-exercise-numbers]: ../exercises/concept/numbers
 [reference]: ../../../reference

--- a/languages/rust/reference/implementing-a-concept-exercise.md
+++ b/languages/rust/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement a Rust concept exercise
 
-This issue describes how to implement a concept exercise for the Rust track. Before diving into the implementation, please read up on the following documents:
+This issue describes how to implement a concept exercise for the Rust track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/rust/reference/implementing-a-concept-exercise.md
+++ b/languages/rust/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This issue describes how to implement a concept exercise for the Rust track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/rust/reference/implementing-a-concept-exercise.md
+++ b/languages/rust/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This issue describes how to implement a concept exercise for the Rust track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/typescript/reference/implementing-a-concept-exercise.md
+++ b/languages/typescript/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a Concept Exercise for the TypeScript track.
 
-**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/typescript/reference/implementing-a-concept-exercise.md
+++ b/languages/typescript/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a Concept Exercise for the TypeScript track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. Before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/typescript/reference/implementing-a-concept-exercise.md
+++ b/languages/typescript/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,8 @@
 # How to implement a TypeScript Concept Exercise
 
-This document describes how to implement a Concept Exercise for the TypeScript track. Before diving into the implementation, please read up on the following documents:
+This document describes how to implement a Concept Exercise for the TypeScript track.
+
+**Please please please read the following docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time.
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/typescript/reference/implementing-a-concept-exercise.md
+++ b/languages/typescript/reference/implementing-a-concept-exercise.md
@@ -2,7 +2,7 @@
 
 This document describes how to implement a Concept Exercise for the TypeScript track.
 
-**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read up on the following documents:
+**Please please please read the docs before starting.** Posting PRs without reading these docs will be a lot more frustrating for you during the review cycle, and exhaust Exercism's maintainers' time. So, before diving into the implementation, please read the following documents:
 
 - [The features of v3][docs-features-of-v3].
 - [Rationale for v3][docs-rationale-for-v3].

--- a/languages/typescript/reference/implementing-a-concept-exercise.md
+++ b/languages/typescript/reference/implementing-a-concept-exercise.md
@@ -1,6 +1,12 @@
 # How to implement a TypeScript Concept Exercise
 
-This document describes how to implement a Concept Exercise for the TypeScript track. As this document is generic, the following placeholders are used:
+This document describes how to implement a Concept Exercise for the TypeScript track. Before diving into the implementation, please read up on the following documents:
+
+- [The features of v3][docs-features-of-v3].
+- [Rationale for v3][docs-rationale-for-v3].
+- [What are concept exercise and how they are structured?][docs-concept-exercises]
+
+As this document is generic, the following placeholders are used:
 
 - `<slug>`: the name of the exercise in snake_case (e.g. `anonymous-methods`).
 - `<concepts>`: the Concepts the exercise is about (e.g. `loops`),
@@ -148,6 +154,9 @@ If you have any questions regarding implementing the exercise, please post them 
 [representer]: https://github.com/exercism/typescript-representer
 [concept-exercises]: ../exercises/concept/README.md
 [how-to-implement-a-concept-exercise]: ../../../docs/maintainers/generic-how-to-implement-a-concept-exercise.md
+[docs-concept-exercises]: ../../../docs/concept-exercises.md
+[docs-rationale-for-v3]: ../../../docs/rationale-for-v3.md
+[docs-features-of-v3]: ../../../docs/features-of-v3.md
 [concept-exercise-strings]: ../exercises/concept/strings.md
 [concept-exercise-numbers]: ../exercises/concept/numbers.md
 [concept-exercise-promises]: ../exercises/concept/promises.md


### PR DESCRIPTION
I've found that people start working on these PR's to implement exercises without reading up on any of the v3 documentation, and thus don't know _why_ some things are done in a particular way. We should encourage people to read up on the documentation.