### PR TITLE
[Reference] Use consistent format for stories

### DIFF
--- a/reference/stories/arrays.magician-card-stack.md
+++ b/reference/stories/arrays.magician-card-stack.md
@@ -1,6 +1,6 @@
 # Magician card stack
 
-## Story introduction
+## Story
 
 As a magician-to-be, Elyse needs to practice some basics. She has a stack of cards that she wants to manipulate.
 
@@ -24,8 +24,6 @@ These are examples of tasks that fit the story of Elyse being a beginner:
 - Remove a card from the bottom of the stack
 - Check size of the stack
 
-Example usage: [`javascript/concept/arrays`][javascript-concept-arrays]
-
 ## Terminology
 
 These are recommendations, not rules, for recurring terminology in the instructions (including stub commentary)
@@ -37,11 +35,15 @@ These are recommendations, not rules, for recurring terminology in the instructi
 - The **top card** is the _first element_
 - The **bottom card** is the _last element_
 
+## Implementations
+
+- [JavaScript][implementation-javascript] (reference implementation)
+
 ## Alternative version
 
 An alternative version of the story uses **you** (the student) as actor, and focusses on re-arranging the deck only.
 
-### Story introduction
+### Story
 
 You're a magician and you handle a deck of cards. In order to correctly execute your magic trick, you need to be able to move a card from one position to another position. That is, you need to be able to rearrange the deck. Naturally, you want to be able to move cards in both directions, and be able to say "from the top of the deck" or "from the bottom of the deck".
 
@@ -52,16 +54,16 @@ These are examples of tasks that fit the story of you wanting to re-arrange card
 - Implement a function arrange that moves a card in a stack from one given position to another, returning a new stack
 - Implement a function rearrange that does the same, mutating the original stack
 
-Example usage: [`research/javascript-1-a`][javascript-research-1-a]
+### Implementations
 
-## Related
+- [JavaScript 1-a (research)][implementation-javascript-research-1-a]
+- [JavaScript 2-a (research)][implementation-javascript-research-2-a]
 
-- [`type/array`][type-array]
-- [`javascript/concept/arrays`][javascript-concept-arrays]
-- [`research/javascript-1-a`][javascript-research-1-a]
-- [`research/javascript-2-a`][javascript-research-2-a]
+## Reference
 
-[type-array]: ../types/array.md
-[javascript-concept-arrays]: ../../languages/javascript/exercises/concept/arrays
-[javascript-research-1-a]: https://github.com/exercism/research_experiment_1/tree/master/exercises/javascript-1-a
-[javascript-research-2-a]: https://github.com/exercism/research_experiment_1/tree/master/exercises/javascript-2-a
+- [`types/array`][types-array]
+
+[types-array]: ../types/array.md
+[implementation-javascript]: ../../languages/javascript/exercises/concept/arrays/.docs/instructions.md
+[implementation-javascript-research-1-a]: https://github.com/exercism/research_experiment_1/tree/master/exercises/javascript-1-a
+[implementation-javascript-research-2-a]: https://github.com/exercism/research_experiment_1/tree/master/exercises/javascript-2-a

--- a/reference/stories/booleans.pac-man.md
+++ b/reference/stories/booleans.pac-man.md
@@ -1,10 +1,14 @@
-# Pac-man
+# Pac-Man
 
-This story uses the classic arcade game _Pac-Man_ as a basis for teaching the [boolean type][boolean-type] / [boolean logic][boolean-logic] concept.
+## Story
+
+This story uses the classic arcade game _Pac-Man_ as a basis for teaching the [boolean type][types-boolean] / [boolean logic][concepts-boolean_logic] concept.
 
 The theme is a derivative of Weng, Tseng, and Lee's (2010)[(1)][1] discussion about strategies for effective learning for logic by using game states.
 
-The story uses several game state checks to practice [boolean expressions][boolean-logic] in the language constructs.
+The story uses several game state checks to practice [boolean expressions][concepts-boolean_logic] in the language constructs.
+
+## Tasks
 
 Game states explored:
 
@@ -13,6 +17,8 @@ Game states explored:
 - If _Pac-Man_ loses the game.
 - If _Pac-Man_ wins the game.
 
+## Terminology
+
 Terms used in the story:
 
 - _Pac-Man_: the main character of the game, whom the player controls.
@@ -20,10 +26,20 @@ Terms used in the story:
 - Dot: an item which gives points, and upon eating them all, wins the stage.
 - Ghost: the CPU opponent in the game, where if a ghost touches _Pac-Man_ without a power-pellet active, causes _Pac-Man_ to lose the stage.
 
