### PR TITLE
[C#] Simplify classes

### DIFF
--- a/languages/csharp/exercises/concept/arrays/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/arrays/.meta/Example.cs
@@ -1,6 +1,6 @@
 using System;
 
-public class BirdCount
+class BirdCount
 {
     private int[] birdsPerDay;
 

--- a/languages/csharp/exercises/concept/arrays/Arrays.cs
+++ b/languages/csharp/exercises/concept/arrays/Arrays.cs
@@ -1,6 +1,6 @@
 using System;
 
-public class BirdCount
+class BirdCount
 {
     private int[] birdsPerDay;
 

--- a/languages/csharp/exercises/concept/datetimes/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/datetimes/.meta/Example.cs
@@ -1,6 +1,6 @@
 using System;
 
-public static class Appointment
+static class Appointment
 {
     public static DateTime Schedule(string appointmentDateDescription)
     {

--- a/languages/csharp/exercises/concept/datetimes/DateTimes.cs
+++ b/languages/csharp/exercises/concept/datetimes/DateTimes.cs
@@ -1,6 +1,6 @@
 using System;
 
-public static class Appointment
+static class Appointment
 {
     public static DateTime Schedule(string appointmentDateDescription)
     {

--- a/languages/csharp/exercises/concept/enums/.docs/after.md
+++ b/languages/csharp/exercises/concept/enums/.docs/after.md
@@ -3,7 +3,7 @@ You can use an enum whenever you have a fixed set of constant values. Using an e
 Each enum member has an associated integer value associated with it. If no value is explicitly defined for an enum member, its value is automatically assigned to `1` plus + the previous member's value. If the first member does not have an explicit value, its value is set to `0`.
 
 ```csharp
-public enum Season
+enum Season
 {
     Spring,     // Value is 0
     Summer = 2, // Value is 2
@@ -26,7 +26,7 @@ You should always consider using an enum whenever you want to model something as
 Note that while one _can_ cast integer values to an enum, doing so can lead to unexpected results when the integer value doesn't map to any enum value:
 
 ```csharp
-public enum Status
+enum Status
 {
     Inactive = 0,
     Active = 1

--- a/languages/csharp/exercises/concept/enums/.docs/introduction.md
+++ b/languages/csharp/exercises/concept/enums/.docs/introduction.md
@@ -1,7 +1,7 @@
 The C# `enum` type represents a fixed set of named constants (an enumeration). Its chief purpose is to provide a type-safe way of interacting with numeric constants, limiting the available values to a pre-defined set. A simple enum can be defined as follows:
 
 ```csharp
-public enum Season
+enum Season
 {
     Spring,
     Summer,
@@ -13,7 +13,7 @@ public enum Season
 If not defined explicitly, enum members will automatically get assigned incrementing integer values, with the first value being zero. It is also possible to assign values explicitly:
 
 ```csharp
-public enum Answer
+enum Answer
 {
     Maybe = 1,
     Yes = 3,

--- a/languages/csharp/exercises/concept/enums/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/enums/.meta/Example.cs
@@ -1,4 +1,4 @@
-public enum LogLevel
+enum LogLevel
 {
     Trace = 0,
     Debug = 1,

--- a/languages/csharp/exercises/concept/enums/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/enums/.meta/Example.cs
@@ -9,7 +9,7 @@ enum LogLevel
     Unknown = 42
 }
 
-public static class LogLine
+static class LogLine
 {
     public static LogLevel ParseLogLevel(string logLine)
     {

--- a/languages/csharp/exercises/concept/enums/Enums.cs
+++ b/languages/csharp/exercises/concept/enums/Enums.cs
@@ -2,7 +2,7 @@ using System;
 
 // TODO: define LogLevel enum
 
-public static class LogLine
+static class LogLine
 {
     public static LogLevel ParseLogLevel(string logLine)
     {

--- a/languages/csharp/exercises/concept/flag-enums/.docs/after.md
+++ b/languages/csharp/exercises/concept/flag-enums/.docs/after.md
@@ -2,7 +2,7 @@ To allow a single enum instance to represent multiple values (usually referred t
 
 ```csharp
 [Flags]
-public enum PhoneFeatures
+enum PhoneFeatures
 {
     Call = 1,
     Text = 2
@@ -13,14 +13,14 @@ Besides using regular integers to set the flag enum members' values, one can als
 
 ```csharp
 [Flags]
-public enum PhoneFeaturesBinary
+enum PhoneFeaturesBinary
 {
     Call = 0b00000001,
     Text = 0b00000010
 }
 
 [Flags]
-public enum PhoneFeaturesBitwiseShift
+enum PhoneFeaturesBitwiseShift
 {
     Call = 1 << 0,
     Text = 1 << 1
@@ -31,7 +31,7 @@ An enum member's value can refer to other enum members values:
 
 ```csharp
 [Flags]
-public enum PhoneFeatures
+enum PhoneFeatures
 {
     Call = 0b00000001,
     Text = 0b00000010,
@@ -71,7 +71,7 @@ By default, the `int` type is used for enum member values. One can use a differe
 
 ```csharp
 [Flags]
-public enum PhoneFeatures : byte
+enum PhoneFeatures : byte
 {
     Call = 0b00000001,
     Text = 0b00000010

--- a/languages/csharp/exercises/concept/flag-enums/.docs/introduction.md
+++ b/languages/csharp/exercises/concept/flag-enums/.docs/introduction.md
@@ -4,7 +4,7 @@ A flags enum can be defined as follows (using binary integer notation):
 
 ```csharp
 [Flags]
-public enum PhoneFeatures
+enum PhoneFeatures
 {
     Call = 0b00000001,
     Text = 0b00000010
@@ -33,7 +33,7 @@ By default, the `int` type is used for enum member values. One can use a differe
 
 ```csharp
 [Flags]
-public enum PhoneFeatures : byte
+enum PhoneFeatures : byte
 {
     Call = 0b00000001,
     Text = 0b00000010

--- a/languages/csharp/exercises/concept/flag-enums/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/flag-enums/.meta/Example.cs
@@ -1,6 +1,6 @@
 using System;
 
-public enum AccountType
+enum AccountType
 {
     Guest,
     User,
@@ -8,7 +8,7 @@ public enum AccountType
 }
 
 [Flags]
-public enum Permission
+enum Permission
 {
     None = 0b_0000_0000,
     Read = 0b_0000_0001,

--- a/languages/csharp/exercises/concept/flag-enums/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/flag-enums/.meta/Example.cs
@@ -17,7 +17,7 @@ enum Permission
     All = Read | Write | Delete
 }
 
-public static class Permissions
+static class Permissions
 {
     public static Permission Default(AccountType accountType)
     {

--- a/languages/csharp/exercises/concept/flag-enums/FlagEnums.cs
+++ b/languages/csharp/exercises/concept/flag-enums/FlagEnums.cs
@@ -4,7 +4,7 @@ using System;
 
 // TODO: define Permission enum
 
-public static class Permissions
+static class Permissions
 {
     public static Permission Default(AccountType accountType)
     {

--- a/languages/csharp/exercises/concept/floating-point-numbers/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/floating-point-numbers/.meta/Example.cs
@@ -1,6 +1,6 @@
 using System;
 
-public static class SavingsAccount
+static class SavingsAccount
 {
     public static float InterestRate(decimal balance)
     {

--- a/languages/csharp/exercises/concept/floating-point-numbers/FloatingPointNumbers.cs
+++ b/languages/csharp/exercises/concept/floating-point-numbers/FloatingPointNumbers.cs
@@ -1,6 +1,6 @@
 using System;
 
-public static class SavingsAccount
+static class SavingsAccount
 {
     public static float InterestRate(decimal balance)
     {

--- a/languages/csharp/exercises/concept/nullability/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/nullability/.meta/Example.cs
@@ -1,4 +1,4 @@
-public static class Badge
+static class Badge
 {
     public static string Print(int? id, string name, string? department)
     {

--- a/languages/csharp/exercises/concept/nullability/Nullability.cs
+++ b/languages/csharp/exercises/concept/nullability/Nullability.cs
@@ -1,6 +1,6 @@
 using System;
 
-public static class Badge
+static class Badge
 {
     public static string Print(int? id, string name, string? department)
     {

--- a/languages/csharp/exercises/concept/numbers/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/numbers/.meta/Example.cs
@@ -1,4 +1,4 @@
-public static class AssemblyLine
+static class AssemblyLine
 {
     private const int ProductionRatePerHourForDefaultSpeed = 221;
 

--- a/languages/csharp/exercises/concept/numbers/Numbers.cs
+++ b/languages/csharp/exercises/concept/numbers/Numbers.cs
@@ -1,6 +1,6 @@
 using System;
 
-public static class AssemblyLine
+static class AssemblyLine
 {
     public static double ProductionRatePerHour(int speed)
     {

--- a/languages/csharp/exercises/concept/properties/.docs/after.md
+++ b/languages/csharp/exercises/concept/properties/.docs/after.md
@@ -59,7 +59,7 @@ the set accessor may be ommitted completely. This is maybe because
 the value of the property is set in the class's constructor.
 
 ```csharp
-public class MyClass
+class MyClass
 {
   public MyClass( int importantValue)
   {

--- a/languages/csharp/exercises/concept/properties/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/properties/.meta/Example.cs
@@ -1,12 +1,12 @@
 using System;
 
-public enum Units
+enum Units
 {
     Pounds,
     Kilograms
 }
 
-public class WeighingMachine
+class WeighingMachine
 {
     private const decimal POUNDS_PER_KILOGRAM = 2.20462m;
     private decimal inputWeight;
@@ -49,7 +49,7 @@ public class WeighingMachine
     private decimal WeightInPounds(decimal weight) => Units == Units.Kilograms ? weight * POUNDS_PER_KILOGRAM : weight;
 }
 
-public class USWeight
+class USWeight
 {
     private const decimal OUNCES_PER_POUND = 16m;
 

--- a/languages/csharp/exercises/concept/properties/Properties.cs
+++ b/languages/csharp/exercises/concept/properties/Properties.cs
@@ -19,7 +19,7 @@ class WeighingMachine
     // TODO: define the 'Units' property
 }
 
-public struct USWeight
+struct USWeight
 {
     public USWeight(decimal weightInPounds)
     {

--- a/languages/csharp/exercises/concept/properties/Properties.cs
+++ b/languages/csharp/exercises/concept/properties/Properties.cs
@@ -1,12 +1,12 @@
 using System;
 
-public enum Units
+enum Units
 {
     Pounds,
     Kilograms
 }
 
-public class WeighingMachine
+class WeighingMachine
 {
     // TODO: define the 'InputWeight' property
 

--- a/languages/csharp/exercises/concept/strings/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/strings/.meta/Example.cs
@@ -1,4 +1,4 @@
-public static class LogLine
+static class LogLine
 {
     public static string Message(string logLine)
     {

--- a/languages/csharp/exercises/concept/strings/Strings.cs
+++ b/languages/csharp/exercises/concept/strings/Strings.cs
@@ -1,6 +1,6 @@
 using System;
 
-public static class LogLine
+static class LogLine
 {
     public static string Message(string logLine)
     {


### PR DESCRIPTION
I've only just realised that all the stubs used `public` before the class name. Strictly speaking this is not necessary, and as I've [removed the `public class` introduction in the basics exercise](https://github.com/exercism/v3/pull/1368), we can't expect students to know about this feature anymore. I've removed this introduction from the basics exercise to keep things as simple as possible.

The plan is to introduce public classes and visibility of classes in the accessibility exercise (that I might rename to namespaces). If an exercise depends on the "accessibility" (or possibly "namespaces") concept, we can then use `public` classes in those stubs.