### PR TITLE
[Docs] Add status/wontfix label

### DIFF
--- a/docs/maintainers/repository-structure.md
+++ b/docs/maintainers/repository-structure.md
@@ -52,6 +52,7 @@ The following labels are used to categorize [issues in the v3 repository][github
 - [status/help-wanted][github-issues-status-help-wanted]: Extra attention is needed
 - [status/in-progress][github-issues-status-in-progress]: This issue is being worked on
 - [status/draft][github-issues-status-draft]: This issue or pull request is a draft, and not ready for review/merge.
+- [status/wontfix][github-issues-status-wontfix]: This issue or pull request is out of scope and will not be fixed. 
 - [about/v3-roadmap][github-issues-type-v3-roadmap]: Everything related to the v3 roadmap.
 - [good-first-issue][github-issues-type-good-first-issue]: Marks an issue as good for newcomers.
 
@@ -109,6 +110,7 @@ You can combine labels to find the issues you'd like, e.g. to [list all the issu
 [github-issues-status-help-wanted]: https://github.com/exercism/v3/issues?q=is%3Aissue+is%3Aopen+label%3Astatus%2Fhelp-wanted
 [github-issues-status-in-progress]: https://github.com/exercism/v3/issues?q=is%3Aopen+is%3Aissue+label%3Astatus%2Fin-progress
 [github-issues-status-draft]: https://github.com/exercism/v3/issues?q=is%3Aopen+is%3Aissue+label%3Astatus%2Fdraft
+[status/wontfix]: https://github.com/exercism/v3/issues?q=is%3Aclosed+is%3Aissue+label%3Astatus%2Fwontfix
 [github-issues-type-v3-roadmap]: https://github.com/exercism/v3/labels/about%2Fv3-roadmap
 [github-issues-type-good-first-issue]: https://github.com/exercism/v3/labels/good%20first%20issue
 [github-issues-track-go]: https://github.com/exercism/v3/issues?q=is%3Aissue+is%3Aopen+label%3Atrack%2Fgo


### PR DESCRIPTION
Motivation: Sometimes it turns out that an exercise idea doesn't work, or that a concept should not be taught. This status allows one to tell apart such issues/PRs from issues/PRs that have been closed due to being fixed or abandoned.