### PR TITLE
[C#] Normalize code

### DIFF
--- a/languages/csharp/exercises/concept/basics/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/basics/.meta/Example.cs
@@ -1,13 +1,22 @@
 public class Lasagna
 {
-    public int ExpectedMinutesInOven() => 40;
+    public int ExpectedMinutesInOven()
+    {
+        return 40;
+    }
 
-    public int RemainingMinutesInOven(int actualMinutesInOven) =>
-        ExpectedMinutesInOven() - actualMinutesInOven;
+    public int RemainingMinutesInOven(int actualMinutesInOven)
+    {
+        return ExpectedMinutesInOven() - actualMinutesInOven;
+    }
 
-    public int PreparationTimeInMinutes(int numberOfLayers) =>
-        numberOfLayers * 2;
+    public int PreparationTimeInMinutes(int numberOfLayers)
+    {
+        return numberOfLayers * 2;
+    }
 
-    public int TotalTimeInMinutes(int numberOfLayers, int actualMinutesInOven) =>
-        PreparationTimeInMinutes(numberOfLayers) + actualMinutesInOven;
+    public int TotalTimeInMinutes(int numberOfLayers, int actualMinutesInOven)
+    {
+        return PreparationTimeInMinutes(numberOfLayers) + actualMinutesInOven;
+    }
 }

--- a/languages/csharp/exercises/concept/basics/BasicsTests.cs
+++ b/languages/csharp/exercises/concept/basics/BasicsTests.cs
@@ -3,26 +3,38 @@ using Xunit;
 public class LasagnaTests
 {
     [Fact]
-    public void ExpectedMinutesInOven() =>
+    public void ExpectedMinutesInOven()
+    {
         Assert.Equal(40, new Lasagna().ExpectedMinutesInOven());
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RemainingMinutesInOven() =>
+    public void RemainingMinutesInOven()
+    {
         Assert.Equal(15, new Lasagna().RemainingMinutesInOven(25));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void PreparationTimeInMinutesForOneLayer() =>
+    public void PreparationTimeInMinutesForOneLayer()
+    {
         Assert.Equal(2, new Lasagna().PreparationTimeInMinutes(1));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void PreparationTimeInMinutesForMultipleLayers() =>
+    public void PreparationTimeInMinutesForMultipleLayers()
+    {
         Assert.Equal(8, new Lasagna().PreparationTimeInMinutes(4));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TotalTimeInMinutesForOneLayer() =>
+    public void TotalTimeInMinutesForOneLayer()
+    {
         Assert.Equal(32, new Lasagna().TotalTimeInMinutes(1, 30));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TotalTimeInMinutesForMultipleLayers() =>
+    public void TotalTimeInMinutesForMultipleLayers()
+    {
         Assert.Equal(16, new Lasagna().TotalTimeInMinutes(4, 8));
+    }
 }

--- a/languages/csharp/exercises/concept/datetimes/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/datetimes/.meta/Example.cs
@@ -2,18 +2,28 @@ using System;
 
 public static class Appointment
 {
-    public static DateTime Schedule(string appointmentDateDescription) =>
-        DateTime.Parse(appointmentDateDescription);
+    public static DateTime Schedule(string appointmentDateDescription)
+    {
+        return DateTime.Parse(appointmentDateDescription);
+    }
 
-    public static bool HasPassed(DateTime appointmentDate) =>
-        appointmentDate < DateTime.Now;
+    public static bool HasPassed(DateTime appointmentDate)
+    {
+        return appointmentDate < DateTime.Now;
+    }
 
-    public static bool IsAfternoonAppointment(DateTime appointmentDate) =>
-        appointmentDate.Hour >= 12 && appointmentDate.Hour < 18;
+    public static bool IsAfternoonAppointment(DateTime appointmentDate)
+    {
+        return appointmentDate.Hour >= 12 && appointmentDate.Hour < 18;
+    }
 
-    public static string Description(DateTime appointmentDate) =>
-        $"You have an appointment on {appointmentDate}.";
+    public static string Description(DateTime appointmentDate)
+    {
+        return $"You have an appointment on {appointmentDate}.";
+    }
 
-    public static DateTime AnniversaryDate() =>
-        new DateTime(DateTime.Now.Year, 9, 15);
+    public static DateTime AnniversaryDate()
+    {
+        return new DateTime(DateTime.Now.Year, 9, 15);
+    }
 }

--- a/languages/csharp/exercises/concept/datetimes/DateTimesTests.cs
+++ b/languages/csharp/exercises/concept/datetimes/DateTimesTests.cs
@@ -9,104 +9,154 @@ using System.Threading;
 public class AppointmentTests
 {
     [Fact]
-    public void ScheduleDateUsingOnlyNumbers() =>
+    public void ScheduleDateUsingOnlyNumbers()
+    {
         Assert.Equal(new DateTime(2019, 07, 25, 13, 45, 0), Appointment.Schedule("7/25/2019 13:45:00"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ScheduleDateWithTextualMonth() =>
+    public void ScheduleDateWithTextualMonth()
+    {
         Assert.Equal(new DateTime(2019, 6, 3, 11, 30, 0), Appointment.Schedule("June 3, 2019 11:30:00"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ScheduleDateWithTextualMonthAndWeekday() =>
+    public void ScheduleDateWithTextualMonthAndWeekday()
+    {
         Assert.Equal(new DateTime(2019, 12, 5, 9, 0, 0), Appointment.Schedule("Thursday, December 5, 2019 09:00:00"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentOneYearAgo() =>
+    public void HasPassedWithAppointmentOneYearAgo()
+    {
         Assert.True(Appointment.HasPassed(DateTime.Now.AddYears(-1).AddHours(2)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentMonthsAgo() =>
+    public void HasPassedWithAppointmentMonthsAgo()
+    {
         Assert.True(Appointment.HasPassed(DateTime.Now.AddMonths(-8)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentDaysAgo() =>
+    public void HasPassedWithAppointmentDaysAgo()
+    {
         Assert.True(Appointment.HasPassed(DateTime.Now.AddDays(-23)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentHoursAgo() =>
+    public void HasPassedWithAppointmentHoursAgo()
+    {
         Assert.True(Appointment.HasPassed(DateTime.Now.AddHours(-12)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentMinutesAgo() =>
+    public void HasPassedWithAppointmentMinutesAgo()
+    {
         Assert.True(Appointment.HasPassed(DateTime.Now.AddMinutes(-55)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentOneMinuteAgo() =>
+    public void HasPassedWithAppointmentOneMinuteAgo()
+    {
         Assert.True(Appointment.HasPassed(DateTime.Now.AddMinutes(-1)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentInOneMinute() =>
+    public void HasPassedWithAppointmentInOneMinute()
+    {
         Assert.False(Appointment.HasPassed(DateTime.Now.AddMinutes(1)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentInMinutes() =>
+    public void HasPassedWithAppointmentInMinutes()
+    {
         Assert.False(Appointment.HasPassed(DateTime.Now.AddMinutes(5)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentInDays() =>
+    public void HasPassedWithAppointmentInDays()
+    {
         Assert.False(Appointment.HasPassed(DateTime.Now.AddDays(19)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentInMonths() =>
+    public void HasPassedWithAppointmentInMonths()
+    {
         Assert.False(Appointment.HasPassed(DateTime.Now.AddMonths(10)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentInYears() =>
+    public void HasPassedWithAppointmentInYears()
+    {
         Assert.False(Appointment.HasPassed(DateTime.Now.AddYears(2).AddMonths(3).AddDays(6)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForEarlyMorningAppointment() =>
+    public void IsAfternoonAppointmentForEarlyMorningAppointment()
+    {
         Assert.False(Appointment.IsAfternoonAppointment(new DateTime(2019, 6, 17, 8, 15, 0)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForLateMorningAppointment() =>
+    public void IsAfternoonAppointmentForLateMorningAppointment()
+    {
         Assert.False(Appointment.IsAfternoonAppointment(new DateTime(2019, 2, 23, 11, 59, 59)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForNoonAppointment() =>
+    public void IsAfternoonAppointmentForNoonAppointment()
+    {
         Assert.True(Appointment.IsAfternoonAppointment(new DateTime(2019, 8, 9, 12, 0, 0)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForEarlyAfternoonAppointment() =>
+    public void IsAfternoonAppointmentForEarlyAfternoonAppointment()
+    {
         Assert.True(Appointment.IsAfternoonAppointment(new DateTime(2019, 8, 9, 12, 0, 1)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForLateAfternoonAppointment() =>
+    public void IsAfternoonAppointmentForLateAfternoonAppointment()
+    {
         Assert.True(Appointment.IsAfternoonAppointment(new DateTime(2019, 9, 1, 17, 59, 59)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForEarlyEveningAppointment() =>
+    public void IsAfternoonAppointmentForEarlyEveningAppointment()
+    {
         Assert.False(Appointment.IsAfternoonAppointment(new DateTime(2019, 9, 1, 18, 0, 0)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForLateEveningAppointment() =>
+    public void IsAfternoonAppointmentForLateEveningAppointment()
+    {
         Assert.False(Appointment.IsAfternoonAppointment(new DateTime(2019, 9, 1, 23, 59, 59)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DescriptionOnFridayAfternoon() =>
+    public void DescriptionOnFridayAfternoon()
+    {
         Assert.Equal("You have an appointment on 3/29/2019 3:00:00 PM.", Appointment.Description(new DateTime(2019, 03, 29, 15, 0, 0)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DescriptionOnThursdayAfternoon() =>
+    public void DescriptionOnThursdayAfternoon()
+    {
         Assert.Equal("You have an appointment on 7/25/2019 1:45:00 PM.", Appointment.Description(new DateTime(2019, 07, 25, 13, 45, 0)));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DescriptionOnWednesdayMorning() =>
+    public void DescriptionOnWednesdayMorning()
+    {
         Assert.Equal("You have an appointment on 9/9/2020 9:09:09 AM.", Appointment.Description(new DateTime(2020, 9, 9, 9, 9, 9)));
+    }
 
     [Fact]
-    public void AnniversaryDate() =>
+    public void AnniversaryDate()
+    {
         Assert.Equal(new DateTime(DateTime.Now.Year, 9, 15), Appointment.AnniversaryDate());
+    }
 
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
     private class UseCultureAttribute : BeforeAfterTestAttribute

--- a/languages/csharp/exercises/concept/enums/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/enums/.meta/Example.cs
@@ -13,7 +13,6 @@ public static class LogLine
 {
     public static LogLevel ParseLogLevel(string logLine)
     {
-
         switch (logLine.Substring(1, 3))
         {
             case "TRC":

--- a/languages/csharp/exercises/concept/enums/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/enums/.meta/Example.cs
@@ -1,5 +1,3 @@
-using System;
-
 public enum LogLevel
 {
     Trace = 0,
@@ -13,26 +11,30 @@ public enum LogLevel
 
 public static class LogLine
 {
-    public static LogLevel ParseLogLevel(string logLine) {
-		
-		switch (logLine.Substring(1, 3)) {
-			case "TRC":
-				return LogLevel.Trace;
-			case "DBG":
-				return LogLevel.Debug;
-			case "INF":
-				return LogLevel.Info;
-			case "WRN":
-				return LogLevel.Warning;
-			case "ERR":
-				return LogLevel.Error;
-			case "FTL":
-				return LogLevel.Fatal;
-			default:
-				return LogLevel.Unknown;
-		}
-	}
+    public static LogLevel ParseLogLevel(string logLine)
+    {
 
-    public static string OutputForShortLog(LogLevel logLevel, string message) =>
-        $"{(int)logLevel}:{message}";
+        switch (logLine.Substring(1, 3))
+        {
+            case "TRC":
+                return LogLevel.Trace;
+            case "DBG":
+                return LogLevel.Debug;
+            case "INF":
+                return LogLevel.Info;
+            case "WRN":
+                return LogLevel.Warning;
+            case "ERR":
+                return LogLevel.Error;
+            case "FTL":
+                return LogLevel.Fatal;
+            default:
+                return LogLevel.Unknown;
+        }
+    }
+
+    public static string OutputForShortLog(LogLevel logLevel, string message)
+    {
+        return $"{(int)logLevel}:{message}";
+    }
 }

--- a/languages/csharp/exercises/concept/enums/EnumsTests.cs
+++ b/languages/csharp/exercises/concept/enums/EnumsTests.cs
@@ -3,58 +3,86 @@ using Xunit;
 public class LogLineTests
 {
     [Fact]
-    public void ParseTrace() =>
+    public void ParseTrace()
+    {
         Assert.Equal(LogLevel.Trace, LogLine.ParseLogLevel("[TRC]: Line 84 - Console.WriteLine('Hello World');"));
-        
+    }
+
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ParseDebug() =>
+    public void ParseDebug()
+    {
         Assert.Equal(LogLevel.Debug, LogLine.ParseLogLevel("[DBG]: ; expected"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ParseInfo() =>
+    public void ParseInfo()
+    {
         Assert.Equal(LogLevel.Info, LogLine.ParseLogLevel("[INF]: Timezone changed"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ParseWarning() =>
+    public void ParseWarning()
+    {
         Assert.Equal(LogLevel.Warning, LogLine.ParseLogLevel("[WRN]: Timezone not set"));
-        
+    }
+
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ParseError() =>
+    public void ParseError()
+    {
         Assert.Equal(LogLevel.Error, LogLine.ParseLogLevel("[ERR]: Disk full"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ParseFatal() =>
+    public void ParseFatal()
+    {
         Assert.Equal(LogLevel.Fatal, LogLine.ParseLogLevel("[FTL]: Not enough memory"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ParseUnknown() =>
+    public void ParseUnknown()
+    {
         Assert.Equal(LogLevel.Unknown, LogLine.ParseLogLevel("[XYZ]: Gibberish message.. beep boop.."));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForTrace() =>
+    public void OutputForShortLogForTrace()
+    {
         Assert.Equal("0:Line 13 - int myNum = 42;", LogLine.OutputForShortLog(LogLevel.Trace, "Line 13 - int myNum = 42;"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForDebug() =>
+    public void OutputForShortLogForDebug()
+    {
         Assert.Equal("1:The name 'LogLevel' does not exist in the current context", LogLine.OutputForShortLog(LogLevel.Debug, "The name 'LogLevel' does not exist in the current context"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForInfo() =>
+    public void OutputForShortLogForInfo()
+    {
         Assert.Equal("4:File moved", LogLine.OutputForShortLog(LogLevel.Info, "File moved"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForWarning() =>
+    public void OutputForShortLogForWarning()
+    {
         Assert.Equal("5:Unsafe password", LogLine.OutputForShortLog(LogLevel.Warning, "Unsafe password"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForError() =>
+    public void OutputForShortLogForError()
+    {
         Assert.Equal("6:Stack overflow", LogLine.OutputForShortLog(LogLevel.Error, "Stack overflow"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForFatal() =>
+    public void OutputForShortLogForFatal()
+    {
         Assert.Equal("7:Dumping all files", LogLine.OutputForShortLog(LogLevel.Fatal, "Dumping all files"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForUnknown() =>
+    public void OutputForShortLogForUnknown()
+    {
         Assert.Equal("42:Something unknown happened", LogLine.OutputForShortLog(LogLevel.Unknown, "Something unknown happened"));
+    }
 }

--- a/languages/csharp/exercises/concept/flag-enums/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/flag-enums/.meta/Example.cs
@@ -19,21 +19,33 @@ public enum Permission
 
 public static class Permissions
 {
-    public static Permission Default(AccountType accountType) =>
-        accountType switch
+    public static Permission Default(AccountType accountType)
+    {
+        switch (accountType)
         {
-            AccountType.Guest => Permission.Read,
-            AccountType.User => Permission.Read | Permission.Write,
-            AccountType.Moderator => Permission.Read | Permission.Write | Permission.Delete,
-            _ => Permission.None
-        };
+            case AccountType.Guest:
+                return Permission.Read;
+            case AccountType.User:
+                return Permission.Read | Permission.Write;
+            case AccountType.Moderator:
+                return Permission.Read | Permission.Write | Permission.Delete;
+            default:
+                return Permission.None;
+        }
+    }
 
-    public static Permission Grant(Permission current, Permission grant) =>
-        current | grant;
+    public static Permission Grant(Permission current, Permission grant)
+    {
+        return current | grant;
+    }
 
-    public static Permission Revoke(Permission current, Permission revoke) =>
-        current & ~revoke;
+    public static Permission Revoke(Permission current, Permission revoke)
+    {
+        return current & ~revoke;
+    }
 
-    public static bool Check(Permission current, Permission check) =>
-        current.HasFlag(check);
+    public static bool Check(Permission current, Permission check)
+    {
+        return current.HasFlag(check);
+    }
 }

--- a/languages/csharp/exercises/concept/flag-enums/FlagEnumsTests.cs
+++ b/languages/csharp/exercises/concept/flag-enums/FlagEnumsTests.cs
@@ -3,90 +3,134 @@ using Xunit;
 public class PermissionsTests
 {
     [Fact]
-    public void DefaultForGuest() =>
+    public void DefaultForGuest()
+    {
         Assert.Equal(Permission.Read, Permissions.Default(AccountType.Guest));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DefaultForUser() =>
+    public void DefaultForUser()
+    {
         Assert.Equal(Permission.Read | Permission.Write, Permissions.Default(AccountType.User));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DefaultForModerator() =>
+    public void DefaultForModerator()
+    {
         Assert.Equal(Permission.Read | Permission.Write | Permission.Delete, Permissions.Default(AccountType.Moderator));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DefaultForUnknown() =>
+    public void DefaultForUnknown()
+    {
         Assert.Equal(Permission.None, Permissions.Default((AccountType)123));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void GrantReadToNone() =>
+    public void GrantReadToNone()
+    {
         Assert.Equal(Permission.Read, Permissions.Grant(Permission.None, Permission.Read));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void GrantReadToRead() =>
+    public void GrantReadToRead()
+    {
         Assert.Equal(Permission.Read, Permissions.Grant(Permission.Read, Permission.Read));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void GrantAllToNone() =>
+    public void GrantAllToNone()
+    {
         Assert.Equal(Permission.All, Permissions.Grant(Permission.None, Permission.All));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void GrantDeleteToReadAndWrite() =>
+    public void GrantDeleteToReadAndWrite()
+    {
         Assert.Equal(Permission.All, Permissions.Grant(Permission.Read | Permission.Write, Permission.Delete));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void GrantReadAndWriteToNone() =>
+    public void GrantReadAndWriteToNone()
+    {
         Assert.Equal(Permission.Read | Permission.Write, Permissions.Grant(Permission.None, Permission.Read | Permission.Write));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RevokeNoneFromRead() =>
+    public void RevokeNoneFromRead()
+    {
         Assert.Equal(Permission.Read, Permissions.Revoke(Permission.Read, Permission.None));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RevokeWriteFromWrite() =>
+    public void RevokeWriteFromWrite()
+    {
         Assert.Equal(Permission.None, Permissions.Revoke(Permission.Write, Permission.Write));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RevokeDeleteFromAll() =>
+    public void RevokeDeleteFromAll()
+    {
         Assert.Equal(Permission.Read | Permission.Write, Permissions.Revoke(Permission.All, Permission.Delete));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RevokeReadAndWriteFromWriteAndDelete() =>
+    public void RevokeReadAndWriteFromWriteAndDelete()
+    {
         Assert.Equal(Permission.Delete, Permissions.Revoke(Permission.Write | Permission.Delete, Permission.Read | Permission.Write));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RevokeAllFromReadAndWrite() =>
+    public void RevokeAllFromReadAndWrite()
+    {
         Assert.Equal(Permission.None, Permissions.Revoke(Permission.Read | Permission.Write, Permission.All));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckNoneForRead() =>
+    public void CheckNoneForRead()
+    {
         Assert.False(Permissions.Check(Permission.None, Permission.Read));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckWriteForWrite() =>
+    public void CheckWriteForWrite()
+    {
         Assert.True(Permissions.Check(Permission.Write, Permission.Write));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckAllForWrite() =>
+    public void CheckAllForWrite()
+    {
         Assert.True(Permissions.Check(Permission.All, Permission.Write));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckReadAndWriteForRead() =>
+    public void CheckReadAndWriteForRead()
+    {
         Assert.True(Permissions.Check(Permission.Read | Permission.Write, Permission.Read));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckAllForReadAndWrite() =>
+    public void CheckAllForReadAndWrite()
+    {
         Assert.True(Permissions.Check(Permission.Read | Permission.Write, Permission.Read | Permission.Write));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckReadAndWriteForReadAndWrite() =>
+    public void CheckReadAndWriteForReadAndWrite()
+    {
         Assert.True(Permissions.Check(Permission.Read | Permission.Write, Permission.Read | Permission.Write));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckReadAndWriteForReadAndDelete() =>
+    public void CheckReadAndWriteForReadAndDelete()
+    {
         Assert.False(Permissions.Check(Permission.Read | Permission.Write, Permission.Read | Permission.Delete));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckReadAndWriteAndDeleteForAll() =>
+    public void CheckReadAndWriteAndDeleteForAll()
+    {
         Assert.True(Permissions.Check(Permission.Read | Permission.Write | Permission.Delete, Permission.All));
+    }
 }

--- a/languages/csharp/exercises/concept/floating-point-numbers/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/floating-point-numbers/.meta/Example.cs
@@ -5,13 +5,19 @@ public static class SavingsAccount
     public static float InterestRate(decimal balance)
     {
         if (balance < 0.0m)
+        {
             return -3.213f;
+        }
 
         if (balance < 1000.0m)
+        {
             return 0.5f;
+        }
 
         if (balance < 5000.0m)
+        {
             return 1.621f;
+        }
 
         return 2.475f;
     }
@@ -22,8 +28,10 @@ public static class SavingsAccount
         return Math.Abs(balance) * multiplier;
     }
 
-    public static decimal AnnualBalanceUpdate(decimal balance) =>
-        balance + AnnualYield(balance);
+    public static decimal AnnualBalanceUpdate(decimal balance)
+    {
+        return balance + AnnualYield(balance);
+    }
 
     public static int YearsBeforeDesiredBalance(decimal balance, decimal targetBalance)
     {

--- a/languages/csharp/exercises/concept/floating-point-numbers/FloatingPointNumbersTests.cs
+++ b/languages/csharp/exercises/concept/floating-point-numbers/FloatingPointNumbersTests.cs
@@ -3,98 +3,146 @@ using Xunit;
 public class SavingsAccountTests
 {
     [Fact]
-    public void MinimalFirstInterestRate() =>
+    public void MinimalFirstInterestRate()
+    {
         Assert.Equal(0.5f, SavingsAccount.InterestRate(0m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TinyFirstInterestRate() =>
+    public void TinyFirstInterestRate()
+    {
         Assert.Equal(0.5f, SavingsAccount.InterestRate(0.000001m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void MaximumFirstInterestRate() =>
+    public void MaximumFirstInterestRate()
+    {
         Assert.Equal(0.5f, SavingsAccount.InterestRate(999.9999m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void MinimalSecondInterestRate() =>
+    public void MinimalSecondInterestRate()
+    {
         Assert.Equal(1.621f, SavingsAccount.InterestRate(1_000.0m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TinySecondInterestRate() =>
+    public void TinySecondInterestRate()
+    {
         Assert.Equal(1.621f, SavingsAccount.InterestRate(1_000.0001m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void MaximumSecondInterestRate() =>
+    public void MaximumSecondInterestRate()
+    {
         Assert.Equal(1.621f, SavingsAccount.InterestRate(4_999.9990m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void MinimalThirdInterestRate() =>
+    public void MinimalThirdInterestRate()
+    {
         Assert.Equal(2.475f, SavingsAccount.InterestRate(5_000.0000m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TinyThirdInterestRate() =>
+    public void TinyThirdInterestRate()
+    {
         Assert.Equal(2.475f, SavingsAccount.InterestRate(5_000.0001m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void LargeThirdInterestRate() =>
+    public void LargeThirdInterestRate()
+    {
         Assert.Equal(2.475f, SavingsAccount.InterestRate(5_639_998.742909m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void MinimalNegativeInterestRate() =>
+    public void MinimalNegativeInterestRate()
+    {
         Assert.Equal(-3.213f, SavingsAccount.InterestRate(-0.000001m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void SmallNegativeInterestRate() =>
+    public void SmallNegativeInterestRate()
+    {
         Assert.Equal(-3.213f, SavingsAccount.InterestRate(-0.123m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RegularNegativeInterestRate() =>
+    public void RegularNegativeInterestRate()
+    {
         Assert.Equal(-3.213f, SavingsAccount.InterestRate(-300.0m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void LargeNegativeInterestRate() =>
+    public void LargeNegativeInterestRate()
+    {
         Assert.Equal(-3.213f, SavingsAccount.InterestRate(-152964.231m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForEmptyStartBalance() =>
+    public void AnnualBalanceUpdateForEmptyStartBalance()
+    {
         Assert.Equal(0.0000m, SavingsAccount.AnnualBalanceUpdate(0.0m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForSmallPositiveStartBalance() =>
+    public void AnnualBalanceUpdateForSmallPositiveStartBalance()
+    {
         Assert.Equal(0.000001005m, SavingsAccount.AnnualBalanceUpdate(0.000001m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForAveragePositiveStartBalance() =>
+    public void AnnualBalanceUpdateForAveragePositiveStartBalance()
+    {
         Assert.Equal(1016.210000m, SavingsAccount.AnnualBalanceUpdate(1_000.0m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForLargePositiveStartBalance() =>
+    public void AnnualBalanceUpdateForLargePositiveStartBalance()
+    {
         Assert.Equal(1016.210101621m, SavingsAccount.AnnualBalanceUpdate(1_000.0001m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForHugePositiveStartBalance() =>
+    public void AnnualBalanceUpdateForHugePositiveStartBalance()
+    {
         Assert.Equal(920352587.26744292868451875m, SavingsAccount.AnnualBalanceUpdate(898124017.826243404425m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForSmallNegativeStartBalance() =>
+    public void AnnualBalanceUpdateForSmallNegativeStartBalance()
+    {
         Assert.Equal(-0.12695199m, SavingsAccount.AnnualBalanceUpdate(-0.123m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForLargeNegativeStartBalance() =>
+    public void AnnualBalanceUpdateForLargeNegativeStartBalance()
+    {
         Assert.Equal(-157878.97174203m, SavingsAccount.AnnualBalanceUpdate(-152964.231m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void YearsBeforeDesiredBalanceForSmallStartBalance() =>
+    public void YearsBeforeDesiredBalanceForSmallStartBalance()
+    {
         Assert.Equal(47, SavingsAccount.YearsBeforeDesiredBalance(100.0m, 125.80m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void YearsBeforeDesiredBalanceForAverageStartBalance() =>
+    public void YearsBeforeDesiredBalanceForAverageStartBalance()
+    {
         Assert.Equal(6, SavingsAccount.YearsBeforeDesiredBalance(1_000.0m, 1_100.0m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void YearsBeforeDesiredBalanceForLargeStartBalance() =>
+    public void YearsBeforeDesiredBalanceForLargeStartBalance()
+    {
         Assert.Equal(5, SavingsAccount.YearsBeforeDesiredBalance(8_080.80m, 9_090.90m));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void YearsBeforeDesiredBalanceForLargeDifferentBetweenStartAndTargetBalance() =>
+    public void YearsBeforeDesiredBalanceForLargeDifferentBetweenStartAndTargetBalance()
+    {
         Assert.Equal(85, SavingsAccount.YearsBeforeDesiredBalance(2_345.67m, 12_345.6789m));
+    }
 }

--- a/languages/csharp/exercises/concept/numbers/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/numbers/.meta/Example.cs
@@ -2,25 +2,37 @@ public static class AssemblyLine
 {
     private const int ProductionRatePerHourForDefaultSpeed = 221;
 
-    public static double ProductionRatePerHour(int speed) =>
-        ProductionRatePerHourForSpeed(speed) * SuccessRate(speed);
+    public static double ProductionRatePerHour(int speed)
+    {
+        return ProductionRatePerHourForSpeed(speed) * SuccessRate(speed);
+    }
 
-    private static int ProductionRatePerHourForSpeed(int speed) =>
-        ProductionRatePerHourForDefaultSpeed * speed;
+    private static int ProductionRatePerHourForSpeed(int speed)
+    {
+        return ProductionRatePerHourForDefaultSpeed * speed;
+    }
 
-    public static int WorkingItemsPerMinute(int speed) =>
-        (int)(ProductionRatePerHour(speed) / 60);
+    public static int WorkingItemsPerMinute(int speed)
+    {
+        return (int)(ProductionRatePerHour(speed) / 60);
+    }
 
     private static double SuccessRate(int speed)
     {
         if (speed == 10)
+        {
             return 0.77;
+        }
 
         if (speed == 9)
+        {
             return 0.8;
+        }
 
         if (speed >= 5)
+        {
             return 0.9;
+        }
 
         return 1;
     }

--- a/languages/csharp/exercises/concept/numbers/NumbersTests.cs
+++ b/languages/csharp/exercises/concept/numbers/NumbersTests.cs
@@ -3,50 +3,74 @@ using Xunit;
 public class AssemblyLineTests
 {
     [Fact]
-    public void ProductionRatePerHourForSpeedZero() =>
+    public void ProductionRatePerHourForSpeedZero()
+    {
         Assert.Equal(0.0, AssemblyLine.ProductionRatePerHour(0));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ProductionRatePerHourForSpeedOne() =>
+    public void ProductionRatePerHourForSpeedOne()
+    {
         Assert.Equal(221.0, AssemblyLine.ProductionRatePerHour(1));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ProductionRatePerHourForSpeedFour() =>
+    public void ProductionRatePerHourForSpeedFour()
+    {
         Assert.Equal(884.0, AssemblyLine.ProductionRatePerHour(4));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ProductionRatePerHourForSpeedSeven() =>
+    public void ProductionRatePerHourForSpeedSeven()
+    {
         Assert.Equal(1392.3, AssemblyLine.ProductionRatePerHour(7));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ProductionRatePerHourForSpeedNine() =>
+    public void ProductionRatePerHourForSpeedNine()
+    {
         Assert.Equal(1591.2, AssemblyLine.ProductionRatePerHour(9));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ProductionRatePerHourForSpeedTen() =>
+    public void ProductionRatePerHourForSpeedTen()
+    {
         Assert.Equal(1701.7, AssemblyLine.ProductionRatePerHour(10));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WorkingItemsPerMinuteForSpeedZero() =>
+    public void WorkingItemsPerMinuteForSpeedZero()
+    {
         Assert.Equal(0, AssemblyLine.WorkingItemsPerMinute(0));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WorkingItemsPerMinuteForSpeedOne() =>
+    public void WorkingItemsPerMinuteForSpeedOne()
+    {
         Assert.Equal(3, AssemblyLine.WorkingItemsPerMinute(1));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WorkingItemsPerMinuteForSpeedFive() =>
+    public void WorkingItemsPerMinuteForSpeedFive()
+    {
         Assert.Equal(16, AssemblyLine.WorkingItemsPerMinute(5));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WorkingItemsPerMinuteForSpeedEight() =>
+    public void WorkingItemsPerMinuteForSpeedEight()
+    {
         Assert.Equal(26, AssemblyLine.WorkingItemsPerMinute(8));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WorkingItemsPerMinuteForSpeedNine() =>
+    public void WorkingItemsPerMinuteForSpeedNine()
+    {
         Assert.Equal(26, AssemblyLine.WorkingItemsPerMinute(9));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WorkingItemsPerMinuteForSpeedTen() =>
+    public void WorkingItemsPerMinuteForSpeedTen()
+    {
         Assert.Equal(28, AssemblyLine.WorkingItemsPerMinute(10));
+    }
 }

--- a/languages/csharp/exercises/concept/properties/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/properties/.meta/Example.cs
@@ -5,15 +5,20 @@ public enum Units
     Pounds,
     Kilograms
 }
+
 public class WeighingMachine
 {
     private const decimal POUNDS_PER_KILOGRAM = 2.20462m;
     private decimal inputWeight;
 
     public Units Units { get; set; } = Units.Kilograms;
+
     public decimal InputWeight
     {
-        get { return inputWeight; }
+        get
+        {
+            return inputWeight;
+        }
         set
         {
             if (value < 0)
@@ -27,7 +32,10 @@ public class WeighingMachine
 
     public decimal DisplayWeight
     {
-        get { return ApplyTareAdjustment(inputWeight); }
+        get
+        {
+            return ApplyTareAdjustment(inputWeight);
+        }
     }
     public USWeight USDisplayWeight
     {

--- a/languages/csharp/exercises/concept/strings/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/strings/.meta/Example.cs
@@ -1,11 +1,17 @@
 public static class LogLine
 {
-    public static string Message(string logLine) =>
-        logLine.Substring(logLine.IndexOf(":") + 1).Trim();
+    public static string Message(string logLine)
+    {
+        return logLine.Substring(logLine.IndexOf(":") + 1).Trim();
+    }
 
-    public static string LogLevel(string logLine) =>
-        logLine.Substring(1, logLine.IndexOf("]")).ToLower();
+    public static string LogLevel(string logLine)
+    {
+        return logLine.Substring(1, logLine.IndexOf("]")).ToLower();
+    }
 
-    public static string Reformat(string logLine) =>
-        $"{Message(logLine)} ({LogLevel(logLine)})";
+    public static string Reformat(string logLine)
+    {
+        return $"{Message(logLine)} ({LogLevel(logLine)})";
+    }
 }

--- a/languages/csharp/exercises/concept/strings/StringsTests.cs
+++ b/languages/csharp/exercises/concept/strings/StringsTests.cs
@@ -3,46 +3,68 @@ using Xunit;
 public class LogLineTests
 {
     [Fact]
-    public void ErrorMessage() =>
+    public void ErrorMessage()
+    {
         Assert.Equal("Stack overflow", LogLine.Message("[ERROR]: Stack overflow"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WarningMessage() =>
+    public void WarningMessage()
+    {
         Assert.Equal("Disk almost full", LogLine.Message("[WARNING]: Disk almost full"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void InfoMessage() =>
+    public void InfoMessage()
+    {
         Assert.Equal("File moved", LogLine.Message("[INFO]: File moved"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void MessageWithLeadingAndTrailingWhiteSpace() =>
+    public void MessageWithLeadingAndTrailingWhiteSpace()
+    {
         Assert.Equal("Timezone not set", LogLine.Message("[WARNING]:   \tTimezone not set  \r\n"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ErrorLogLevel() =>
+    public void ErrorLogLevel()
+    {
         Assert.Equal("error", LogLine.LogLevel("[ERROR]: Disk full"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WarningLogLevel() =>
+    public void WarningLogLevel()
+    {
         Assert.Equal("warning", LogLine.LogLevel("[WARNING]: Unsafe password"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void InfoLogLevel() =>
+    public void InfoLogLevel()
+    {
         Assert.Equal("info", LogLine.LogLevel("[INFO]: Timezone changed"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ErrorReformat() =>
+    public void ErrorReformat()
+    {
         Assert.Equal("Segmentation fault (error)", LogLine.Reformat("[ERROR]: Segmentation fault"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WarningReformat() =>
+    public void WarningReformat()
+    {
         Assert.Equal("Decreased performance (warning)", LogLine.Reformat("[WARNING]: Decreased performance"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void InfoReformat() =>
+    public void InfoReformat()
+    {
         Assert.Equal("Disk defragmented (info)", LogLine.Reformat("[INFO]: Disk defragmented"));
+    }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ReformatWithLeadingAndTrailingWhiteSpace() =>
+    public void ReformatWithLeadingAndTrailingWhiteSpace()
+    {
         Assert.Equal("Corrupt disk (error)", LogLine.Reformat("[ERROR]: \t Corrupt disk\t \t \r\n"));
+    }
 }


### PR DESCRIPTION
Many of the examples and all the tests were using expression-bodied methods. However, the example files will be used as canonical examples on how we expect the student to solve the exercise, and the student is not guaranteed to know about expression-bodied members at this point (there _will_ be an expression-bodied members exercise, but not at this point in the curriculum).

Similarly, the test files will be downloaded to a student's machine if using the CLI, so we write them in a format that students should at least be able to understand.