### PR TITLE
[Haskell] Shared docs CLI and Debug

### DIFF
--- a/languages/haskell/exercises/shared/.docs/README.md
+++ b/languages/haskell/exercises/shared/.docs/README.md
@@ -1,0 +1,9 @@
+# Haskell shared exercise documents
+
+There are two documents that are shared between all exercises:
+
+- [cli.md][cli]: contains information on how to work with the exercise when using the CLI to download and submit the exercise.
+- [debug.md][debug]: explains how a student that is coding in the browser can still do "debugging."
+
+[cli]: ./cli.md
+[debug]: ./debug.md

--- a/languages/haskell/exercises/shared/.docs/cli.md
+++ b/languages/haskell/exercises/shared/.docs/cli.md
@@ -1,6 +1,6 @@
 # CLI
 
-You can run the tests by opening a command prompt in the exercise's directory, and then running the [`stack test` command][docs-stack-test]. If your code compiles this command will
+You can run the tests by opening a command prompt in the exercise's directory, and then running the [`stack test` command][docs-stack-test]. If your code compiles this command will show you which tests passed and which failed - when a test fails the rest might not be executed so just focus on making tests pass one by one.
 
 Once all the tests are passing, you can submit your solution by opening a command prompt in the exercise's directory and running the [`exercism submit` command][docs-exercism-cli].
 

--- a/languages/haskell/exercises/shared/.docs/cli.md
+++ b/languages/haskell/exercises/shared/.docs/cli.md
@@ -1,0 +1,8 @@
+# CLI
+
+You can run the tests by opening a command prompt in the exercise's directory, and then running the [`stack test` command][docs-stack-test]. If your code compiles this command will
+
+Once all the tests are passing, you can submit your solution by opening a command prompt in the exercise's directory and running the [`exercism submit` command][docs-exercism-cli].
+
+[docs-stack-test]: https://docs.haskellstack.org/en/stable/build_command/
+[docs-exercism-cli]: https://exercism.io/cli

--- a/languages/haskell/exercises/shared/.docs/cli.md
+++ b/languages/haskell/exercises/shared/.docs/cli.md
@@ -1,6 +1,6 @@
 # CLI
 
-You can run the tests by opening a command prompt in the exercise's directory, and then running the [`stack test` command][docs-stack-test]. If your code compiles this command will show you which tests passed and which failed - when a test fails the rest might not be executed so just focus on making tests pass one by one.
+You can run the tests by opening a command prompt in the exercise's directory, and then running the [`stack test` command][docs-stack-test]. If your code compiles, this command will show you which tests passed and which failed - when a test fails try to make it pass and execute tests again.
 
 Once all the tests are passing, you can submit your solution by opening a command prompt in the exercise's directory and running the [`exercism submit` command][docs-exercism-cli].
 

--- a/languages/haskell/exercises/shared/.docs/debug.md
+++ b/languages/haskell/exercises/shared/.docs/debug.md
@@ -1,5 +1,5 @@
 # Debug
 
-When a test fails or your code doesn't compile when running tests there will be an error shown in the console. If it's not helpful you can run the [`stack ghci` command] [docs-stack-ghci] and enter the interactive REPL.
+When a test fails or your code doesn't compile when running tests there will be an error shown in the console. If it's not helpful you can run the [`stack ghci` command][docs-stack-ghci] and enter the interactive REPL.
 
 [docs-stack-ghci]: todo

--- a/languages/haskell/exercises/shared/.docs/debug.md
+++ b/languages/haskell/exercises/shared/.docs/debug.md
@@ -1,5 +1,6 @@
 # Debug
 
-When a test fails or your code doesn't compile when running tests there will be an error shown in the console. If it's not helpful you can run the [`stack ghci` command][docs-stack-ghci] and enter the interactive REPL.
+When a test fails or your code doesn't compile there will be an error shown in the console. If it's not helpful you can run the [`stack ghci` command][docs-stack-ghci] and enter the [interactive REPL][docs-ghci]. There you can try out your functions and experiment until you understand how to correct your code.
 
-[docs-stack-ghci]: todo
+[docs-stack-ghci]: https://docs.haskellstack.org/en/stable/ghci/
+[docs-ghci]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/ghci.html

--- a/languages/haskell/exercises/shared/.docs/debug.md
+++ b/languages/haskell/exercises/shared/.docs/debug.md
@@ -1,0 +1,5 @@
+# Debug
+
+When a test fails or your code doesn't compile when running tests there will be an error shown in the console. If it's not helpful you can run the [`stack ghci` command] [docs-stack-ghci] and enter the interactive REPL.
+
+[docs-stack-ghci]: todo


### PR DESCRIPTION
This is regarding #544  
Let me know if I can improve something. 
I had a doubt regarding the debugging part after I copied the README file from C# and it mentions debugging in browser. I don't know how the browser experience will look for Haskell so I wrote how I would debug the Haskell exercises in current version of Exercism.