### PR TITLE
[CI] Make /format trigger CI

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -26,8 +26,6 @@ jobs:
           HEAD_REF=$(jq -r ".head.ref" "$PR_DATA")
           HEAD_REPO=$(jq -r '.head.repo.ssh_url' "$PR_DATA")
 
-          echo "$HEAD_REPO"
-
           git clone $HEAD_REPO .
           git checkout -b "$HEAD_REF" "origin/$HEAD_REF"
 

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -10,6 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/format')
     steps:
+      - name: 'Setup SSH deploy key'
+        run: |
+          mkdir ~/.ssh
+          echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
       - name: 'Checkout code'
         run: |
           PR_DATA="/tmp/pr.json"
@@ -18,7 +24,9 @@ jobs:
             xargs curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -o "$PR_DATA" --url
 
           HEAD_REF=$(jq -r ".head.ref" "$PR_DATA")
-          HEAD_REPO=$(jq -r '.head.repo.clone_url | sub("https://"; "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@")' "$PR_DATA")
+          HEAD_REPO=$(jq -r '.head.repo.ssh_url' "$PR_DATA")
+
+          echo "$HEAD_REPO"
 
           git clone $HEAD_REPO .
           git checkout -b "$HEAD_REF" "origin/$HEAD_REF"


### PR DESCRIPTION
Currently, the `/format` command does not trigger CI itself because it uses the default actions token which does not have permission to trigger other workflows. This means that the commit created by `/format` will get the PR stuck in a state where it can't be merged because required checks, like `valid-links`, haven't been run (see #1434). By using an SSH deploy key, we can get around that restriction. The deploy key, unlike personal access tokens, only has access to this repo.

Proof of concept/test PR: https://github.com/SaschaMann/v3/pull/5

This requires some manual setup before it works:

- Create a new SSH key pair using `ssh-keygen -t ed25519`, ideally in a temporary directory. Do not set a password for the key.
- Add the public key `id_ed25519.pub` as a deploy key to this repo in the [repo settings](https://github.com/exercism/v3/settings/keys)
- Add the private key `id_ed25519` as a secret called `DEPLOY_KEY`.

---

Thanks to @DilumAluthge for finding and sharing this workaround on the Julia Slack! :)

---

closes #1434 