### PR TITLE
[Rust] remove testing from concepts.csv

### DIFF
--- a/languages/rust/reference/concepts.csv
+++ b/languages/rust/reference/concepts.csv
@@ -1,5 +1,4 @@
 concept,category
-test-suites,fundamentals
 variable-assignment,fundamentals
 conditionals,fundamentals
 slices,fundamentals


### PR DESCRIPTION
Test driven development is out of scope for the Rust track.
See
https://github.com/exercism/v3/blob/master/languages/rust/reference/out-of-scope.md
for other examples.