### PR TITLE
[CI] Fix escaping in markdown formatting match

### DIFF
--- a/.github/workflows/verify-markdown-formatting.yml
+++ b/.github/workflows/verify-markdown-formatting.yml
@@ -1,21 +1,21 @@
-name: "Verify Markdown formatting"
+name: 'Verify Markdown formatting'
 
 on:
   push:
     paths:
-      - "**.md"
+      - '**.md'
   pull_request:
     paths:
-      - "**.md"
+      - '**.md'
 
 jobs:
   verify-markdown-formatting:
     runs-on: [ubuntu-latest]
     steps:
-      - name: "Checkout code"
+      - name: 'Checkout code'
         uses: actions/checkout@v2
 
-      - name: "Verify formatting of all Markdown files"
+      - name: 'Verify formatting of all Markdown files'
         if: github.ref == 'refs/heads/master'
         run: npx prettier@2.0.4 --check "**/*.md"
 
@@ -24,5 +24,5 @@ jobs:
         run: |
           PULL_REQUEST_URL=$(jq -r ".pull_request.url" "$GITHUB_EVENT_PATH")
           curl --url $"${PULL_REQUEST_URL}/files" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | \
-            jq -c '.[] | select(.status == "added" or .status == "modified") | select(.filename | match(".md$")) | .filename' | \
+            jq -c '.[] | select(.status == "added" or .status == "modified") | select(.filename | match("\\.md$")) | .filename' | \
             xargs npx prettier@2.0.4 --write


### PR DESCRIPTION
The filtering used `.md` to filter, but it should have been `\\.md`