### PR TITLE
[Elixir] Improve concept exercise: basics

### DIFF
--- a/languages/elixir/exercises/concept/basics/.docs/after.md
+++ b/languages/elixir/exercises/concept/basics/.docs/after.md
@@ -47,29 +47,31 @@
   - You may use underscores to separate large numbers.
   - Integers support the [basic mathematical operators][operators].
 
-## Comments
+## Documentation
 
-- Elixir supports [inline documentation][inline-documentation]
+- Elixir provides 3 ways to write [inline documentation][inline-documentation].
 
   - Single line comments are preceded by `#`.
-  - Comments to document a named function must precede the named function definition
+  - Functions may be documented with `@doc` preceding the named function definition
 
-  ```elixir
-  @doc """
-  Function Documentation
-  """
-  def function(), do: true
-  ```
-
-  - One comment to document a module may immediately follow the module definition
-
-  ```elixir
-  defmodule Example do
-    @moduledoc """
-    Module documentation
+    ```elixir
+    @doc """
+    Function Documentation
     """
-  end
-  ```
+    def function(), do: true
+    ```
+
+  - Module may be documented with `@moduledoc` immediately following the module definition
+
+    ```elixir
+    defmodule Example do
+      @moduledoc """
+      Module documentation
+      """
+
+      #...
+    end
+    ```
 
 [functional-programming]: https://en.wikipedia.org/wiki/Functional_programming
 [match]: https://elixirschool.com/en/lessons/basics/pattern-matching/

--- a/languages/elixir/exercises/concept/basics/.docs/after.md
+++ b/languages/elixir/exercises/concept/basics/.docs/after.md
@@ -1,51 +1,75 @@
-Elixir is a dynamically-typed language, meaning that the type of a variable is only checked at runtime. In Elixir, we refer to variable assignment as being _bound_ to a value. Using the [match `=` operator][match], we can bind a value to a variable name:
+- Elixir is dynamically-typed
+  - the type of a variable is only checked at run-time
+- Using the match `=/2` operator, we can bind a value of any type to a variable name:
+  - It is possible to re-bind variables
+  - A variable may have any type of value bound to it.
 
-```elixir
-variable = 10 # Bind the integer value 10
-```
+## Modules
 
-Re-binding a variable's value is also done performed with the [match `=` operator][match]. Once defined, a variable's type can change when re-bound.
+- Modules are the basis of code organization in Elixir.
+  - A module is visible to all other modules.
+  - A module is defined with `defmodule`.
 
-```elixir
-count = 1 # Bind an integer literal value of 1
-count = 2 # Re-bind to the new value of 2
+## Named Functions
 
-# Compiler does not error when binding a new type to the variable
-count = false
-```
+- All named functions must be defined in a module.
 
-Elixir is an [functional-programming language][functional-programming] and requires all named [functions][functions] to be defined in a [module][modules]. The `defmodule` keyword is used to define a module. All modules are available to all other modules at runtime and do not require an _access modifier_ to make them visible to other parts of the program. A [module][modules] is analogous to a _class_ in other programming languages.
+  - Named functions are defined with `def`.
+  - A named function may be made private from external modules by using `defp` instead.
+  - The value of the last line of a function is _implicitly returned_ after it is evaluated
+  - Short functions may also be written using a one-line syntax.
 
-_Named Functions_ must be defined in a module. Each [function][functions] can have zero or more parameters. All parameters are dynamically typed, and the return type is not explicitly declared, it is the type of the value returned. An _access modifier_ can be specified for functions, making only desired functions available for use external to the module. In a function, the value of the last line is _implicitly returned_ to the calling function.
-
-```elixir
-defmodule Calculator do
-  def add(x, y) do
-    x + y
+  ```elixir
+  def increment(n) do
+    n + 1
   end
-end
-```
 
-Invoking a function is done by specifying its module- and function name and passing arguments for each of the functions's parameters. The module name may be omitted if the function is invoked inside of the module.
+  defp private_increment(n) do
+    n + 1
+  end
 
-```elixir
-sum = Calculator.add(1, 2)
-```
+  def short_increment(n), do: n + 1
+  ```
 
-If the function to be called is defined in the same module as the function that calls it, the module name can be omitted.
+- Functions are invoked using the full name of the function with the module name.
+  - If invoked from within its own module, the module name may be omitted.
+- The arity of a function is often used when referring to a named function
 
-When referring to functions, refer to them with their _arity_. The _arity_ of a function is the number or parameters it takes.
+  - The arity refers to the number of parameters it accepts.
 
-```elixir
-# add_3/1 because this function has one parameter, thus an arity of 1
-def add_3(x) do
-  3 + x
-end
-```
+  ```elixir
+  def add(x, y, z), do: x + y + z # add/3, because the arity is 3
+  ```
 
-Elixir supports one type of comment for [inline documentation][inline-documentation]. Single line comments are preceded by `#`.
+## Integers
 
