### PR TITLE
[C#] [Properties] Use basic syntax

### DIFF
--- a/languages/csharp/exercises/concept/properties/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/properties/.meta/Example.cs
@@ -9,6 +9,7 @@ enum Units
 class WeighingMachine
 {
     private const decimal POUNDS_PER_KILOGRAM = 2.20462m;
+
     private decimal inputWeight;
 
     public Units Units { get; set; } = Units.Kilograms;
@@ -37,6 +38,7 @@ class WeighingMachine
             return ApplyTareAdjustment(inputWeight);
         }
     }
+
     public USWeight USDisplayWeight
     {
         get
@@ -44,9 +46,23 @@ class WeighingMachine
             return new USWeight(WeightInPounds(DisplayWeight));
         }
     }
+
     public decimal TareAdjustment { set; private get; }
-    private decimal ApplyTareAdjustment(decimal weight) => weight - TareAdjustment;
-    private decimal WeightInPounds(decimal weight) => Units == Units.Kilograms ? weight * POUNDS_PER_KILOGRAM : weight;
+
+    private decimal ApplyTareAdjustment(decimal weight)
+    {
+        return weight - TareAdjustment;
+    }
+
+    private decimal WeightInPounds(decimal weight)
+    {
+        if (Units == Units.Kilograms)
+        {
+            return weight * POUNDS_PER_KILOGRAM;
+        }
+
+        return weight;
+    }
 }
 
 class USWeight

--- a/languages/csharp/exercises/concept/properties/PropertiesTests.cs
+++ b/languages/csharp/exercises/concept/properties/PropertiesTests.cs
@@ -19,20 +19,37 @@ public class WeighingMachineTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Get_us_display_weight()
+    public void Get_us_display_weight_pounds()
     {
         var wm = new WeighingMachine();
         wm.InputWeight = 60m;
-        Assert.Equal((132, 4), (wm.USDisplayWeight.Pounds, wm.USDisplayWeight.Ounces));
+        Assert.Equal(132, wm.USDisplayWeight.Pounds);
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Input_pounds_and_get_us_display_weight()
+    public void Get_us_display_weight_ounces()
+    {
+        var wm = new WeighingMachine();
+        wm.InputWeight = 60m;
+        Assert.Equal(4, wm.USDisplayWeight.Ounces);
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Input_pounds_and_get_us_display_weight_pounds()
     {
         var wm = new WeighingMachine();
         wm.Units = Units.Pounds;
         wm.InputWeight = 175.5m;
-        Assert.Equal((175, 8), (wm.USDisplayWeight.Pounds, wm.USDisplayWeight.Ounces));
+        Assert.Equal(175, wm.USDisplayWeight.Pounds);
+    }
+
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Input_pounds_and_get_is_display_weight_ounces()
+    {
+        var wm = new WeighingMachine();
+        wm.Units = Units.Pounds;
+        wm.InputWeight = 175.5m;
+        Assert.Equal(8, wm.USDisplayWeight.Ounces);
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]


### PR DESCRIPTION
This PR tries to simplify the syntax features used. It removes:

- Expression-bodied members
- Don't use tuples