### PR TITLE
[Ruby/lasagna] Remove constants from stub

### DIFF
--- a/languages/ruby/exercises/concept/basics/lasagna.rb
+++ b/languages/ruby/exercises/concept/basics/lasagna.rb
@@ -1,7 +1,4 @@
 class Lasagna
-  EXPECTED_MINUTES_IN_OVEN = 40
-  PREPARATION_MINUTES_PER_LAYER = 2
-
   def remaining_minutes_in_oven(actual_minutes_in_oven)
     raise NotImplementedError, 'Please implement the remaining_minutes_in_oven method'
   end


### PR DESCRIPTION
It seems that we accidentally leaked out constants into the stub. This removes them.