-Integer values are defined as one or more (consecutive) digits and support the [default mathematical operators][operators].
+- Integer values are whole numbers written with one or more digits.
+  - You may use underscores to separate large numbers.
+  - Integers support the [basic mathematical operators][operators].
+
+## Comments
+
+- Elixir supports [inline documentation][inline-documentation]
+
+  - Single line comments are preceded by `#`.
+  - Comments to document a named function must precede the named function definition
+
+  ```elixir
+  @doc """
+  Function Documentation
+  """
+  def function(), do: true
+  ```
+
+  - One comment to document a module may immediately follow the module definition
+
+  ```elixir
+  defmodule Example do
+    @moduledoc """
+    Module documentation
+    """
+  end
+  ```
 
 [functional-programming]: https://en.wikipedia.org/wiki/Functional_programming
 [match]: https://elixirschool.com/en/lessons/basics/pattern-matching/

--- a/languages/elixir/exercises/concept/basics/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/basics/.docs/introduction.md
@@ -51,8 +51,12 @@ def add(x, y, z) do
 end
 ```
 
-## Comments
+## Documentation
 
-Comments can be used for inline documentation. Single line comments in Elixir are preceded by `#`.
+Documentation is a priority in high-quality Elixir code bases, and there are 3 ways to write inline documentation:
+
+- Comments can be used for inline documentation. Single line comments in Elixir are preceded by `#`.
+- Function-level documentation uses the `@doc` annotation preceding named function definitions
+- Module-level documentation uses the `@moduledoc` annotation following the module definition
 
 [functional-programming]: https://en.wikipedia.org/wiki/Functional_programming

--- a/languages/elixir/exercises/concept/basics/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/basics/.docs/introduction.md
@@ -1,44 +1,42 @@
-Elixir is a dynamically-typed language, meaning that the type of a variable is only checked at runtime. Using the match `=` operator, we can bind a value to a variable name:
+Elixir is a dynamically-typed language, meaning that the type of a variable is only checked at runtime. Using the match `=` operator, we can bind a value of any type to a variable name:
 
 ```elixir
-variable = 10 # Bind the integer value 10
+count = 1 # Bound an integer value of 1
+count = 2 # You may re-bind variables
+
+count = false # You may re-bind any type to a variable
 ```
 
-Re-binding a variable's value is also done performed with the `=` operator. Once defined, a variable's type can change when re-bound.
-
-```elixir
-count = 1 # Bind an integer value of 1
-count = 2 # Re-bind to the new value of 2
-
-# Compiler does not error when binding a new type to the variable
-count = false
-```
+## Modules
 
 Elixir is an [functional-programming language][functional-programming] and requires all named functions to be defined in a _module_. The `defmodule` keyword is used to define a module. All modules are available to all other modules at runtime and do not require an _access modifier_ to make them visible to other parts of the program. A _module_ is analogous to a _class_ in other programming languages.
 
-```elixir
-defmodule Calculator do
-  # ...
-end
-```
+## Named Functions
 
 _Named Functions_ must be defined in a module. Each function can have zero or more parameters. All parameters are dynamically-typed, and the return type is not explicitly declared, it is the type of the value returned. An _access modifier_ can be specified for functions, making only desired functions available for use external to the module. In a function, the value of the last line is _implicitly returned_ to the calling function.
+
+Invoking a function is done by specifying its module- and function name and passing arguments for each of the function's parameters. The module name may be omitted if the function is invoked inside of the module.
+
+You may also write short functions using a one-line syntax (note the comma `,` and the colon `:` around the keyword `do`).
 
 ```elixir
 defmodule Calculator do
   def add(x, y) do
     x + y
   end
+
+  def short_add(x, y), do: x + y
 end
-```
 
-Invoking a function is done by specifying its module- and function name and passing arguments for each of the function's parameters. The module name may be omitted if the function is invoked inside of the module.
-
-```elixir
 sum = Calculator.add(1, 2)
+# => 3
+sum = Calculator.short_add(2, 2)
+# => 4
 ```
 
-When referring to functions, it is very common to refer to them with their _arity_. The _arity_ of a function is the number or parameters it takes.
+## Arity of Functions
+
+It is common to refer to functions with their _arity_. The _arity_ of a function is the number of parameters it accepts.
 
 ```elixir
 # add/3 because this function has three parameters, thus an arity of 3
@@ -46,6 +44,8 @@ def add(x, y, z) do
   x + y + z
 end
 ```
+
+## Comments
 
 Comments can be used for inline documentation. Single line comments in Elixir are preceded by `#`.
 

--- a/languages/elixir/exercises/concept/basics/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/basics/.docs/introduction.md
@@ -11,6 +11,12 @@ count = false # You may re-bind any type to a variable
 
 Elixir is an [functional-programming language][functional-programming] and requires all named functions to be defined in a _module_. The `defmodule` keyword is used to define a module. All modules are available to all other modules at runtime and do not require an _access modifier_ to make them visible to other parts of the program. A _module_ is analogous to a _class_ in other programming languages.
 
+```elixir
+defmodule Calculator do
+  # ...
+end
+```
+
 ## Named Functions
 
 _Named Functions_ must be defined in a module. Each function can have zero or more parameters. All parameters are dynamically-typed, and the return type is not explicitly declared, it is the type of the value returned. An _access modifier_ can be specified for functions, making only desired functions available for use external to the module. In a function, the value of the last line is _implicitly returned_ to the calling function.


### PR DESCRIPTION
Some improvements to the basics exercise' introduction and after document.

I have added some content re: `@doc` and `@moduledoc` as comment types (rather than as heredoc strings attached to module attributes).