### PR TITLE
[Docs] Flesh out the rules for concept-exercies.md slightly more

### DIFF
--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -66,13 +66,13 @@ See the C# floating-point-numbers exercise's [introduction.md file][csharp-docs-
 
 **Purpose:** Provide instructions for the exercise.
 
-This file is split into two halves. 
-1. The first half explains the "story" or "theme" of the exercise. It should generally contain no code samples.
-2. The second half provides clear instructions of what a student needs to do, providing tasks.
+This file is split into two parts. 
+1. The first part explains the "story" or "theme" of the exercise. It should generally contain no code samples.
+2. The second part provides clear instructions of what a student needs to do, providing tasks.
 
-Each tasks must conform to the following standard:
+Each task must conform to the following standard:
 - Start with a third-level heading starting with a number (.e.g `### 1.`, `### 2.`)
-- Provide a method that a student needs to define with its signature(e.g. `X(...)` that takes an A and returns a Z),
+- Describe which function/method the student needs to define/implement (e.g. `Implement method X(...)` that takes an A and returns a Z),
 - Provide an example usage of that function. These examples should be different examples to those given in the tests.
 
 Avoid any controversial topics in the stories - be empathetic to triggers that people might have - there's normally a less controversial or risque variant of a story that can be used.
@@ -85,10 +85,10 @@ See the C# numbers exercise's [instructions.md file][csharp-docs-instructions.md
 
 - If the student gets stuck, we will allow them to click a button requesting a hint, which will show the relevant part of file. 
 - Hints should be bullet-pointed underneath headings.
-- General hints about the exericse can appear under the `### General` heading.
-- Task-specific hints should appear underneath headings that match their task in the `instructions.md` (e.g. `### 2.`).
+- General hints about the exercise can appear under the `### General` heading.
+- Task-specific hints should appear underneath headings that match their task heading in the `instructions.md` (e.g. `### 2.`).
 
-Viewing hints will not be a "recommended" path and we will (softly) discourage them using it unless they can't progress without it. As such, it's worth considering that the student reading it will be a little confused/overwhelmed and maybe frustrated. These hints should be enough to unblock almost any student. They might link to the docs of the functions that need to be used. The hints should not spell out the solution, but instead point to a resource describing the solution (e.g. linking to documentation for the function to use).
+Viewing hints will not be a "recommended" path and we will (softly) discourage using it unless the student can't progress without it. As such, it's worth considering that the student reading it will be a little confused/overwhelmed and maybe frustrated. These hints should be enough to unblock almost any student. They might link to the docs of the functions that need to be used. The hints should not spell out the solution, but instead point to a resource describing the solution (e.g. linking to documentation for the function to use).
 
 See the C# floating-point-numbers exercise's [hints.md file][csharp-docs-hints.md] for an example.
 

--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -86,7 +86,7 @@ See the C# numbers exercise's [instructions.md file][csharp-docs-instructions.md
 - If the student gets stuck, we will allow them to click a button requesting a hint, which will show the relevant part of file. 
 - Hints should be bullet-pointed underneath headings.
 - General hints about the exericse can appear under the`### General` heading.
-- Task-specific hints should appear undernearth headings that match their task in the `instructions.md` (e.g. `### 2.`).
+- Task-specific hints should appear underneath headings that match their task in the `instructions.md` (e.g. `### 2.`).
 
 Viewing hints will not be a "recommended" path and we will (softly) discourage them using it unless they can't progress without it. As such, it's worth considering that the student reading it will be a little confused/overwhelmed and maybe frustrated. These hints should be enough to unblock almost any student. They might link to the docs of the functions that need to be used. The hints should not spell out the solution, but instead point to a resource describing the solution (e.g. linking to documentation for the function to use).
 

--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -73,7 +73,7 @@ This file is split into two halves.
 Each tasks must conform to the following standard:
 - Start with a third-level heading starting with a number (.e.g `### 1.`, `### 2.`)
 - Provide a method that a student needs to define with its signature(e.g. `X(...)` that takes an A and returns a Z),
-- Provide at example usage of that function. These examples should be different examples to those given in the tests.
+- Provide an example usage of that function. These examples should be different examples to those given in the tests.
 
 Avoid any controversial topics in the stories - be empathetic to triggers that people might have - there's normally a less controversial or risque variant of a story that can be used.
 

--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -67,7 +67,7 @@ See the C# floating-point-numbers exercise's [introduction.md file][csharp-docs-
 **Purpose:** Provide instructions for the exercise.
 
 This file is split into two halves. 
-1. The first half explains the "story" or "theme" of the exericise. It should generally contain no code samples.
+1. The first half explains the "story" or "theme" of the exercise. It should generally contain no code samples.
 2. The second half provides clear instructions of what a student needs to do, providing tasks.
 
 Each tasks must conform to the following standard:

