### PR TITLE
Remove ref. to common lisp track.

### DIFF
--- a/reference/concepts/assignment.md
+++ b/reference/concepts/assignment.md
@@ -23,13 +23,11 @@ This exercise deals with cooking a lasagna dish in the oven. The reference imple
 | Track       | Exercise                             | Changes                                          |
 | ----------- | ------------------------------------ | ------------------------------------------------ |
 | C#          | [basics][implementation-csharp]      | None                                             |
-| Common Lisp | [basics][implementation-common-lisp] | There is no updating of a variable               |
 | Elixir      | [basics][implementation-elixir]      | Introduces binding values rather than assignment |
 | F#          | [basics][implementation-fsharp]      | There is no updating of a variable               |
 | Ruby        | [basics][implementation-ruby]        |                                                  |
 
 [implementation-csharp]: ../../languages/csharp/exercises/concept/basics/.docs/introduction.md
-[implementation-common-lisp]: ../../languages/common-lisp/exercises/concept/basics/.docs/introduction.md
 [implementation-elixir]: ../../languages/elixir/exercises/concept/basics/.docs/introduction.md
 [implementation-fsharp]: ../../languages/fsharp/exercises/concept/basics/.docs/introduction.md
 [implementation-ruby]: ../../languages/ruby/exercises/concept/basics/.docs/introduction.md


### PR DESCRIPTION
The common lisp track does not have an exercise about assignment as ofyet.

I think it was simply mistakenly added in #1158.