### PR TITLE
[General] revert inclusion of .vscode settings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ Gemfile.lock
 
 # Rust
 Cargo.lock
+
+# VScode settings
+.vscode
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "cSpell.words": [
-    "Elyse",
-    "Exercism",
-    "Representer"
-  ]
-}


### PR DESCRIPTION
VScode allows workspace specific settings throgh the use of the .vscode/settings.json file.  Inclusion of this file in the repo disallows personal workspace settings.

Patching to revert that inclusion.