### PR TITLE
[Emacs Lisp] Fix Markdown formatting from old merge

### DIFF
--- a/languages/_sidebar.md
+++ b/languages/_sidebar.md
@@ -31,4 +31,3 @@
   - [Paradigms](/reference/paradigms/README.md)
   - [Tooling](/reference/tooling/README.md)
   - [Types](/reference/types/README.md)
-  

--- a/languages/emacs-lisp/_sidebar.md
+++ b/languages/emacs-lisp/_sidebar.md
@@ -1,4 +1,5 @@
 [Start here](/)
+
 - Docs
 - [Languages](/languages/README.md)
   - [Emacs Lisp](/languages/emacs-lisp/README.md)

--- a/languages/emacs-lisp/reference/README.md
+++ b/languages/emacs-lisp/reference/README.md
@@ -24,6 +24,7 @@ The core features a Emacs Lisp developer should know about are:
 #### Generic
 
 =======
+
 - Special forms
 - Atoms
 - Quote
@@ -67,7 +68,6 @@ The core features a Emacs Lisp developer should know about are:
 - Process
 - Text
 
-
 [evaluation]: ../../../reference/concepts/evaluation.md
 [functions]: ../../../reference/concepts/functions.md
 [variables]: ../../../reference/concepts/variables.md
@@ -81,7 +81,6 @@ The core features a Emacs Lisp developer should know about are:
 ### Concepts
 
 #### General
-
 
 - [Evaluation][evaluation]
 - [Interactive and non interactive functions][functions]
@@ -104,7 +103,7 @@ The core features a Emacs Lisp developer should know about are:
 - S-expressions
 - Arguments
 - Defcustom
-- Autoloading 
+- Autoloading
 - Byte compilation
 - Hooks
 - Minor modes
@@ -125,5 +124,5 @@ The core features a Emacs Lisp developer should know about are:
 [conditionals]: ../../../reference/concepts/conditionals.md
 [comments]: ../../../reference/concepts/comments.md
 [boolean_logic]: ../../../reference/concepts/boolean_logic.md
-[anonymous_functions]: ../../../reference/concepts/anonymous_functions.md
-=======
+
+# [anonymous_functions]: ../../../reference/concepts/anonymous_functions.md


### PR DESCRIPTION
In merging #908 and #967, Markdown formatting CI runs failed due to the PRs existing before these formatting checks were run. This PR runs `npx prettier@2.0.4 --write "**/*.md"` to fix these files.