### PR TITLE
[Elixir] Patch exercise .docs *.md headings

### DIFF
--- a/languages/elixir/exercises/concept/anonymous-functions/.docs/after.md
+++ b/languages/elixir/exercises/concept/anonymous-functions/.docs/after.md
@@ -7,7 +7,7 @@ Enum.map([1, 2, 3], &(&1 + 1))
 # => [2, 3, 4]
 ```
 
-### Key points
+## Key points
 
 - Functions are treated as first class citizens:
   - Can be assigned to variables.

--- a/languages/elixir/exercises/concept/anonymous-functions/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/anonymous-functions/.docs/introduction.md
@@ -33,7 +33,7 @@ variable.(1)
 # => 2
 ```
 
-### Bitwise operations
+## Bitwise operations
 
 Elixir supports many functions for working with bits found in the _Bitwise module_.
 

--- a/languages/elixir/exercises/concept/tuples/.docs/after.md
+++ b/languages/elixir/exercises/concept/tuples/.docs/after.md
@@ -19,7 +19,7 @@ end
 
 It might occur to you that this function may crash if the file does not exist. Don't worry, in Elixir it is often said to [**let it crash**][let-it-crash], because in elixir applications, a supervising process will restart the application to a known-good state.
 
-## [Tuples][tuple-doc]
+## Tuples
 
 - [Tuple][tuple-doc] literals are enclosed with curly braces, `{}`.
 - [Tuples][tuple-doc] may hold any data-type in contiguous memory, which is allocated when the tuple is created.

--- a/languages/elixir/exercises/concept/tuples/.docs/after.md
+++ b/languages/elixir/exercises/concept/tuples/.docs/after.md
@@ -19,9 +19,7 @@ end
 
 It might occur to you that this function may crash if the file does not exist. Don't worry, in Elixir it is often said to [**let it crash**][let-it-crash], because in elixir applications, a supervising process will restart the application to a known-good state.
 
-## Key-points
-
-### [Tuples][tuple-doc]
+## [Tuples][tuple-doc]
 
 - [Tuple][tuple-doc] literals are enclosed with curly braces, `{}`.
 - [Tuples][tuple-doc] may hold any data-type in contiguous memory, which is allocated when the tuple is created.
@@ -29,7 +27,7 @@ It might occur to you that this function may crash if the file does not exist. D
 - When manipulating a [tuple][tuple-doc], rather than mutating the existing [tuple][tuple-doc], a new one is created.
 - The [`Kernel`][kernel-module] and [`Tuple`][tuple-module] modules have useful functions for working with [tuples][tuple-doc].
 
-### Pattern Matching
+## Pattern Matching
 
 - [Pattern matching][pattern-match-doc] is explicitly performed using the match operator, [`=/2`][match-op].
 


### PR DESCRIPTION
Referring to the [style guide](https://github.com/exercism/v3/blob/master/docs/maintainers/style-guide.md), headings now fixed for each of the student-facing exercise docs.

All headings standardized to level 2 headings (e.g. `## heading`).  No other substantive changes made.

---

I've included @SleeplessByte for review as he is often involved in website-copy.