### PR TITLE
[C#] Update test naming

### DIFF
--- a/languages/csharp/exercises/concept/arrays/ArraysTests.cs
+++ b/languages/csharp/exercises/concept/arrays/ArraysTests.cs
@@ -3,13 +3,13 @@ using Xunit;
 public class BirdCountTests
 {
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void LastWeek()
+    public void Last_week()
     {
         Assert.Equal(new int[] { 0, 2, 5, 3, 7, 8, 4 }, BirdCount.LastWeek());
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void YesterdayForDisappointingWeek()
+    public void Yesterday_for_disappointing_week()
     {
         var counts = new int[] { 0, 0, 1, 0, 0, 1, 0 };
         var birdCount = new BirdCount(counts);
@@ -17,7 +17,7 @@ public class BirdCountTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void YesterdayDaysForBusyWeek()
+    public void Yesterday_days_for_busy_week()
     {
         var counts = new int[] { 8, 8, 9, 5, 4, 7, 10 };
         var birdCount = new BirdCount(counts);
@@ -25,7 +25,7 @@ public class BirdCountTests
     }
 
     [Fact]
-    public void TotalForDisappointingWeek()
+    public void Total_for_disappointing_week()
     {
         var counts = new int[] { 0, 0, 1, 0, 0, 1, 0 };
         var birdCount = new BirdCount(counts);
@@ -33,7 +33,7 @@ public class BirdCountTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TotalForBusyWeek()
+    public void Total_for_busy_week()
     {
         var counts = new int[] { 5, 9, 12, 6, 8, 8, 17 };
         var birdCount = new BirdCount(counts);
@@ -41,7 +41,7 @@ public class BirdCountTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void BusyDaysForDisappointingWeek()
+    public void Busy_days_for_disappointing_week()
     {
         var counts = new int[] { 1, 1, 1, 0, 0, 0, 0 };
         var birdCount = new BirdCount(counts);
@@ -49,7 +49,7 @@ public class BirdCountTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void BusyDaysForBusyWeek()
+    public void Busy_days_for_busy_week()
     {
         var counts = new int[] { 4, 9, 5, 7, 8, 8, 2 };
         var birdCount = new BirdCount(counts);
@@ -57,7 +57,7 @@ public class BirdCountTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasDayWithoutBirdsWithDayWithoutBirds()
+    public void Has_day_without_birds_with_day_without_birds()
     {
         var counts = new int[] { 5, 5, 4, 0, 7, 6, 7 };
         var birdCount = new BirdCount(counts);
@@ -65,7 +65,7 @@ public class BirdCountTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasDayWithoutBirdsWithNoDayWithoutBirds()
+    public void Has_day_without_birds_with_no_day_without_birds()
     {
         var counts = new int[] { 4, 5, 9, 10, 9, 4, 3 };
         var birdCount = new BirdCount(counts);

--- a/languages/csharp/exercises/concept/basics/BasicsTests.cs
+++ b/languages/csharp/exercises/concept/basics/BasicsTests.cs
@@ -3,37 +3,37 @@ using Xunit;
 public class LasagnaTests
 {
     [Fact]
-    public void ExpectedMinutesInOven()
+    public void Expected_minutes_in_oven()
     {
         Assert.Equal(40, new Lasagna().ExpectedMinutesInOven());
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RemainingMinutesInOven()
+    public void Remaining_minutes_in_oven()
     {
         Assert.Equal(15, new Lasagna().RemainingMinutesInOven(25));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void PreparationTimeInMinutesForOneLayer()
+    public void Preparation_time_in_minutes_for_one_layer()
     {
         Assert.Equal(2, new Lasagna().PreparationTimeInMinutes(1));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void PreparationTimeInMinutesForMultipleLayers()
+    public void Preparation_time_in_minutes_for_multiple_layers()
     {
         Assert.Equal(8, new Lasagna().PreparationTimeInMinutes(4));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TotalTimeInMinutesForOneLayer()
+    public void Total_time_in_minutes_for_one_layer()
     {
         Assert.Equal(32, new Lasagna().TotalTimeInMinutes(1, 30));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TotalTimeInMinutesForMultipleLayers()
+    public void Total_time_in_minutes_for_multiple_layers()
     {
         Assert.Equal(16, new Lasagna().TotalTimeInMinutes(4, 8));
     }

--- a/languages/csharp/exercises/concept/booleans/BooleansTests.cs
+++ b/languages/csharp/exercises/concept/booleans/BooleansTests.cs
@@ -3,21 +3,21 @@ using Xunit;
 public class QuestLogicTests
 {
     [Fact]
-    public void CannotExecuteFastAttackIfKnightIsAwake()
+    public void Cannot_execute_fast_attack_if_knight_is_awake()
     {
         var knightIsAwake = true;
         Assert.False(QuestLogic.CanFastAttack(knightIsAwake));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanExecuteFastAttackIfKnightIsSleeping()
+    public void Can_execute_fast_attack_if_knight_is_sleeping()
     {
         var knightIsAwake = false;
         Assert.True(QuestLogic.CanFastAttack(knightIsAwake));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotSpyIfEveryoneIsSleeping()
+    public void Cannot_spy_if_everyone_is_sleeping()
     {
         var knightIsAwake = false;
         var archerIsAwake = false;
@@ -26,7 +26,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanSpyIfEveryoneButKnightIsSleeping()
+    public void Can_spy_if_everyone_but_knight_is_sleeping()
     {
         var knightIsAwake = true;
         var archerIsAwake = false;
@@ -35,7 +35,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanSpyIfEveryoneButArcherIsSleeping()
+    public void Can_spy_if_everyone_but_archer_is_sleeping()
     {
         var knightIsAwake = false;
         var archerIsAwake = true;
@@ -44,7 +44,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanSpyIfEveryoneButPrisonerIsSleeping()
+    public void Can_spy_if_everyone_but_prisoner_is_sleeping()
     {
         var knightIsAwake = false;
         var archerIsAwake = false;
@@ -55,7 +55,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanSpyIfOnlyKnightIsSleeping()
+    public void Can_spy_if_only_knight_is_sleeping()
     {
         var knightIsAwake = false;
         var archerIsAwake = true;
@@ -64,7 +64,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanSpyIfOnlyArcherIsSleeping()
+    public void Can_spy_if_only_archer_is_sleeping()
     {
         var knightIsAwake = true;
         var archerIsAwake = false;
@@ -73,7 +73,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanSpyIfOnlyPrisonerIsSleeping()
+    public void Can_spy_if_only_prisoner_is_sleeping()
     {
         var knightIsAwake = true;
         var archerIsAwake = true;
@@ -82,7 +82,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanSpyIfEveryoneIsAwake()
+    public void Can_spy_if_everyone_is_awake()
     {
         var knightIsAwake = true;
         var archerIsAwake = true;
@@ -91,7 +91,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanSignalPrisonerIfarcherIsSleepingAndPrisonerIsAwake()
+    public void Can_signal_prisoner_ifarcher_is_sleeping_and_prisoner_is_awake()
     {
         var archerIsAwake = false;
         var prisonerIsAwake = true;
@@ -99,7 +99,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotSignalPrisonerIfarcherIsAwakeAndPrisonerIsSleeping()
+    public void Cannot_signal_prisoner_ifarcher_is_awake_and_prisoner_is_sleeping()
     {
         var archerIsAwake = true;
         var prisonerIsAwake = false;
@@ -107,7 +107,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotSignalPrisonerIfarcherAndPrisonerAreBothSleeping()
+    public void Cannot_signal_prisoner_ifarcher_and_prisoner_are_both_sleeping()
     {
         var archerIsAwake = false;
         var prisonerIsAwake = false;
@@ -115,7 +115,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotSignalPrisonerIfarcherAndPrisonerAreBothAwake()
+    public void Cannot_signal_prisoner_ifarcher_and_prisoner_are_both_awake()
     {
         var archerIsAwake = true;
         var prisonerIsAwake = true;
@@ -123,7 +123,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotReleasePrisonerIfEveryoneIsAwakeAndPetDogIsPresent()
+    public void Cannot_release_prisoner_if_everyone_is_awake_and_pet_dog_is_present()
     {
         var knightIsAwake = true;
         var archerIsAwake = true;
@@ -133,7 +133,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotReleasePrisonerIfEveryoneIsAwakeAndPetDogIsAbsent()
+    public void Cannot_release_prisoner_if_everyone_is_awake_and_pet_dog_is_absent()
     {
         var knightIsAwake = true;
         var archerIsAwake = true;
@@ -143,7 +143,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanReleasePrisonerIfEveryoneIsAsleepAndPetDogIsPresent()
+    public void Can_release_prisoner_if_everyone_is_asleep_and_pet_dog_is_present()
     {
         var knightIsAwake = false;
         var archerIsAwake = false;
@@ -153,7 +153,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotReleasePrisonerIfEveryoneIsAsleepAndPetDogIsAbsent()
+    public void Cannot_release_prisoner_if_everyone_is_asleep_and_pet_dog_is_absent()
     {
         var knightIsAwake = false;
         var archerIsAwake = false;
@@ -163,7 +163,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanReleasePrisonerIfOnlyPrisonerIsAwakeAndPetDogIsPresent()
+    public void Can_release_prisoner_if_only_prisoner_is_awake_and_pet_dog_is_present()
     {
         var knightIsAwake = false;
         var archerIsAwake = false;
@@ -173,7 +173,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanReleasePrisonerIfOnlyPrisonerIsAwakeAndPetDogIsAbsent()
+    public void Can_release_prisoner_if_only_prisoner_is_awake_and_pet_dog_is_absent()
     {
         var knightIsAwake = false;
         var archerIsAwake = false;
@@ -183,7 +183,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotReleasePrisonerIfOnlyArcherIsAwakeAndPetDogIsPresent()
+    public void Cannot_release_prisoner_if_only_archer_is_awake_and_pet_dog_is_present()
     {
         var knightIsAwake = false;
         var archerIsAwake = true;
@@ -193,7 +193,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotReleasePrisonerIfOnlyArcherIsAwakeAndPetDogIsAbsent()
+    public void Cannot_release_prisoner_if_only_archer_is_awake_and_pet_dog_is_absent()
     {
         var knightIsAwake = false;
         var archerIsAwake = true;
@@ -203,7 +203,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanReleasePrisonerIfOnlyKnightIsAwakeAndPetDogIsPresent()
+    public void Can_release_prisoner_if_only_knight_is_awake_and_pet_dog_is_present()
     {
         var knightIsAwake = true;
         var archerIsAwake = false;
@@ -213,7 +213,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotReleasePrisonerIfOnlyKnightIsAwakeAndPetDogIsAbsent()
+    public void Cannot_release_prisoner_if_only_knight_is_awake_and_pet_dog_is_absent()
     {
         var knightIsAwake = true;
         var archerIsAwake = false;
@@ -223,7 +223,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotReleasePrisonerIfOnlyKnightIsAsleepAndPetDogIsPresent()
+    public void Cannot_release_prisoner_if_only_knight_is_asleep_and_pet_dog_is_present()
     {
         var knightIsAwake = false;
         var archerIsAwake = true;
@@ -233,7 +233,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotReleasePrisonerIfOnlyKnightIsAsleepAndPetDogIsAbsent()
+    public void Cannot_release_prisoner_if_only_knight_is_asleep_and_pet_dog_is_absent()
     {
         var knightIsAwake = false;
         var archerIsAwake = true;
@@ -243,7 +243,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CanReleasePrisonerIfOnlyArcherIsAsleepAndPetDogIsPresent()
+    public void Can_release_prisoner_if_only_archer_is_asleep_and_pet_dog_is_present()
     {
         var knightIsAwake = true;
         var archerIsAwake = false;
@@ -253,7 +253,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotReleasePrisonerIfOnlyArcherIsAsleepAndPetDogIsAbsent()
+    public void Cannot_release_prisoner_if_only_archer_is_asleep_and_pet_dog_is_absent()
     {
         var knightIsAwake = true;
         var archerIsAwake = false;
@@ -263,7 +263,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotReleasePrisonerIfOnlyPrisonerIsAsleepAndPetDogIsPresent()
+    public void Cannot_release_prisoner_if_only_prisoner_is_asleep_and_pet_dog_is_present()
     {
         var knightIsAwake = true;
         var archerIsAwake = true;
@@ -273,7 +273,7 @@ public class QuestLogicTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CannotReleasePrisonerIfOnlyPrisonerIsAsleepAndPetDogIsAbsent()
+    public void Cannot_release_prisoner_if_only_prisoner_is_asleep_and_pet_dog_is_absent()
     {
         var knightIsAwake = true;
         var archerIsAwake = true;

--- a/languages/csharp/exercises/concept/classes/ClassesTests.cs
+++ b/languages/csharp/exercises/concept/classes/ClassesTests.cs
@@ -3,14 +3,14 @@ using Xunit;
 public class RemoteControlCarTests
 {
     [Fact]
-    public void BuyNewCarReturnsInstance()
+    public void Buy_new_car_returns_instance()
     {
         var car = RemoteControlCar.Buy();
         Assert.NotNull(car);
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void BuyNewCarReturnsNewCarEachTime()
+    public void Buy_new_car_returns_new_car_each_time()
     {
         var car1 = RemoteControlCar.Buy();
         var car2 = RemoteControlCar.Buy();
@@ -18,21 +18,21 @@ public class RemoteControlCarTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void NewCarDistanceDisplay()
+    public void New_car_distance_display()
     {
         var car = new RemoteControlCar();
         Assert.Equal("Driven 0 meters", car.DistanceDisplay());
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void NewCarBatteryDisplay()
+    public void New_car_battery_display()
     {
         var car = new RemoteControlCar();
         Assert.Equal("Battery at 100%", car.BatteryDisplay());
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DistanceDisplayAfterDrivingOnce()
+    public void Distance_display_after_driving_once()
     {
         var car = new RemoteControlCar();
         car.Drive();
@@ -40,7 +40,7 @@ public class RemoteControlCarTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DistanceDisplayAfterDrivingMultipleTimes()
+    public void Distance_display_after_driving_multiple_times()
     {
         var car = new RemoteControlCar();
 
@@ -53,7 +53,7 @@ public class RemoteControlCarTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void BatteryDisplayAfterDrivingOnce()
+    public void Battery_display_after_driving_once()
     {
         var car = new RemoteControlCar();
         car.Drive();
@@ -61,7 +61,7 @@ public class RemoteControlCarTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void BatteryDisplayAfterDrivingMultipleTimes()
+    public void Battery_display_after_driving_multiple_times()
     {
         var car = new RemoteControlCar();
 
@@ -74,7 +74,7 @@ public class RemoteControlCarTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void BatteryDisplayWhenBatteryEmpty()
+    public void Battery_display_when_battery_empty()
     {
         var car = new RemoteControlCar();
 
@@ -91,7 +91,7 @@ public class RemoteControlCarTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DistanceDisplayWhenBatteryEmpty()
+    public void Distance_display_when_battery_empty()
     {
         var car = new RemoteControlCar();
 

--- a/languages/csharp/exercises/concept/constructors/ConstructorsTests.cs
+++ b/languages/csharp/exercises/concept/constructors/ConstructorsTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 public class RemoteControlCarTests
 {
     [Fact]
-    public void NewRemoteControlCarHasNotDrivenAnyDistance()
+    public void New_remote_control_car_has_not_driven_any_distance()
     {
         int speed = 10;
         int batteryDrain = 2;
@@ -13,7 +13,7 @@ public class RemoteControlCarTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DriveIncreasesDistanceDrivenWithSpeed()
+    public void Drive_increases_distance_driven_with_speed()
     {
         int speed = 5;
         int batteryDrain = 1;
@@ -25,7 +25,7 @@ public class RemoteControlCarTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DriveDoesNotIncreaseDistanceDrivenWhenBatteryDrained()
+    public void Drive_does_not_increase_distance_driven_when_battery_drained()
     {
         int speed = 9;
         int batteryDrain = 50;
@@ -42,7 +42,7 @@ public class RemoteControlCarTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void NewRemoteControlCarBatteryIsNotDrained()
+    public void New_remote_control_car_battery_is_not_drained()
     {
         int speed = 15;
         int batteryDrain = 3;
@@ -52,7 +52,7 @@ public class RemoteControlCarTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DriveToAlmostDrainBattery()
+    public void Drive_to_almost_drain_battery()
     {
         int speed = 2;
         int batteryDrain = 1;
@@ -68,7 +68,7 @@ public class RemoteControlCarTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DriveUntilBatteryIsDrained()
+    public void Drive_until_battery_is_drained()
     {
         int speed = 2;
         int batteryDrain = 1;
@@ -84,21 +84,21 @@ public class RemoteControlCarTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TopOfTheLineCarHasNotDrivenAnyDistance()
+    public void Top_of_the_line_car_has_not_driven_any_distance()
     {
         var car = RemoteControlCar.TopOfTheLine();
         Assert.Equal(0, car.DistanceDriven());
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TopOfTheLineCarHasBatteryNotDrained()
+    public void Top_of_the_line_car_has_battery_not_drained()
     {
         var car = RemoteControlCar.TopOfTheLine();
         Assert.False(car.BatteryDrained());
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TopOfTheLineCarHasCorrectSpeed()
+    public void Top_of_the_line_car_has_correct_speed()
     {
         var car = RemoteControlCar.TopOfTheLine();
         car.Drive();
@@ -106,7 +106,7 @@ public class RemoteControlCarTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TopOfTheLineHasCorrectBatteryDrain()
+    public void Top_of_the_line_has_correct_battery_drain()
     {
         var car = RemoteControlCar.TopOfTheLine();
 
@@ -128,7 +128,7 @@ public class RemoteControlCarTests
 public class RaceTrackTests
 {
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CarCanFinishWithCarThatCanEasilyFinish()
+    public void Car_can_finish_with_car_that_can_easily_finish()
     {
         int speed = 10;
         int batteryDrain = 2;
@@ -141,7 +141,7 @@ public class RaceTrackTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CarCanFinishWithCarThatCanJustFinish()
+    public void Car_can_finish_with_car_that_can_just_finish()
     {
         int speed = 2;
         int batteryDrain = 10;
@@ -154,7 +154,7 @@ public class RaceTrackTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CarCanFinishWithCarThatJustCannotFinish()
+    public void Car_can_finish_with_car_that_just_cannot_finish()
     {
         int speed = 3;
         int batteryDrain = 20;
@@ -167,7 +167,7 @@ public class RaceTrackTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CarCanFinishWithCarThatCannotFinish()
+    public void Car_can_finish_with_car_that_cannot_finish()
     {
         int speed = 1;
         int batteryDrain = 20;

--- a/languages/csharp/exercises/concept/datetimes/DateTimesTests.cs
+++ b/languages/csharp/exercises/concept/datetimes/DateTimesTests.cs
@@ -9,151 +9,151 @@ using System.Threading;
 public class AppointmentTests
 {
     [Fact]
-    public void ScheduleDateUsingOnlyNumbers()
+    public void Schedule_date_using_only_numbers()
     {
         Assert.Equal(new DateTime(2019, 07, 25, 13, 45, 0), Appointment.Schedule("7/25/2019 13:45:00"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ScheduleDateWithTextualMonth()
+    public void Schedule_date_with_textual_month()
     {
         Assert.Equal(new DateTime(2019, 6, 3, 11, 30, 0), Appointment.Schedule("June 3, 2019 11:30:00"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ScheduleDateWithTextualMonthAndWeekday()
+    public void Schedule_date_with_textual_month_and_weekday()
     {
         Assert.Equal(new DateTime(2019, 12, 5, 9, 0, 0), Appointment.Schedule("Thursday, December 5, 2019 09:00:00"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentOneYearAgo()
+    public void Has_passed_with_appointment_one_year_ago()
     {
         Assert.True(Appointment.HasPassed(DateTime.Now.AddYears(-1).AddHours(2)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentMonthsAgo()
+    public void Has_passed_with_appointment_months_ago()
     {
         Assert.True(Appointment.HasPassed(DateTime.Now.AddMonths(-8)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentDaysAgo()
+    public void Has_passed_with_appointment_days_ago()
     {
         Assert.True(Appointment.HasPassed(DateTime.Now.AddDays(-23)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentHoursAgo()
+    public void Has_passed_with_appointment_hours_ago()
     {
         Assert.True(Appointment.HasPassed(DateTime.Now.AddHours(-12)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentMinutesAgo()
+    public void Has_passed_with_appointment_minutes_ago()
     {
         Assert.True(Appointment.HasPassed(DateTime.Now.AddMinutes(-55)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentOneMinuteAgo()
+    public void Has_passed_with_appointment_one_minute_ago()
     {
         Assert.True(Appointment.HasPassed(DateTime.Now.AddMinutes(-1)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentInOneMinute()
+    public void Has_passed_with_appointment_in_one_minute()
     {
         Assert.False(Appointment.HasPassed(DateTime.Now.AddMinutes(1)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentInMinutes()
+    public void Has_passed_with_appointment_in_minutes()
     {
         Assert.False(Appointment.HasPassed(DateTime.Now.AddMinutes(5)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentInDays()
+    public void Has_passed_with_appointment_in_days()
     {
         Assert.False(Appointment.HasPassed(DateTime.Now.AddDays(19)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentInMonths()
+    public void Has_passed_with_appointment_in_months()
     {
         Assert.False(Appointment.HasPassed(DateTime.Now.AddMonths(10)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void HasPassedWithAppointmentInYears()
+    public void Has_passed_with_appointment_in_years()
     {
         Assert.False(Appointment.HasPassed(DateTime.Now.AddYears(2).AddMonths(3).AddDays(6)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForEarlyMorningAppointment()
+    public void Is_afternoon_appointment_for_early_morning_appointment()
     {
         Assert.False(Appointment.IsAfternoonAppointment(new DateTime(2019, 6, 17, 8, 15, 0)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForLateMorningAppointment()
+    public void Is_afternoon_appointment_for_late_morning_appointment()
     {
         Assert.False(Appointment.IsAfternoonAppointment(new DateTime(2019, 2, 23, 11, 59, 59)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForNoonAppointment()
+    public void Is_afternoon_appointment_for_noon_appointment()
     {
         Assert.True(Appointment.IsAfternoonAppointment(new DateTime(2019, 8, 9, 12, 0, 0)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForEarlyAfternoonAppointment()
+    public void Is_afternoon_appointment_for_early_afternoon_appointment()
     {
         Assert.True(Appointment.IsAfternoonAppointment(new DateTime(2019, 8, 9, 12, 0, 1)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForLateAfternoonAppointment()
+    public void Is_afternoon_appointment_for_late_afternoon_appointment()
     {
         Assert.True(Appointment.IsAfternoonAppointment(new DateTime(2019, 9, 1, 17, 59, 59)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForEarlyEveningAppointment()
+    public void Is_afternoon_appointment_for_early_evening_appointment()
     {
         Assert.False(Appointment.IsAfternoonAppointment(new DateTime(2019, 9, 1, 18, 0, 0)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void IsAfternoonAppointmentForLateEveningAppointment()
+    public void Is_afternoon_appointment_for_late_evening_appointment()
     {
         Assert.False(Appointment.IsAfternoonAppointment(new DateTime(2019, 9, 1, 23, 59, 59)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DescriptionOnFridayAfternoon()
+    public void Description_on_friday_afternoon()
     {
         Assert.Equal("You have an appointment on 3/29/2019 3:00:00 PM.", Appointment.Description(new DateTime(2019, 03, 29, 15, 0, 0)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DescriptionOnThursdayAfternoon()
+    public void Description_on_thursday_afternoon()
     {
         Assert.Equal("You have an appointment on 7/25/2019 1:45:00 PM.", Appointment.Description(new DateTime(2019, 07, 25, 13, 45, 0)));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DescriptionOnWednesdayMorning()
+    public void Description_on_wednesday_morning()
     {
         Assert.Equal("You have an appointment on 9/9/2020 9:09:09 AM.", Appointment.Description(new DateTime(2020, 9, 9, 9, 9, 9)));
     }
 
     [Fact]
-    public void AnniversaryDate()
+    public void Anniversary_date()
     {
         Assert.Equal(new DateTime(DateTime.Now.Year, 9, 15), Appointment.AnniversaryDate());
     }

--- a/languages/csharp/exercises/concept/enums/EnumsTests.cs
+++ b/languages/csharp/exercises/concept/enums/EnumsTests.cs
@@ -3,85 +3,85 @@ using Xunit;
 public class LogLineTests
 {
     [Fact]
-    public void ParseTrace()
+    public void Parse_trace()
     {
         Assert.Equal(LogLevel.Trace, LogLine.ParseLogLevel("[TRC]: Line 84 - Console.WriteLine('Hello World');"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ParseDebug()
+    public void Parse_debug()
     {
         Assert.Equal(LogLevel.Debug, LogLine.ParseLogLevel("[DBG]: ; expected"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ParseInfo()
+    public void Parse_info()
     {
         Assert.Equal(LogLevel.Info, LogLine.ParseLogLevel("[INF]: Timezone changed"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ParseWarning()
+    public void Parse_warning()
     {
         Assert.Equal(LogLevel.Warning, LogLine.ParseLogLevel("[WRN]: Timezone not set"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ParseError()
+    public void Parse_error()
     {
         Assert.Equal(LogLevel.Error, LogLine.ParseLogLevel("[ERR]: Disk full"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ParseFatal()
+    public void Parse_fatal()
     {
         Assert.Equal(LogLevel.Fatal, LogLine.ParseLogLevel("[FTL]: Not enough memory"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ParseUnknown()
+    public void Parse_unknown()
     {
         Assert.Equal(LogLevel.Unknown, LogLine.ParseLogLevel("[XYZ]: Gibberish message.. beep boop.."));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForTrace()
+    public void Output_for_short_log_for_trace()
     {
         Assert.Equal("0:Line 13 - int myNum = 42;", LogLine.OutputForShortLog(LogLevel.Trace, "Line 13 - int myNum = 42;"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForDebug()
+    public void Output_for_short_log_for_debug()
     {
         Assert.Equal("1:The name 'LogLevel' does not exist in the current context", LogLine.OutputForShortLog(LogLevel.Debug, "The name 'LogLevel' does not exist in the current context"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForInfo()
+    public void Output_for_short_log_for_info()
     {
         Assert.Equal("4:File moved", LogLine.OutputForShortLog(LogLevel.Info, "File moved"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForWarning()
+    public void Output_for_short_log_for_warning()
     {
         Assert.Equal("5:Unsafe password", LogLine.OutputForShortLog(LogLevel.Warning, "Unsafe password"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForError()
+    public void Output_for_short_log_for_error()
     {
         Assert.Equal("6:Stack overflow", LogLine.OutputForShortLog(LogLevel.Error, "Stack overflow"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForFatal()
+    public void Output_for_short_log_for_fatal()
     {
         Assert.Equal("7:Dumping all files", LogLine.OutputForShortLog(LogLevel.Fatal, "Dumping all files"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void OutputForShortLogForUnknown()
+    public void Output_for_short_log_for_unknown()
     {
         Assert.Equal("42:Something unknown happened", LogLine.OutputForShortLog(LogLevel.Unknown, "Something unknown happened"));
     }

--- a/languages/csharp/exercises/concept/flag-enums/FlagEnumsTests.cs
+++ b/languages/csharp/exercises/concept/flag-enums/FlagEnumsTests.cs
@@ -3,133 +3,133 @@ using Xunit;
 public class PermissionsTests
 {
     [Fact]
-    public void DefaultForGuest()
+    public void Default_for_guest()
     {
         Assert.Equal(Permission.Read, Permissions.Default(AccountType.Guest));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DefaultForUser()
+    public void Default_for_user()
     {
         Assert.Equal(Permission.Read | Permission.Write, Permissions.Default(AccountType.User));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DefaultForModerator()
+    public void Default_for_moderator()
     {
         Assert.Equal(Permission.Read | Permission.Write | Permission.Delete, Permissions.Default(AccountType.Moderator));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void DefaultForUnknown()
+    public void Default_for_unknown()
     {
         Assert.Equal(Permission.None, Permissions.Default((AccountType)123));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void GrantReadToNone()
+    public void Grant_read_to_none()
     {
         Assert.Equal(Permission.Read, Permissions.Grant(Permission.None, Permission.Read));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void GrantReadToRead()
+    public void Grant_read_to_read()
     {
         Assert.Equal(Permission.Read, Permissions.Grant(Permission.Read, Permission.Read));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void GrantAllToNone()
+    public void Grant_all_to_none()
     {
         Assert.Equal(Permission.All, Permissions.Grant(Permission.None, Permission.All));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void GrantDeleteToReadAndWrite()
+    public void Grant_delete_to_read_and_write()
     {
         Assert.Equal(Permission.All, Permissions.Grant(Permission.Read | Permission.Write, Permission.Delete));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void GrantReadAndWriteToNone()
+    public void Grant_read_and_write_to_none()
     {
         Assert.Equal(Permission.Read | Permission.Write, Permissions.Grant(Permission.None, Permission.Read | Permission.Write));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RevokeNoneFromRead()
+    public void Revoke_none_from_read()
     {
         Assert.Equal(Permission.Read, Permissions.Revoke(Permission.Read, Permission.None));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RevokeWriteFromWrite()
+    public void Revoke_write_from_write()
     {
         Assert.Equal(Permission.None, Permissions.Revoke(Permission.Write, Permission.Write));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RevokeDeleteFromAll()
+    public void Revoke_delete_from_all()
     {
         Assert.Equal(Permission.Read | Permission.Write, Permissions.Revoke(Permission.All, Permission.Delete));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RevokeReadAndWriteFromWriteAndDelete()
+    public void Revoke_read_and_write_from_write_and_delete()
     {
         Assert.Equal(Permission.Delete, Permissions.Revoke(Permission.Write | Permission.Delete, Permission.Read | Permission.Write));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RevokeAllFromReadAndWrite()
+    public void Revoke_all_from_read_and_write()
     {
         Assert.Equal(Permission.None, Permissions.Revoke(Permission.Read | Permission.Write, Permission.All));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckNoneForRead()
+    public void Check_none_for_read()
     {
         Assert.False(Permissions.Check(Permission.None, Permission.Read));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckWriteForWrite()
+    public void Check_write_for_write()
     {
         Assert.True(Permissions.Check(Permission.Write, Permission.Write));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckAllForWrite()
+    public void Check_all_for_write()
     {
         Assert.True(Permissions.Check(Permission.All, Permission.Write));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckReadAndWriteForRead()
+    public void Check_read_and_write_for_read()
     {
         Assert.True(Permissions.Check(Permission.Read | Permission.Write, Permission.Read));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckAllForReadAndWrite()
+    public void Check_all_for_read_and_write()
     {
         Assert.True(Permissions.Check(Permission.Read | Permission.Write, Permission.Read | Permission.Write));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckReadAndWriteForReadAndWrite()
+    public void Check_read_and_write_for_read_and_write()
     {
         Assert.True(Permissions.Check(Permission.Read | Permission.Write, Permission.Read | Permission.Write));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckReadAndWriteForReadAndDelete()
+    public void Check_read_and_write_for_read_and_delete()
     {
         Assert.False(Permissions.Check(Permission.Read | Permission.Write, Permission.Read | Permission.Delete));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void CheckReadAndWriteAndDeleteForAll()
+    public void Check_read_and_write_and_delete_for_all()
     {
         Assert.True(Permissions.Check(Permission.Read | Permission.Write | Permission.Delete, Permission.All));
     }

--- a/languages/csharp/exercises/concept/floating-point-numbers/FloatingPointNumbersTests.cs
+++ b/languages/csharp/exercises/concept/floating-point-numbers/FloatingPointNumbersTests.cs
@@ -3,145 +3,145 @@ using Xunit;
 public class SavingsAccountTests
 {
     [Fact]
-    public void MinimalFirstInterestRate()
+    public void Minimal_first_interest_rate()
     {
         Assert.Equal(0.5f, SavingsAccount.InterestRate(0m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TinyFirstInterestRate()
+    public void Tiny_first_interest_rate()
     {
         Assert.Equal(0.5f, SavingsAccount.InterestRate(0.000001m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void MaximumFirstInterestRate()
+    public void Maximum_first_interest_rate()
     {
         Assert.Equal(0.5f, SavingsAccount.InterestRate(999.9999m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void MinimalSecondInterestRate()
+    public void Minimal_second_interest_rate()
     {
         Assert.Equal(1.621f, SavingsAccount.InterestRate(1_000.0m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TinySecondInterestRate()
+    public void Tiny_second_interest_rate()
     {
         Assert.Equal(1.621f, SavingsAccount.InterestRate(1_000.0001m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void MaximumSecondInterestRate()
+    public void Maximum_second_interest_rate()
     {
         Assert.Equal(1.621f, SavingsAccount.InterestRate(4_999.9990m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void MinimalThirdInterestRate()
+    public void Minimal_third_interest_rate()
     {
         Assert.Equal(2.475f, SavingsAccount.InterestRate(5_000.0000m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void TinyThirdInterestRate()
+    public void Tiny_third_interest_rate()
     {
         Assert.Equal(2.475f, SavingsAccount.InterestRate(5_000.0001m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void LargeThirdInterestRate()
+    public void Large_third_interest_rate()
     {
         Assert.Equal(2.475f, SavingsAccount.InterestRate(5_639_998.742909m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void MinimalNegativeInterestRate()
+    public void Minimal_negative_interest_rate()
     {
         Assert.Equal(-3.213f, SavingsAccount.InterestRate(-0.000001m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void SmallNegativeInterestRate()
+    public void Small_negative_interest_rate()
     {
         Assert.Equal(-3.213f, SavingsAccount.InterestRate(-0.123m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void RegularNegativeInterestRate()
+    public void Regular_negative_interest_rate()
     {
         Assert.Equal(-3.213f, SavingsAccount.InterestRate(-300.0m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void LargeNegativeInterestRate()
+    public void Large_negative_interest_rate()
     {
         Assert.Equal(-3.213f, SavingsAccount.InterestRate(-152964.231m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForEmptyStartBalance()
+    public void Annual_balance_update_for_empty_start_balance()
     {
         Assert.Equal(0.0000m, SavingsAccount.AnnualBalanceUpdate(0.0m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForSmallPositiveStartBalance()
+    public void Annual_balance_update_for_small_positive_start_balance()
     {
         Assert.Equal(0.000001005m, SavingsAccount.AnnualBalanceUpdate(0.000001m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForAveragePositiveStartBalance()
+    public void Annual_balance_update_for_average_positive_start_balance()
     {
         Assert.Equal(1016.210000m, SavingsAccount.AnnualBalanceUpdate(1_000.0m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForLargePositiveStartBalance()
+    public void Annual_balance_update_for_large_positive_start_balance()
     {
         Assert.Equal(1016.210101621m, SavingsAccount.AnnualBalanceUpdate(1_000.0001m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForHugePositiveStartBalance()
+    public void Annual_balance_update_for_huge_positive_start_balance()
     {
         Assert.Equal(920352587.26744292868451875m, SavingsAccount.AnnualBalanceUpdate(898124017.826243404425m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForSmallNegativeStartBalance()
+    public void Annual_balance_update_for_small_negative_start_balance()
     {
         Assert.Equal(-0.12695199m, SavingsAccount.AnnualBalanceUpdate(-0.123m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void AnnualBalanceUpdateForLargeNegativeStartBalance()
+    public void Annual_balance_update_for_large_negative_start_balance()
     {
         Assert.Equal(-157878.97174203m, SavingsAccount.AnnualBalanceUpdate(-152964.231m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void YearsBeforeDesiredBalanceForSmallStartBalance()
+    public void Years_before_desired_balance_for_small_start_balance()
     {
         Assert.Equal(47, SavingsAccount.YearsBeforeDesiredBalance(100.0m, 125.80m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void YearsBeforeDesiredBalanceForAverageStartBalance()
+    public void Years_before_desired_balance_for_average_start_balance()
     {
         Assert.Equal(6, SavingsAccount.YearsBeforeDesiredBalance(1_000.0m, 1_100.0m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void YearsBeforeDesiredBalanceForLargeStartBalance()
+    public void Years_before_desired_balance_for_large_start_balance()
     {
         Assert.Equal(5, SavingsAccount.YearsBeforeDesiredBalance(8_080.80m, 9_090.90m));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void YearsBeforeDesiredBalanceForLargeDifferentBetweenStartAndTargetBalance()
+    public void Years_before_desired_balance_for_large_different_between_start_and_target_balance()
     {
         Assert.Equal(85, SavingsAccount.YearsBeforeDesiredBalance(2_345.67m, 12_345.6789m));
     }

--- a/languages/csharp/exercises/concept/nullability/NullabilityTests.cs
+++ b/languages/csharp/exercises/concept/nullability/NullabilityTests.cs
@@ -3,25 +3,25 @@ using Xunit;
 public class NullabilityTests
 {
     [Fact]
-    public void LabelForEmployee()
+    public void Label_for_employee()
     {
         Assert.Equal("[17] Ryder Herbert - MARKETING", Badge.Print(17, "Ryder Herbert", "Marketing"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void LabelForNewEmployee()
+    public void Label_for_new_employee()
     {
         Assert.Equal("Bogdan Rosario - MARKETING", Badge.Print(null, "Bogdan Rosario", "Marketing"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void LabelForOwner()
+    public void Label_for_owner()
     {
         Assert.Equal("[59] Julie Sokato - OWNER", Badge.Print(59, "Julie Sokato", null));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void LabelForNewOwner()
+    public void Label_for_new_owner()
     {
         Assert.Equal("Amare Osei - OWNER", Badge.Print(null, "Amare Osei", null));
     }

--- a/languages/csharp/exercises/concept/numbers/NumbersTests.cs
+++ b/languages/csharp/exercises/concept/numbers/NumbersTests.cs
@@ -3,73 +3,73 @@ using Xunit;
 public class AssemblyLineTests
 {
     [Fact]
-    public void ProductionRatePerHourForSpeedZero()
+    public void Production_rate_per_hour_for_speed_zero()
     {
         Assert.Equal(0.0, AssemblyLine.ProductionRatePerHour(0));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ProductionRatePerHourForSpeedOne()
+    public void Production_rate_per_hour_for_speed_one()
     {
         Assert.Equal(221.0, AssemblyLine.ProductionRatePerHour(1));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ProductionRatePerHourForSpeedFour()
+    public void Production_rate_per_hour_for_speed_four()
     {
         Assert.Equal(884.0, AssemblyLine.ProductionRatePerHour(4));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ProductionRatePerHourForSpeedSeven()
+    public void Production_rate_per_hour_for_speed_seven()
     {
         Assert.Equal(1392.3, AssemblyLine.ProductionRatePerHour(7));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ProductionRatePerHourForSpeedNine()
+    public void Production_rate_per_hour_for_speed_nine()
     {
         Assert.Equal(1591.2, AssemblyLine.ProductionRatePerHour(9));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ProductionRatePerHourForSpeedTen()
+    public void Production_rate_per_hour_for_speed_ten()
     {
         Assert.Equal(1701.7, AssemblyLine.ProductionRatePerHour(10));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WorkingItemsPerMinuteForSpeedZero()
+    public void Working_items_per_minute_for_speed_zero()
     {
         Assert.Equal(0, AssemblyLine.WorkingItemsPerMinute(0));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WorkingItemsPerMinuteForSpeedOne()
+    public void Working_items_per_minute_for_speed_one()
     {
         Assert.Equal(3, AssemblyLine.WorkingItemsPerMinute(1));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WorkingItemsPerMinuteForSpeedFive()
+    public void Working_items_per_minute_for_speed_five()
     {
         Assert.Equal(16, AssemblyLine.WorkingItemsPerMinute(5));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WorkingItemsPerMinuteForSpeedEight()
+    public void Working_items_per_minute_for_speed_eight()
     {
         Assert.Equal(26, AssemblyLine.WorkingItemsPerMinute(8));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WorkingItemsPerMinuteForSpeedNine()
+    public void Working_items_per_minute_for_speed_nine()
     {
         Assert.Equal(26, AssemblyLine.WorkingItemsPerMinute(9));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WorkingItemsPerMinuteForSpeedTen()
+    public void Working_items_per_minute_for_speed_ten()
     {
         Assert.Equal(28, AssemblyLine.WorkingItemsPerMinute(10));
     }

--- a/languages/csharp/exercises/concept/properties/PropertiesTests.cs
+++ b/languages/csharp/exercises/concept/properties/PropertiesTests.cs
@@ -19,7 +19,7 @@ public class WeighingMachineTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Get_US_display_weight()
+    public void Get_us_display_weight()
     {
         var wm = new WeighingMachine();
         wm.InputWeight = 60m;
@@ -27,7 +27,7 @@ public class WeighingMachineTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Input_pounds_and_get_US_display_weight()
+    public void Input_pounds_and_get_us_display_weight()
     {
         var wm = new WeighingMachine();
         wm.Units = Units.Pounds;

--- a/languages/csharp/exercises/concept/strings/StringsTests.cs
+++ b/languages/csharp/exercises/concept/strings/StringsTests.cs
@@ -3,67 +3,67 @@ using Xunit;
 public class LogLineTests
 {
     [Fact]
-    public void ErrorMessage()
+    public void Error_message()
     {
         Assert.Equal("Stack overflow", LogLine.Message("[ERROR]: Stack overflow"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WarningMessage()
+    public void Warning_message()
     {
         Assert.Equal("Disk almost full", LogLine.Message("[WARNING]: Disk almost full"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void InfoMessage()
+    public void Info_message()
     {
         Assert.Equal("File moved", LogLine.Message("[INFO]: File moved"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void MessageWithLeadingAndTrailingWhiteSpace()
+    public void Message_with_leading_and_trailing_white_space()
     {
         Assert.Equal("Timezone not set", LogLine.Message("[WARNING]:   \tTimezone not set  \r\n"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ErrorLogLevel()
+    public void Error_log_level()
     {
         Assert.Equal("error", LogLine.LogLevel("[ERROR]: Disk full"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WarningLogLevel()
+    public void Warning_log_level()
     {
         Assert.Equal("warning", LogLine.LogLevel("[WARNING]: Unsafe password"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void InfoLogLevel()
+    public void Info_log_level()
     {
         Assert.Equal("info", LogLine.LogLevel("[INFO]: Timezone changed"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ErrorReformat()
+    public void Error_reformat()
     {
         Assert.Equal("Segmentation fault (error)", LogLine.Reformat("[ERROR]: Segmentation fault"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void WarningReformat()
+    public void Warning_reformat()
     {
         Assert.Equal("Decreased performance (warning)", LogLine.Reformat("[WARNING]: Decreased performance"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void InfoReformat()
+    public void Info_reformat()
     {
         Assert.Equal("Disk defragmented (info)", LogLine.Reformat("[INFO]: Disk defragmented"));
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void ReformatWithLeadingAndTrailingWhiteSpace()
+    public void Reformat_with_leading_and_trailing_white_space()
     {
         Assert.Equal("Corrupt disk (error)", LogLine.Reformat("[ERROR]: \t Corrupt disk\t \t \r\n"));
     }

--- a/languages/csharp/reference/implementing-a-concept-exercise.md
+++ b/languages/csharp/reference/implementing-a-concept-exercise.md
@@ -62,6 +62,7 @@ For more information, please read [this in-depth description][stub-file], [watch
 - [xUnit][xunit] is used as the test framework.
 - Only use `Fact` tests; don't use `Theory` tests.
 - All but the first test should be skipped by default (check [this example][skip-fact]).
+- Test methods should be named using `snake_case`, with the first character uppercased (check [this example][test-name]).
 
 For more information, please read [this in-depth description][tests-file], [watch this video][video-tests-file] and check [this example tests file][example-tests-file].
 
@@ -142,6 +143,7 @@ If you have any questions regarding implementing the exercise, please post them 
 [example-example-file]: ../exercises/concept/strings/.meta/Example.cs
 [example-project-file]: ../exercises/concept/strings/Strings.csproj
 [skip-fact]: ../exercises/concept/strings/StringsTests.cs#L11
+[test-name]: ../exercises/concept/strings/StringsTests.cs#L24
 [xunit]: https://xunit.net/
 [not-implemented-static]: ../exercises/concept/arrays/Arrays.cs#L12
 [not-implemented]: ../exercises/concept/arrays/Arrays.cs#L17


### PR DESCRIPTION
We used inconsistent test method naming. I've updated the convention to use to `snake_case` with the first character uppercased.