### PR TITLE
[Elixir] Typo in README.md

### DIFF
--- a/languages/elixir/exercises/concept/README.md
+++ b/languages/elixir/exercises/concept/README.md
@@ -16,7 +16,7 @@ It's only important that it's reasonably easy to _find_ the exercise. It's okay 
 
 ## Contributing
 
-Thanks for wanting to contribute to the Go track's concept exercises! Contributions are very welcome!
+Thanks for wanting to contribute to the Elixir track's concept exercises! Contributions are very welcome!
 
 To contribute, please find and work on one of the [new exercise issues][issues-new-exercise] or [improve exercise issues][issues-improve-exercise].
 


### PR DESCRIPTION
Fixes a typo in the `exercises/concept/README.md`