### PR TITLE
[Elixir] Do not require specific Elixir versions

### DIFF
--- a/languages/elixir/exercises/concept/basics/mix.exs
+++ b/languages/elixir/exercises/concept/basics/mix.exs
@@ -5,7 +5,7 @@ defmodule Lasagna.MixProject do
     [
       app: :basics,
       version: "0.1.0",
-      elixir: "~> 1.10",
+      # elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/languages/elixir/exercises/concept/conditionals/mix.exs
+++ b/languages/elixir/exercises/concept/conditionals/mix.exs
@@ -5,7 +5,7 @@ defmodule LogLevel.MixProject do
     [
       app: :conditionals,
       version: "0.1.0",
-      elixir: "~> 1.10",
+      # elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/languages/elixir/exercises/concept/lists/mix.exs
+++ b/languages/elixir/exercises/concept/lists/mix.exs
@@ -3,9 +3,9 @@ defmodule LanguageList.MixProject do
 
   def project do
     [
-      app: :strings,
+      app: :lists,
       version: "0.1.0",
-      elixir: "~> 1.10",
+      # elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/languages/elixir/exercises/concept/maps/mix.exs
+++ b/languages/elixir/exercises/concept/maps/mix.exs
@@ -5,7 +5,7 @@ defmodule HighScore.MixProject do
     [
       app: :maps,
       version: "0.1.0",
-      elixir: "~> 1.10",
+      # elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/languages/elixir/exercises/concept/strings/mix.exs
+++ b/languages/elixir/exercises/concept/strings/mix.exs
@@ -5,7 +5,7 @@ defmodule HighSchoolSweetheart.MixProject do
     [
       app: :strings,
       version: "0.1.0",
-      elixir: "~> 1.10",
+      # elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/languages/elixir/exercises/concept/tuples/mix.exs
+++ b/languages/elixir/exercises/concept/tuples/mix.exs
@@ -5,7 +5,7 @@ defmodule KitchenCalculator.MixProject do
     [
       app: :tuples,
       version: "0.1.0",
-      elixir: "~> 1.10",
+      # elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]


### PR DESCRIPTION
A decision was made to comment Elixir version requirements out of `mix.exs` for backwards compatibility since some package manager versions are out of date, preventing less experienced users being able to run it.