--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -76,7 +76,6 @@ Each task must conform to the following standard:
 - Describe which function/method the student needs to define/implement (e.g. `Implement method X(...)` that takes an A and returns a Z),
 - Provide an example usage of that function. These examples should be different examples to those given in the tests.
 
-Avoid any topics in the stories that could be misconstrued or cause offence - be empathetic to triggers that people might have - there's normally a less controversial or risque variant of a story that can be used.
 
 See the C# numbers exercise's [instructions.md file][csharp-docs-instructions.md] for an example. Notice the clear distinction between the story at the top and the tasks with code samples below.
 

--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -54,7 +54,7 @@ An exercise has the following files. In the browser they will show at the releva
 **Purpose:** Introduce the concept(s) that the exercise teaches to the student.
 
 - The information provided should give the student just enough context to figure out the solution themselves. 
-- It should not give the student any extra information about a concept not needed to understand the fundamentals of the concept or solve the exercise.
+- The file should not give the student any extra information about a concept not needed to understand the fundamentals of the concept or solve the exercise.
 - Use the proper technical terms so that the student can easily search for more information. 
 - If the exercise introduces new syntax, an example of the syntax should always be included; students should not need to search the web for examples of syntax.
 

--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -51,29 +51,50 @@ An exercise has the following files. In the browser they will show at the releva
 
 ### `.docs/introduction.md`
 
-This file contains an introduction to the concept. It should make the exercise's learning goals explicit and provide a short introduction with enough detail for the student to complete the exercise. The aim is to give the student just enough context to figure out the solution themselves, as research has shown that self-discovery is the most effective learning experience. Using the proper technical terms in the descriptions will be helpful if the student wants to search for more information. If the exercise introduces new syntax, an example of the syntax should always be included; students should not need to search the web for examples of syntax.
+**Purpose:** Introduce the concept(s) that the exercise teaches to the student.
 
-As an example, the introduction to a "strings" exercise might describe a string as just a "Sequence of Unicode characters" or a "series of bytes". Unless the student needs to understand more nuanced details in order to solve the exercise, this type of brief explanation (along with an example of its syntax) should be sufficient information for the student to solve the exercise.
+- The information provided should give the student just enough context to figure out the solution themselves. 
+- It should not give the student any extra information about a concept not needed to understand the fundamentals of the concept or solve the exercise.
+- Use the proper technical terms so that the student can easily search for more information. 
+- If the exercise introduces new syntax, an example of the syntax should always be included; students should not need to search the web for examples of syntax.
+
+As an example, the introduction to a "strings" exercise might describe a string as just a "Sequence of Unicode characters" or a "series of bytes", tell the users how to create a string, and explain that a string has methods that can be used to manipulate it. Unless the student needs to understand more nuanced details in order to solve the exercise, this type of brief explanation (along with an example of its syntax) should be sufficient information for the student to solve the exercise.
 
 See the C# floating-point-numbers exercise's [introduction.md file][csharp-docs-introduction.md] for an example.
 
 ### `.docs/instructions.md`
 
-This file contains instructions for the exercise. It should explicitly explain what the student needs to do (define a method with the signature `X(...)` that takes an A and returns a Z), and provide at least one example usage of that function. If there are multiple tasks within the exercise, it should provide an example of each.
+**Purpose:** Provide instructions for the exercise.
 
-See the C# floating-point-numbers exercise's [instructions.md file][csharp-docs-instructions.md] for an example.
+This file is split into two halves. 
+1. The first half explains the "story" or "theme" of the exericise. It should generally contain no code samples.
+2. The second half provides clear instructions of what a student needs to do, providing tasks.
+
+Each tasks must conform to the following standard:
+- Start with a third-level heading starting with a number (.e.g `### 1.`, `### 2.`)
+- Provide a method that a student needs to define with its signature(e.g. `X(...)` that takes an A and returns a Z),
+- Provide at example usage of that function. These examples should be different examples to those given in the tests.
+
+Avoid any controversial topics in the stories - be empathetic to triggers that people might have - there's normally a less controversial or risque variant of a story that can be used.
+
+See the C# numbers exercise's [instructions.md file][csharp-docs-instructions.md] for an example. Notice the clear distinction between the story at the top and the tasks with code samples below.
 
 ### `.docs/hints.md`
 
-If the student gets stuck, we will allow them to click a button requesting a hint, which shows this file. This will not be a "recommended" path and we will (softly) discourage them using it unless they can't progress without it. As such, it's worth considering that the student reading it will be a little confused/overwhelmed and maybe frustrated.
+**Purpose:** Provide hints to a student to help them get themselves unstuck n an exercise.
 