+## Implementations
+
+- [Elixir][implementation-elixir] (reference implementation)
+
+## Reference
+
+- [`concepts/boolean_logic`][concepts-boolean_logic]
+- [`types/boolean`][types-boolean]
+
 ## References
 
 [1][1]. Jui-Feng Weng, Shian-Shyong Tseng, Tsung-Ju Lee, Teaching Boolean Logic through Game Rule Tuning, IEEE Trans. Learning Technol. 3 (2010) 319–328. <https://doi.org/10.1109/TLT.2010.33>.
 
 [1]: https://doi.org/10.1109/TLT.2010.33
-[boolean-type]: ../types/boolean.md
-[boolean-logic]: ../concepts/boolean_logic.md
+[types-boolean]: ../types/boolean.md
+[concepts-boolean_logic]: ../concepts/boolean_logic.md
+[implementation-elixir]: ../../languages/elixir/exercises/concept/booleans/.docs/instructions.md

--- a/reference/stories/booleans.rpg-quest-logic.md
+++ b/reference/stories/booleans.rpg-quest-logic.md
@@ -1,6 +1,6 @@
 # RPG Quest Logic
 
-## Story introduction
+## Story
 
 In this exercise, you'll be implementing the quest logic for a new RPG game a friend is developing. The game's main character is Annalyn, a brave girl with a fierce and loyal pet dog. Unfortunately, disaster strikes, as her best friend was kidnapped while searching for berries in the forest. Annalyn will try to find and free her best friend, optionally taking her dog with her on this quest.
 
@@ -22,8 +22,6 @@ These are example tasks that fit the story of Annalyn rescuing her best friend:
 - Implement check for _Signal prisoner_: the prisoner can be signalled using bird sounds if the prisoner is awake and the archer is sleeping, as archers are trained in bird signaling so they could intercept the message.
 - Implement check for _Free prisoner_: Annalyn can try sneaking into the camp to free the prisoner, but this tactic will only work if the prisoner is awake and the other two characters are sleeping. If the prisoner is sleeping, they'll be startled by Annalyn's sudden appearance and will awaken the other two characters. The prisoner can also be freed if the archer is sleeping and Annalyn has her pet dog with her, as the knight will be scared by the dog and will withdraw, and the archer can't equip his bow fast enough to prevent the prisoner from being freed.
 
-Example usage: [`javascript/concept/booleans`][javascript-concept-booleans]
-
 ## Terminology
 
 These are recommendations, not rules, for recurring terminology in the instructions (including stub commentary)
@@ -33,10 +31,16 @@ These are recommendations, not rules, for recurring terminology in the instructi
 - The prisoner is her best friend, and their pronouns are **they/their**.
 - Do _not_ refer to **Annalyn**, the **prisoner**, the **archer**, the **knight** or Annalyn's **pet dog** by pronoun, as the meaning will most likely be ambiguous; instead use the indicators as emphasized.
 
