### PR TITLE
[JavaScript] Improve Concept Exercise: strings

### DIFF
--- a/languages/javascript/exercises/concept/strings/.docs/after.md
+++ b/languages/javascript/exercises/concept/strings/.docs/after.md
@@ -1,0 +1,5 @@
+The key thing to remember about JavaScript strings is that they can call methods like `toUpperCase`, `trim`, etc.
+
+You can find all the methods in the [MDN docs].
+
+[MDN docs]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Instance_methods

--- a/languages/javascript/exercises/concept/strings/.docs/after.md
+++ b/languages/javascript/exercises/concept/strings/.docs/after.md
@@ -2,4 +2,4 @@ The key thing to remember about JavaScript strings is that they can call methods
 
 You can find all the methods in the [MDN docs].
 
-[MDN docs]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Instance_methods
+[mdn docs]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Instance_methods

--- a/languages/javascript/exercises/concept/strings/.docs/after.md
+++ b/languages/javascript/exercises/concept/strings/.docs/after.md
@@ -1,4 +1,4 @@
-The key thing to remember about JavaScript strings is that they can call methods like `toUpperCase`, `trim`, etc.
+The key thing to remember about JavaScript strings is that we can call methods on them like `toUpperCase`, `trim`, etc.
 
 You can find all the methods in the [MDN docs].
 

--- a/languages/javascript/exercises/concept/strings/.docs/after.md
+++ b/languages/javascript/exercises/concept/strings/.docs/after.md
@@ -1,5 +1,5 @@
 The key thing to remember about JavaScript strings is that we can call methods on them like `toUpperCase`, `trim`, etc.
 
-You can find all the methods in the [MDN docs].
+You can find all the methods in the [MDN docs][mdn docs].
 
 [mdn docs]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Instance_methods

--- a/languages/javascript/exercises/concept/strings/.docs/instructions.md
+++ b/languages/javascript/exercises/concept/strings/.docs/instructions.md
@@ -93,7 +93,7 @@ backDoorResponse('Stands so high')
 
 ### 4. Trim a sentence
 
-Implement a function that trim a sentence:
+Improve the previous function so that it trims a sentence and returns the last character:
 
 ```javascript
 backDoorResponse('Stands so high   ')

--- a/languages/javascript/exercises/concept/strings/.docs/instructions.md
+++ b/languages/javascript/exercises/concept/strings/.docs/instructions.md
@@ -93,7 +93,7 @@ backDoorResponse('Stands so high')
 
 ### 4. Trim a sentence
 
-Improve the previous function so that it trims a sentence and returns the last character:
+Improve the previous function so that it removes whitespace from the end of a sentence and returns the last character:
 
 ```javascript
 backDoorResponse('Stands so high   ')

--- a/languages/javascript/exercises/concept/strings/.docs/introduction.md
+++ b/languages/javascript/exercises/concept/strings/.docs/introduction.md
@@ -2,18 +2,20 @@ Strings are useful for holding data that can be represented in text form.
 There are two ways to access an individual character in a string.
 
 The first is the charAt() method:
+
 ```javascript
 'cat'.charAt(1)
 // => "a"
 ```
 
 The other way is to treat a string as an array-like object, where individual characters correspond to a numerical index(starts at zero):
+
 ```javascript
 'cat'[1]
 // => "a"
 ```
 
-Some of the most-used operations on strings are to check their `length` and to concatenate them using the `+`  string operators.
+Some of the most-used operations on strings are to check their `length` and to concatenate them using the `+` string operators.
 
 ```javascript
 'cat'.length

--- a/languages/javascript/exercises/concept/strings/.docs/introduction.md
+++ b/languages/javascript/exercises/concept/strings/.docs/introduction.md
@@ -1,7 +1,7 @@
 Strings are useful for holding data that can be represented in text form.
 There are two ways to access an individual character in a string.
 
-The first is the charAt() method:
+The first is the `charAt()` method:
 
 ```javascript
 'cat'.charAt(1)

--- a/languages/javascript/exercises/concept/strings/.docs/introduction.md
+++ b/languages/javascript/exercises/concept/strings/.docs/introduction.md
@@ -8,7 +8,7 @@ The first is the `charAt()` method:
 // => "a"
 ```
 
-The other way is to treat a string as an array-like object, where individual characters correspond to a numerical index(starts at zero):
+The other way is to treat a `string` as a list of characters, where individual characters correspond to a numerical index (starts at zero):
 
 ```javascript
 'cat'[1]

--- a/languages/javascript/exercises/concept/strings/.docs/introduction.md
+++ b/languages/javascript/exercises/concept/strings/.docs/introduction.md
@@ -1,5 +1,24 @@
-Strings are useful for holding data that can be represented in text form. Some
-of the most-used operations on strings are to check their `length`, to build
-and concatenate them using the `+` and `+=` string operators, checking for the
-existence or location of substrings with the `indexOf()` method, or extracting
-substrings with the `substring()` method.
+Strings are useful for holding data that can be represented in text form.
+There are two ways to access an individual character in a string.
+
+The first is the charAt() method:
+```javascript
+'cat'.charAt(1)
+// => "a"
+```
+
+The other way is to treat a string as an array-like object, where individual characters correspond to a numerical index(starts at zero):
+```javascript
+'cat'[1]
+// => "a"
+```
+
+Some of the most-used operations on strings are to check their `length` and to concatenate them using the `+`  string operators.
+
+```javascript
+'cat'.length
+// => 3
+
+'I like' + ' ' + 'cats'
+// => "I like cats"
+```


### PR DESCRIPTION
This PR and #1353 resolve #1298.

I add `after.md` to the string concept exercise and rewrite `introduction.md`.

I don't think it's not helpful for beginners or can be confusing that knowing JavaScript strings are UTF-16 encoded strings and JavaScript strings have primitives and objects, so I don't mention them at `after.md`.

I also rewrite `introduction.md` to make it easier for students to get started the exercise.