### PR TITLE
Simplify concept lists - removing separate "loop"

### DIFF
--- a/languages/common-lisp/reference/README.md
+++ b/languages/common-lisp/reference/README.md
@@ -64,13 +64,6 @@ A more formal, machine-readable version of this concept list exists as
   - Miscellaneous
   - Numbers
   - Tables
-- Loop
-  - Basic
-  - Collecting
-  - Miscellaneous
-  - Ranges
-  - Tests
-  - Traversal
 
 ### CLOS (Needs Some Work)
 

--- a/languages/common-lisp/reference/concepts.csv
+++ b/languages/common-lisp/reference/concepts.csv
@@ -23,12 +23,6 @@ format.language, dsls
 format.miscellaneous, dsls
 format.numbers, dsls
 format.tables, dsls
-loop.basic, dsls
-loop.collecting, dsls
-loop.miscellaneous, dsls
-loop.ranges, dsls
-loop.tests, dsls
-loop.traversal, dsls
 classes, clos
 generic-functions, clos
 methods, clos


### PR DESCRIPTION
The enumerate concept exercise will focus on the basics of `loop` and
will discuss in its after other parts of `loop` as well as `do`.  It
does not seem that an extensive breakdown of `loop` as a concept is
needed anymore.