-The file should contain both general and task-specific "hints". These hints should be enough to unblock almost any student. They might link to the docs of the functions that need to be used.
+- If the student gets stuck, we will allow them to click a button requesting a hint, which will show the relevant part of file. 
+- Hints should be bullet-pointed underneath headings.
+- General hints about the exericse can appear under the`### General` heading.
+- Task-specific hints should appear undernearth headings that match their task in the `instructions.md` (e.g. `### 2.`).
 
-The hints should not spell out the solution, but instead point to a resource describing the solution (e.g. linking to documentation for the function to use).
+Viewing hints will not be a "recommended" path and we will (softly) discourage them using it unless they can't progress without it. As such, it's worth considering that the student reading it will be a little confused/overwhelmed and maybe frustrated. These hints should be enough to unblock almost any student. They might link to the docs of the functions that need to be used. The hints should not spell out the solution, but instead point to a resource describing the solution (e.g. linking to documentation for the function to use).
 
 See the C# floating-point-numbers exercise's [hints.md file][csharp-docs-hints.md] for an example.
 
 ### `.docs/after.md`
+
+**Purpose:** Provide more information about the concept(s) for a student to learn from.
 
 Once the student completes the exercise they will be shown this file, which should provide them with a summary of what the exercise aimed to teach. If the exercise introduced new syntax, syntax samples should be included. This document can also link to any additional resources that might be interesting to the student in the context of the exercise.
 

--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -85,7 +85,7 @@ See the C# numbers exercise's [instructions.md file][csharp-docs-instructions.md
 
 - If the student gets stuck, we will allow them to click a button requesting a hint, which will show the relevant part of file. 
 - Hints should be bullet-pointed underneath headings.
-- General hints about the exericse can appear under the`### General` heading.
+- General hints about the exericse can appear under the `### General` heading.
 - Task-specific hints should appear underneath headings that match their task in the `instructions.md` (e.g. `### 2.`).
 
 Viewing hints will not be a "recommended" path and we will (softly) discourage them using it unless they can't progress without it. As such, it's worth considering that the student reading it will be a little confused/overwhelmed and maybe frustrated. These hints should be enough to unblock almost any student. They might link to the docs of the functions that need to be used. The hints should not spell out the solution, but instead point to a resource describing the solution (e.g. linking to documentation for the function to use).

--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -75,7 +75,7 @@ Each task must conform to the following standard:
 - Describe which function/method the student needs to define/implement (e.g. `Implement method X(...)` that takes an A and returns a Z),
 - Provide an example usage of that function. These examples should be different examples to those given in the tests.
 
-Avoid any controversial topics in the stories - be empathetic to triggers that people might have - there's normally a less controversial or risque variant of a story that can be used.
+Avoid any topics in the stories that could be misconstrued or cause offence - be empathetic to triggers that people might have - there's normally a less controversial or risque variant of a story that can be used.
 
 See the C# numbers exercise's [instructions.md file][csharp-docs-instructions.md] for an example. Notice the clear distinction between the story at the top and the tasks with code samples below.
 

--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -81,7 +81,7 @@ See the C# numbers exercise's [instructions.md file][csharp-docs-instructions.md
 
 ### `.docs/hints.md`
 
-**Purpose:** Provide hints to a student to help them get themselves unstuck n an exercise.
+**Purpose:** Provide hints to a student to help them get themselves unstuck in an exercise.
 
 - If the student gets stuck, we will allow them to click a button requesting a hint, which will show the relevant part of file. 
 - Hints should be bullet-pointed underneath headings.

--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -54,6 +54,7 @@ An exercise has the following files. In the browser they will show at the releva
 **Purpose:** Introduce the concept(s) that the exercise teaches to the student.
 
 - The information provided should give the student just enough context to figure out the solution themselves. 
+- Links should be used sparingly if at all. While a link explaining a complex topic like recursion might be useful, for most concepts the links will provide more information than needed so explaining things concisely inline should be the aim.
 - The file should not give the student any extra information about a concept not needed to understand the fundamentals of the concept or solve the exercise.
 - Use the proper technical terms so that the student can easily search for more information. 
 - If the exercise introduces new syntax, an example of the syntax should always be included; students should not need to search the web for examples of syntax.


### PR DESCRIPTION
We're suffering from people not reading these docs. I'm putting a video to help. This PR addresses the following to help:

- Clearly specifies the purpose of each file to give quick overviews
- More bullet points and less prose to provide extra information
- Incorporates some of @mikedamay's points in https://github.com/exercism/v3/issues/1087

We can improve the other sections later - but if everyone agrees this is an improvement, let's get it down on master.