### PR TITLE
[CI] JSON validation needs `**/**/` in glob path

### DIFF
--- a/.github/bin/validate_json.py
+++ b/.github/bin/validate_json.py
@@ -5,7 +5,7 @@ import json
 import sys
 
 def get_files():
-  return glob.glob('**/*.json', recursive=True)
+  return glob.glob('**/**/*.json', recursive=True)
 
 def validate_files(files):
   return [report for report in (validate_json_file(file) for file in files) if report != None]


### PR DESCRIPTION
Found a typo in the python script, needs the extra `**/` to correctly expand to all directories.

Sorry.