+## Implementations
+
+- [F#][implementation-fsharp]
+- [JavaScript][implementation-javascript] (reference implementation)
+
 ## Related
 
-- [`type/boolean`][type-boolean]
-- [`javascript/concept/booleans`][javascript-concept-booleans]
+- [`types/boolean`][types-boolean]
 
-[type-boolean]: ../types/boolean.md
+[types-boolean]: ../types/boolean.md
 [javascript-concept-booleans]: ../../languages/javascript/exercises/concept/booleans
+[implementation-fsharp]: ../../languages/fsharp/exercises/concept/booleans/.docs/instructions.md
+[implementation-javascript]: ../../languages/javascript/exercises/concept/booleans/.docs/instructions.md

--- a/reference/stories/deep-dig.basketball-team-website.md
+++ b/reference/stories/deep-dig.basketball-team-website.md
@@ -1,6 +1,6 @@
 # Basketball team website
 
-## Story introduction
+## Story
 
 You're working on a website for basketball team. The website displays lots of data, but unfortunately what is displayed changes often. As the data is stored in a single object, this is not hard to do, but it is time-consuming and boring. You've therefore decided to automate things.
 
@@ -10,20 +10,21 @@ These are examples of tasks that fit the story of automating the website:
 
 - Your goal is to allow the content team to select which data to display by themselves. They'll do this by specifying a path to the data to be displayed in the website's content editor. Your task is to create a function extract that takes an object and a path, separated by a dot character. Return the value at that path, or a default value.
 
-Example usage: [`research/javascript-1-b`][javascript-research-1-b]
-
 ## Additional Tasks
 
 The story can be continued, for example:
 
 - The content team is very excited about this new functionality, and has already requested a new feature to be added. They'd like to be able to display data of specific elements in an array.
 
-## Related
+## Implementations
 
-- [`type/dictionary`][type-dictionary]
-- [`research/javascript-1-b`][javascript-research-1-b]
-- [`research/javascript-2-b`][javascript-research-2-b]
+- [JavaScript 1-b (research)][implementation-javascript-research-1-b]
+- [JavaScript 2-b (research)][implementation-javascript-research-2-b]
 
-[type-dictionary]: ../types/dictionary.md
-[javascript-research-1-b]: https://github.com/exercism/research_experiment_1/tree/master/exercises/javascript-1-b
-[javascript-research-2-b]: https://github.com/exercism/research_experiment_1/tree/master/exercises/javascript-2-b
+## Reference
+
+- [`types/dictionary`][types-dictionary]
+
+[types-dictionary]: ../types/dictionary.md
+[implementation-javascript-research-1-b]: https://github.com/exercism/research_experiment_1/tree/master/exercises/javascript-1-b/README.md
+[implementation-javascript-research-2-b]: https://github.com/exercism/research_experiment_1/tree/master/exercises/javascript-2-b/README.md

--- a/reference/stories/lambda-function.secret-device.md
+++ b/reference/stories/lambda-function.secret-device.md
@@ -1,24 +1,32 @@
 # Secret Device
 
-This story uses the setting of creating a device to encrypt messages reliably and repeatedly using [anonymous functions][anon-fns].
+## Story
+
+This story uses the setting of creating a device to encrypt messages reliably and repeatedly using [anonymous functions][concepts-anonymous_functions].
 
 Concepts explored:
 
-- [Anonymous functions][anon-fns]
-- [Function composition][fn-composition]
-- [Higher order functions][higher-order]
+- [Anonymous functions][concepts-anonymous_functions]
+- [Function composition][concepts-function_composition]
+- [Higher order functions][concepts-higher_order_functions]
 
-The story also adapts well for [bitwise-manipulation][bitwise-manipulation] and the [bit][bit] type.
-
-and composing functions.
+The story also adapts well for [concepts-bitwise_manipulation][concepts-bitwise_manipulation], the [types-bit][types-bit] type and composing functions.
 
 ## Implementations
 
-- [Elixir][implementation-elixir]
+- [Elixir][implementation-elixir] (reference implementation)
 
-[implementation-elixir]: ../../languages/elixir/exercises/concept/anonymous-functions/.docs/introduction.md
-[anon-fns]: ../concepts/anonymous_functions.md
-[fn-composition]: ../concepts/function_composition.md
-[higher-order]: ../concepts/higher_order_functions.md
-[bitwise-manipulation]: ../concepts/bitwise_manipulation.md
-[bit]: ../types/bit.md
+## Reference
+
+- [`concepts/anonymous_functions`][concepts-anonymous_functions]
+- [`concepts/function_composition`][concepts-function_composition]
+- [`concepts/higher_order_functions`][concepts-higher_order_functions]
+- [`concepts/bitwise_manipulation`][concepts-bitwise_manipulation]
+- [`types/bit`][types-bit]
+
+[implementation-elixir]: ../../languages/elixir/exercises/concept/anonymous-functions/.docs/instructions.md
+[concepts-anonymous_functions]: ../concepts/anonymous_functions.md
+[concepts-function_composition]: ../concepts/function_composition.md
+[concepts-higher_order_functions]: ../concepts/higher_order_functions.md
+[concepts-bitwise_manipulation]: ../concepts/bitwise_manipulation.md
+[types-bit]: ../types/bit.md

--- a/reference/stories/lists.language-list.md
+++ b/reference/stories/lists.language-list.md
@@ -1,8 +1,12 @@
 # Language List
 
-This story facilitates the exploration of [lists][lists-type] in a language.
+## Story
 
-The basic premise is that a person wants to maintain a [list][lists-type] of languages that they want to learn on Exercism's website.
+This story facilitates the exploration of [lists][types-list] in a language.
+
+The basic premise is that a person wants to maintain a [list][types-list] of languages that they want to learn on Exercism's website.
+
+## Tasks
 
 The exercise generally guides students how to:
 
@@ -15,9 +19,15 @@ The exercise generally guides students how to:
 
 ## Implementations
 
-- [Clojure][implementation-clojure]
+- [Clojure][implementation-clojure] (reference implementation)
 - [Elixir][implementation-elixir]
+- [F#][implementation-fsharp]
 
-[implementation-clojure]: ../../languages/clojure/exercises/concept/lists/.docs/introduction.md
-[implementation-elixir]: ../../languages/elixir/exercises/concept/lists/.docs/introduction.md
-[lists-type]: ../types/list.md
+## Reference
+
+- [`types/list`][types-list]
+
+[implementation-clojure]: ../../languages/clojure/exercises/concept/lists/.docs/instructions.md
+[implementation-elixir]: ../../languages/elixir/exercises/concept/lists/.docs/instructions.md
+[implementation-fsharp]: ../../languages/fsharp/exercises/concept/lists/.docs/instructions.md
+[types-list]: ../types/list.md

--- a/reference/stories/maps.high-score-board.md
+++ b/reference/stories/maps.high-score-board.md
@@ -1,6 +1,10 @@
 # High Score Board
 
-This exercise uses the setting of maintaining a high-score board for an arcade hall to teach the concept of key-value [collections][collection] ([maps][map], [hashes][hash], associative arrays, [dictionaries][dict], etc.). A player's name serves as the key, and the score serves as the value.
+## Story
+
+This exercise uses the setting of maintaining a high-score board for an arcade hall to teach the concept of key-value [collections][collection] ([maps][types-map], [hashes][types-hash_map], associative arrays, [dictionaries][dict], etc.). A player's name serves as the key, and the score serves as the value.
+
+## Tasks
 
 The student is then guided through some operations:
 
@@ -13,10 +17,16 @@ The student is then guided through some operations:
 
 ## Implementations
 
-- [Elixir][implementation-elixir]
+- [Elixir][implementation-elixir] (reference implementation)
+
+## Reference
+
+- [`types/dictionary`][types-dictionary]
+- [`types/hash_map`][types-hash_map]
+- [`types/map`][types-map]
 
 [collection]: ../types/collection.md
-[map]: ../types/map.md
-[hash]: ../types/hash_map.md
-[dicts]: ../types/dictionary.md
-[implementation-elixir]: ../../languages/elixir/exercises/concept/maps/.docs/introduction.md
+[types-map]: ../types/map.md
+[types-hash_map]: ../types/hash_map.md
+[types-dictionary]: ../types/dictionary.md
+[implementation-elixir]: ../../languages/elixir/exercises/concept/maps/.docs/instructions.md

--- a/reference/stories/numbers.freelancer-rates.md
+++ b/reference/stories/numbers.freelancer-rates.md
@@ -1,6 +1,6 @@
 # Freelancer Rates
 
-## Story introduction
+## Story
 
 In this exercise you'll be writing code to help a freelancer communicate with a
 project manager by providing a few utilities to quickly calculate day- and
@@ -26,8 +26,6 @@ These are example tasks that fit the story of the freelancer communicating with 
 - Calculate the month rate, given an hourly rate and a discount
 - Calculate the number of workdays given a budget, rate and discount
 
-Example usage: [`javascript/concept/numbers`][javascript-concept-numbers]
-
 ## Terminology
 
 These are recommendations, not rules, for recurring terminology in the instructions (including stub commentary)
@@ -36,16 +34,19 @@ These are recommendations, not rules, for recurring terminology in the instructi
 - Monthly rate is 22 times the daily rate; it should be mentioned
 - If discount is supplied as a _different_ type than the numeric types, use the terminology **discounts are modeled as**
 
-## Related
+## Implementations
 
-- [`type/number`][type-number]
-- [`type/decimal_number`][type-decimal-number]
-- [`type/floating_point_number`][type-floating-point-number]
-- [`type/string`][type-string]
-- [`javascript/concept/numbers`][javascript-concept-numbers]
+- [JavaScript][implementation-javascript] (reference implementation)
 
-[type-number]: ../types/number.md
-[type-decimal-number]: ../types/decimal_number.md
-[type-floating-point-number]: ../types/floating_point_number.md
-[type-string]: ../types/string.md
-[javascript-concept-numbers]: ../../languages/javascript/exercises/concept/numbers
+## Reference
+
+- [`types/number`][types-number]
+- [`types/decimal_number`][types-decimal-number]
+- [`types/floating_point_number`][types-floating-point-number]
+- [`types/string`][types-string]
+
+[types-number]: ../types/number.md
+[types-decimal-number]: ../types/decimal_number.md
+[types-floating-point-number]: ../types/floating_point_number.md
+[types-string]: ../types/string.md
+[implementation-javascript]: ../../languages/javascript/exercises/concept/numbers/.docs/instructions.md

--- a/reference/stories/promises.klingon-translation-service.md
+++ b/reference/stories/promises.klingon-translation-service.md
@@ -1,6 +1,6 @@
 # Klingon Translation Service
 
-## Story introduction
+## Story
 
 In this exercise you'll be providing a `TranslationService` where paid members
 have some quality assurance.
@@ -45,8 +45,6 @@ These These are examples of tasks that fit the story of the translation service:
 - Request a translation, retrying at most 2 times
 - Fetch a translation, inspect the quality, or request it
 
-Example usage: [`javascript/concept/promises`][javascript-concept-promises]
-
 ## Terminology
 
 These are recommendations, not rules, for recurring terminology in the instructions (including stub commentary)
@@ -58,21 +56,22 @@ These are recommendations, not rules, for recurring terminology in the instructi
 
 All the translation texts are Klingon to English.
 
-Example usage: [`javascript/concept/promises`][javascript-concept-promises]
+## Implementations
 
-## Related
+- [JavaScript][implementation-javascript] (reference implementation)
 
-- [`type/promise`][type-promise]
-- [`type/future`][type-future]
-- [`type/string`][type-string]
-- [`type/number`][type-number]
-- [`javascript/concept/promises`][javascript-concept-promises]
+## Reference
 
-[type-promise]: ../types/promise.md
-[type-future]: ../types/future.md
-[type-string]: ../types/string.md
-[type-number]: ../types/number.md
-[javascript-concept-promises]: ../../languages/javascript/exercises/concept/promises
+- [`types/promise`][types-promise]
+- [`types/future`][types-future]
+- [`types/string`][types-string]
+- [`types/number`][types-number]
+
+[types-promise]: ../types/promise.md
+[types-future]: ../types/future.md
+[types-string]: ../types/string.md
+[types-number]: ../types/number.md
+[implementation-javascript]: ../../languages/javascript/exercises/concept/promises/.docs/instructions.md
 
 ## N.B.
 

--- a/reference/stories/strings.poetry-club-door-policy.md
+++ b/reference/stories/strings.poetry-club-door-policy.md
@@ -1,6 +1,6 @@
 # Poetry club door policy
 
-## Story introduction
+## Story
 
 A new poetry club has opened in town, and you're thinking of attending. Because
 there have been incidents in the past, the club has a very specific door policy
@@ -63,10 +63,13 @@ recites **Huge hooves too**, you'll respond **o**.
 Finally the password you write down is `Horse, please`, and you can party
 with the renowned poets.
 
-## Related
+## Implementations
 
-- [`type/string`][type-string]
-- [`javascript/concept/strings`][javascript-concept-strings]
+- [JavaScript][implementation-javascript] (reference implementation)
 
-[type-string]: ../types/string.md
-[javascript-concept-strings]: ../../languages/javascript/exercises/concept/strings
+## Reference
+
+- [`types/string`][types-string]
+
+[types-string]: ../types/string.md
+[implementation-javascript]: ../../languages/javascript/exercises/concept/strings/.docs/instructions.md

--- a/reference/types/list.md
+++ b/reference/types/list.md
@@ -8,12 +8,12 @@ In many languages lists are _homogenous_ like arrays, and can contain only one t
 
 ### Language List
 
-In this exercise, the student processes a list of laguages to learn on Exercism. The exercise aims to teach:
+In this exercise, the student processes a list of laguages to learn on Exercism. The reference implementation (Clojure) teaches:
 
-- adding an item to a list
-- returning the first item from a list
-- returning a list of all items but the first
-- returning the number of items in a list.
+- Adding an item to a list
+- Returning the first item from a list
+- Returning a list of all items but the first
+- Returning the number of items in a list.
 
 #### Implementations
 

--- a/reference/types/list.md
+++ b/reference/types/list.md
@@ -8,7 +8,7 @@ In many languages lists are _homogenous_ like arrays, and can contain only one t
 
 ### Language List
 
-In this exercise, the student processes a list of laguages to learn on Exercism. The reference implementation (Clojure) teaches:
+In this exercise, the student processes a list of languages to learn on Exercism. The reference implementation (Clojure) teaches:
 
 - Adding an item to a list
 - Returning the first item from a list


### PR DESCRIPTION
I've tried to make the format for the stories consistent. What I've done is:

- Have an explicit `## Story` section if there wasn't one. This section describes the story.
- Add a `## Implementations` section if there wasn't one. This section lists the implementations of this story.
- Add a `(reference implementation)` suffix to the reference implementation, to make the format used in the reference documents.
- Any links to exercise now link to the `instructions.md` document, which is probably the best way to quickly get an idea of how the story is implemented.

And some other, minor changes. The format is up for debate, so let me know what you think!