### PR TITLE
[Docs] Use consistent headings in documentation

### DIFF
--- a/docs/concept-exercises.md
+++ b/docs/concept-exercises.md
@@ -80,8 +80,8 @@ This file is split into two parts.
 
 Each task must conform to the following standard:
 
-- Start with a third-level heading starting with a number (e.g. `### 1. Do X`, `### 2. Do Y`).
-- The heading should describe _what_ to implement, not _how_ to implement it (e.g. `### 1. Check if an appointment has already passed`).
+- Start with a second-level heading starting with a number (e.g. `## 1. Do X`, `## 2. Do Y`).
+- The heading should describe _what_ to implement, not _how_ to implement it (e.g. `## 1. Check if an appointment has already passed`).
 - Describe which function/method the student needs to define/implement (e.g. `Implement method X(...) that takes an A and returns a Z`),
 - Provide an example usage of that function in code. These examples should be different to those given in the tests.
 
@@ -95,8 +95,8 @@ For more information, watch [this video][video-docs-instructions.md] and check [
 - Hints should be bullet-pointed underneath headings.
 - The hints should be enough to unblock almost any student.
 - The hints should not spell out the solution, but instead point to a resource describing the solution (e.g. linking to documentation for the function to use).
-- General hints about the exercise can appear under the `### General` heading.
-- Task-specific hints should appear underneath headings that match their task heading in the `instructions.md` (e.g. `### 2. Do Y`).
+- General hints about the exercise can appear under the `## General` heading.
+- Task-specific hints should appear underneath headings that match their task heading in the `instructions.md` (e.g. `## 2. Do Y`).
 
 Viewing hints will not be a "recommended" path and we will (softly) discourage using it unless the student can't progress without it. As such, it's worth considering that the student reading it will be a little confused/overwhelmed and maybe frustrated.
 

--- a/languages/clojure/exercises/concept/lists/.docs/hints.md
+++ b/languages/clojure/exercises/concept/lists/.docs/hints.md
@@ -1,23 +1,23 @@
-### 1. Create an empty list
+## 1. Create an empty list
 
 Creating an empty list is just like creating a list with items. It can be done using `list` or using `quote` on an empty list.
 
-### 2. Add a new language to the list
+## 2. Add a new language to the list
 
 Clojure has a core function that can [prepend an item to a list](https://clojuredocs.org/clojure.core/cons).
 
-### 3. Check the language last added
+## 3. Check the language last added
 
 Like other Lisps, Clojure has a function that [returns the first item from a list](https://clojuredocs.org/clojure.core/first).
 
-### 4. Remove the first language from the list
+## 4. Remove the first language from the list
 
 Likewise, Clojure also has a function for [returning a list with the first item removed](https://clojuredocs.org/clojure.core/rest).
 
-### 5. Count the languages in the list
+## 5. Count the languages in the list
 
 The [number of items](https://clojuredocs.org/clojure.core/count) in a list can easily be returned using a Clojure core function.
 
-### 6. Put it all together
+## 6. Put it all together
 
 Remember that function calls can be nested.

--- a/languages/clojure/exercises/concept/lists/.docs/instructions.md
+++ b/languages/clojure/exercises/concept/lists/.docs/instructions.md
@@ -2,7 +2,7 @@ In this exercise you'll be writing code to process a list of programming languag
 
 You have six tasks.
 
-### 1. Create a new list
+## 1. Create a new list
 
 Before you can add languages, you'll need to start by creating an new list. Define a function that returns an empty list.
 
@@ -11,7 +11,7 @@ Before you can add languages, you'll need to start by creating an new list. Defi
 ;; => ()
 ```
 
-### 2. Add a new language to the list
+## 2. Add a new language to the list
 
 As you explore Exercism and find languages you want to learn, you'll need to be able to add them to your list. Define a function to add a new language the the beginning of your list.
 
@@ -20,7 +20,7 @@ As you explore Exercism and find languages you want to learn, you'll need to be 
 ;; => '("JavaScript" "Clojurescript")
 ```
 
-### 3. Check the language last added
+## 3. Check the language last added
 
 You'll want to quickly check which language you just added. Define a function that returns the first language from your list.
 
@@ -29,7 +29,7 @@ You'll want to quickly check which language you just added. Define a function th
 ;; => "Haskell"
 ```
 
-### 4. Remove the first language from the list
+## 4. Remove the first language from the list
 
 Sometimes you'll change your mind about a language you just added. Define a function to remove the first language from your list.
 
@@ -38,7 +38,7 @@ Sometimes you'll change your mind about a language you just added. Define a func
 ;; => '("Racket" "Scheme")
 ```
 
-### 5. Count the languages in the list
+## 5. Count the languages in the list
 
 Counting the languages one-by-one is inconvenient. Define function to count the number of languages on your list.
 
@@ -47,7 +47,7 @@ Counting the languages one-by-one is inconvenient. Define function to count the 
 ;; => 4
 ```
 
-### 6. Put it all together
+## 6. Put it all together
 
 Define a `learning-list` function, within which you will use the some of the functions you've defined above.
 

--- a/languages/cpp/exercises/concept/strings/.docs/hints.md
+++ b/languages/cpp/exercises/concept/strings/.docs/hints.md
@@ -1,14 +1,14 @@
-### General
+## General
 
 - [This tutorial][strings-tutorial] offers a nice introduction to C++ strings.
 - The `std::basic_string` class has many useful [built-in methods][cpp-reference-string].
 
-### 1. Get message from a log line
+## 1. Get message from a log line
 
 - The built-in methods offer some ways to [find][cpp-reference-string-find] text in a string.
 - The built-in methods can help us [get a portion][cpp-reference-string-substr] of a string
 
-### 2. Reformat a log line
+## 2. Reformat a log line
 
 There are several ways to concatenate strings, the simplest is using the [`+` operator][cpp-reference-string-concatenation] but there are [more advanced ones][cpp-reference-printf].
 

--- a/languages/cpp/exercises/concept/strings/.docs/instructions.md
+++ b/languages/cpp/exercises/concept/strings/.docs/instructions.md
@@ -10,7 +10,7 @@ There are three different log levels:
 
 You have three tasks, each of which will take a log line and ask you to do something with it.
 
-### 1. Get message from a log line
+## 1. Get message from a log line
 
 Implement the `log_line::message` method to return a log line's message:
 
@@ -19,7 +19,7 @@ log_line::message("[ERROR]: Invalid operation")
 // => "Invalid operation"
 ```
 
-### 2. Get log level from a log line
+## 2. Get log level from a log line
 
 Implement the `log_line::log_level` method to return a log line's log level, which should be returned in lowercase:
 
@@ -28,7 +28,7 @@ log_line::log_level("[ERROR]: Invalid operation")
 // => "ERROR"
 ```
 
-### 3. Reformat a log line
+## 3. Reformat a log line
 
 Implement the `log_line::reformat` method that reformats the log line, putting the message first and the log level after it in parentheses:
 

--- a/languages/csharp/exercises/concept/arrays/.docs/hints.md
+++ b/languages/csharp/exercises/concept/arrays/.docs/hints.md
@@ -1,33 +1,33 @@
-### General
+## General
 
 - The bird count per day is stored in a [field][fields] named `birdsPerDay`.
 - The bird count per day is an array that contains exactly 7 integers.
 
-### 1. Check what the counts were last week
+## 1. Check what the counts were last week
 
 - As this method does _not_ depend on the current week's count, it is defined as a [`static` method][static-members].
 - There are [several ways to define an array][single-dimensional-arrays].
 
-### 2. Check how many birds visited today
+## 2. Check how many birds visited today
 
 - Remember that the counts are ordered by day from oldest to most recent, with the last element representing today.
 - Accessing the last element can be done either by using its (fixed) index (remember to start counting from zero) or by calculating its index using the [array's size][array-length].
 
-### 3. Increment today's count
+## 3. Increment today's count
 
 - Set the element representing today's count to today's count plus 1.
 
-### 4. Check if there was a day with no visiting birds
+## 4. Check if there was a day with no visiting birds
 
 - The `Array` class has a [built-in method][array-indexof] that returns the first index where the element is found, or -1 if no matching element was found.
 
-### 5. Calculate the total number of visiting birds
+## 5. Calculate the total number of visiting birds
 
 - A variable can be used to hold the total number of visiting birds.
 - The array can be iterated over using a [`foreach` loop][array-foreach].
 - The variable can be updated inside the loop.
 
-### 6. Calculate the number of busy days
+## 6. Calculate the number of busy days
 
 - A variable can be used to hold the number of busy days.
 - The array can be iterated over using a [`foreach` loop][array-foreach].

--- a/languages/csharp/exercises/concept/arrays/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/arrays/.docs/instructions.md
@@ -2,7 +2,7 @@ You're an avid bird watcher that keeps track of how many birds have visited your
 
 You have six tasks, all dealing with the numbers of birds that visited your garden.
 
-### 1. Check what the counts were last week
+## 1. Check what the counts were last week
 
 For comparison purposes, you always keep a copy of last week's counts nearby, which were: 0, 2, 5, 3, 7, 8 and 4. Implement the (_static_) `BirdCount.LastWeek()` method that returns last week's counts:
 
@@ -11,7 +11,7 @@ BirdCount.LastWeek();
 // => [0, 2, 5, 3, 7, 8, 4]
 ```
 
-### 2. Check how many birds visited today
+## 2. Check how many birds visited today
 
 Implement the `BirdCount.Today()` method to return how many birds visited your garden today. The bird counts are ordered by day, with the first element being the count of the oldest day, and the last element being today's count.
 
@@ -22,7 +22,7 @@ birdCount.Today();
 // => 1
 ```
 
-### 3. Increment today's count
+## 3. Increment today's count
 
 Implement the `BirdCount.IncrementDayCount()` method to increment today's count:
 
@@ -34,7 +34,7 @@ birdCount.Today();
 // => 2
 ```
 
-### 4. Check if there was a day with no visiting birds
+## 4. Check if there was a day with no visiting birds
 
 Implement the `BirdCount.HasDayWithoutBirds()` method that returns `true` if there was a day at which zero birds visited the garden; otherwise, return `false`:
 
@@ -45,7 +45,7 @@ birdCount.HasDayWithoutBirds();
 // => true
 ```
 
-### 5. Calculate the total number of visiting birds
+## 5. Calculate the total number of visiting birds
 
 Implement the `BirdCount.Total()` method to return the total number of birds that have visited your garden:
 
@@ -56,7 +56,7 @@ birdCount.Total();
 // => 19
 ```
 
-### 6. Calculate the number of busy days
+## 6. Calculate the number of busy days
 
 Some days are busier that others. A busy day is one where five or more birds have visited your garden.
 Implement the `BirdCount.BusyDays()` method to return the number of busy days:

--- a/languages/csharp/exercises/concept/basics/.docs/hints.md
+++ b/languages/csharp/exercises/concept/basics/.docs/hints.md
@@ -1,27 +1,27 @@
-### General
+## General
 
 - An [integer value][integers] can be defined as one or more consecutive digits.
 
-### 1. Define the expected oven time in minutes
+## 1. Define the expected oven time in minutes
 
 - You need to define a [method][methods] without any arguments.
 - You need to return an [integer][integers].
 
-### 2. Calculate the remaining oven time in minutes
+## 2. Calculate the remaining oven time in minutes
 
 - You need to define a [method][methods] with a single parameter.
 - You have to [explicitly return an integer][return] from a method.
 - The method's parameter is an [integer][integers].
 - You can use the [mathematical operator for subtraction][operators] to subtract values.
 
-### 3. Calculate the preparation time in minutes
+## 3. Calculate the preparation time in minutes
 
 - You need to define a [method][methods] with a single parameter.
 - You have to [explicitly return an integer][return] from a method.
 - The method's parameter is an [integer][integers].
 - You can use the [mathematical operator for multiplicaton][operators] to multiply values.
 
-### 4. Calculate the total working time in minutes
+## 4. Calculate the total working time in minutes
 
 - You need to define a [method][methods] with two parameters.
 - You have to [explicitly return an integer][return] from a method.

--- a/languages/csharp/exercises/concept/basics/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/basics/.docs/instructions.md
@@ -2,7 +2,7 @@ In this exercise you're going to write some code to help you cook a brilliant la
 
 You have four tasks, all related to the time spent cooking the lasasgna.
 
-### 1. Define the expected oven time in minutes
+## 1. Define the expected oven time in minutes
 
 Define the `Lasagna.ExpectedMinutesInOven()` method that does not take any parameters and returns how many minutes the lasagna should be in the oven. According to the cooking book, the expected oven time in minutes is 40:
 
@@ -12,7 +12,7 @@ lasagna.ExpectedMinutesInOven();
 // => 40
 ```
 
-### 2. Calculate the remaining oven time in minutes
+## 2. Calculate the remaining oven time in minutes
 
 Define the `Lasagna.RemainingMinutesInOven()` method that takes the actual minutes the lasagna has been in the oven as a parameter and returns how many minutes the lasagna still has to remain in the oven, based on the expected oven time in minutes from the previous task.
 
@@ -22,7 +22,7 @@ lasagna.RemainingMinutesInOven(30);
 // => 10
 ```
 
-### 3. Calculate the preparation time in minutes
+## 3. Calculate the preparation time in minutes
 
 Define the `Lasagna.PreparationTimeInMinutes()` method that takes the number of layers you added to the lasagna as a parameter and returns how many minutes you spent preparing the lasagna, assuming each layer takes you 2 minutes to prepare.
 
@@ -32,7 +32,7 @@ lasagna.PreparationTimeInMinutes(2);
 // => 4
 ```
 
-### 4. Calculate the total working time in minutes
+## 4. Calculate the total working time in minutes
 
 Define the `Lasagna.TotalTimeInMinutes()` method that takes two parameters: the first parameter is the number of layers you added to the lasagna, and the second parameter is the number of minutes the lasagna has been in the oven. The function should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
 

--- a/languages/csharp/exercises/concept/booleans/.docs/hints.md
+++ b/languages/csharp/exercises/concept/booleans/.docs/hints.md
@@ -1,9 +1,9 @@
-### General
+## General
 
 - There are three [boolean operators][operators] to work with boolean values.
 - Multiple operators can be combined in a single expression.
 
-### 1. Check if a fast attack can be made
+## 1. Check if a fast attack can be made
 
 - The [boolean operators][operators] can also be applied to boolean parameters.
 

--- a/languages/csharp/exercises/concept/booleans/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/booleans/.docs/instructions.md
@@ -13,7 +13,7 @@ You have four tasks: to implement the logic for determining if the above actions
 
 ## Tasks
 
-### 1. Check if a fast attack can be made
+## 1. Check if a fast attack can be made
 
 Implement the (_static_) `QuestLogic.CanFastAttack()` method that takes a boolean value that indicates if the knight is awake. This method returns `true` if a fast attack can be made based on the state of the knight. Otherwise, returns `false`:
 
@@ -23,7 +23,7 @@ QuestLogic.CanFastAttack(knightIsAwake);
 // => false
 ```
 
-### 2. Check if the group can be spied upon
+## 2. Check if the group can be spied upon
 
 Implement the (_static_) `QuestLogic.CanSpy()` method that takes three boolean values, indicating if the knight, archer and the prisoner, respectively, are awake. The method returns `true` if the group can be spied upon, based on the state of the three characters. Otherwise, returns `false`:
 
@@ -35,7 +35,7 @@ QuestLogic.CanSpy(knightIsAwake, archerIsAwake, prisonerIsAwake);
 // => true
 ```
 
-### 3. Check if the prisoner can be signalled
+## 3. Check if the prisoner can be signalled
 
 Implement the (_static_) `QuestLogic.CanSignalPrisoner()` method that takes two boolean values, indicating if the archer and the prisoner, respectively, are awake. The method returns `true` if the prisoner can be signalled, based on the state of the two characters. Otherwise, returns `false`:
 
@@ -46,7 +46,7 @@ QuestLogic.CanSignalPrisoner(archerIsAwake, prisonerIsAwake);
 // => true
 ```
 
-### 4. Check if the prisoner can be freed
+## 4. Check if the prisoner can be freed
 
 Implement the (_static_) `QuestLogic.CanFreePrisoner()` method that takes four boolean values. The first three parameters indicate if the knight, archer and the prisoner, respectively, are awake. The last parameter indicates if Annalyn's pet dog is present. The method returns `true` if the prisoner can be freed based on the state of the three characters and Annalyn's pet dog presence. Otherwise, it returns `false`:
 

--- a/languages/csharp/exercises/concept/classes/.docs/hints.md
+++ b/languages/csharp/exercises/concept/classes/.docs/hints.md
@@ -1,31 +1,31 @@
-### General
+## General
 
-### 1. Buy a brand-new remote controlled car
+## 1. Buy a brand-new remote controlled car
 
 - [This page shows how to create a new instance of a class][creating-objects].
 
-### 2. Display the distance driven
+## 2. Display the distance driven
 
 - Keep track of the distance driven in a [field][fields].
 - Consider what visibility to use for the field (does it need to be used outside the class?).
 - Consider using [string interpolation][string-interpolation] to format the string to return.
 
-### 3. Display the battery percentage
+## 3. Display the battery percentage
 
 - Keep track of the distance driven in a [field][fields].
 - Initialize the field to a specific value to correspond to the initial battery charge.
 - Consider what visibility to use for the field (does it need to be used outside the class?).
 - Consider using [string interpolation][string-interpolation] to format the string to return.
 
-### 4. Update the number of meters driven when driving
+## 4. Update the number of meters driven when driving
 
 - Update the field representing the distance driven.
 
-### 5. Update the battery percentage when driving
+## 5. Update the battery percentage when driving
 
 - Update the field representing the battery percentage driven.
 
-### 6. Prevent driving when the battery is drained
+## 6. Prevent driving when the battery is drained
 
 - Add a conditional to only update the distance and battery if the battery is not already drained.
 - Add a conditional to display the empty battery message if the battery is drained.

--- a/languages/csharp/exercises/concept/classes/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/classes/.docs/instructions.md
@@ -11,7 +11,7 @@ If the battery is at 0%, you can't drive the car anymore and the battery display
 
 You have six tasks, each of which will work with remote controlled car instances.
 
-### 1. Buy a brand-new remote controlled car
+## 1. Buy a brand-new remote controlled car
 
 Implement the (_static_) `RemoteControlCar.Buy()` method to return a brand-new remote controlled car instance:
 
@@ -19,7 +19,7 @@ Implement the (_static_) `RemoteControlCar.Buy()` method to return a brand-new r
 RemoteControlCar car = RemoteControlCar.Buy();
 ```
 
-### 2. Display the distance driven
+## 2. Display the distance driven
 
 Implement the `RemoteControlCar.DistanceDisplay()` method to return the distance as displayed on the LED display:
 
@@ -29,7 +29,7 @@ car.DistanceDisplay();
 // => "Driven 0 meters"
 ```
 
-### 3. Display the battery percentage
+## 3. Display the battery percentage
 
 Implement the `RemoteControlCar.BatteryDisplay()` method to return the distance as displayed on the LED display:
 
@@ -39,7 +39,7 @@ car.BatteryDisplay();
 // => "Battery at 100%"
 ```
 
-### 4. Update the number of meters driven when driving
+## 4. Update the number of meters driven when driving
 
 Implement the `RemoteControlCar.Drive()` method that updates the number of meters driven:
 
@@ -51,7 +51,7 @@ car.DistanceDisplay();
 // => "Driven 40 meters"
 ```
 
-### 5. Update the battery percentage when driving
+## 5. Update the battery percentage when driving
 
 Update the `RemoteControlCar.Drive()` method to update the battery percentage:
 
@@ -63,7 +63,7 @@ car.BatteryDisplay();
 // => "Battery at 98%"
 ```
 
-### 6. Prevent driving when the battery is drained
+## 6. Prevent driving when the battery is drained
 
 Update the `RemoteControlCar.Drive()` method to not increase the distance driven nor decrease the battery percentage when the battery is drained (at 0%):
 

--- a/languages/csharp/exercises/concept/constructors/.docs/hints.md
+++ b/languages/csharp/exercises/concept/constructors/.docs/hints.md
@@ -1,30 +1,30 @@
-### 1. Creating a remote controlled car
+## 1. Creating a remote controlled car
 
 - [Define a constructor][constructor-syntax] that has two `int` parameters.
 - Store the two parameters as [fields][fields] to access them from the classes' methods.
 
-### 2. Creating a race track
+## 2. Creating a race track
 
 - [Define a constructor][constructor-syntax] that has one `int` parameter.
 - Store the parameter as a [field][fields] to access it from the class' method.
 
-### 3. Drive the car
+## 3. Drive the car
 
 - Add a [field][fields] to keep track of the distance driven.
 - Add the car's speed to the [field][fields] that keeps track of the distance driven.
 
-### 4. Check for a drained battery
+## 4. Check for a drained battery
 
 - Add a [field][fields] to keep track of the remaining battery charge percentage (starts at 100%).
 - Remove the car's battery drain from the [field][fields] to keep track of the battery charge.
 - Don't update the distance driven if the battery is drained.
 - Remember that if the battery charge is less than the battery drain percentage, it is considered drained.
 
-### 5. Create the Nitro remote control car
+## 5. Create the Nitro remote control car
 
 - [Instantiate][instance-constructors] an instance of the `RemoteControlCar` with the correct arguments.
 
-### 6. Check if a remote control car can finish a race
+## 6. Check if a remote control car can finish a race
 
 - Solving this is probably best done by [repeatedly driving the car][while].
 - Remember that the car has a method to retrieve the distance it has driven.

--- a/languages/csharp/exercises/concept/constructors/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/constructors/.docs/instructions.md
@@ -8,7 +8,7 @@ Each race track has its own distance. Cars are tested by checking if they can fi
 
 You have six tasks, each of which will work with remote controller car instances.
 
-### 1. Creating a remote controlled car
+## 1. Creating a remote controlled car
 
 Allow creating a remote controller car by defining a constructor for the `RemoteControlCar` class that takes the speed of the car in meters and the battery drain percentage as its two parameters (both of type `int`):
 
@@ -18,7 +18,7 @@ int batteryDrain = 2;
 var car = new RemoteControlCar(speed, batteryDrain);
 ```
 
-### 2. Creating a race track
+## 2. Creating a race track
 
 Allow creating a race track by defining a constructor for the `RaceTrack` class that takes the track's distance in meters as its sole parameter (which is of type `int`):
 
@@ -27,7 +27,7 @@ int distance = 800;
 var raceTrack = new RaceTrack(distance);
 ```
 
-### 3. Drive the car
+## 3. Drive the car
 
 Implement the `RemoteControlCar.Drive()` method that updates the number of meters driven based on the car's speed. Also implement the `RemoteControlCar.DistanceDriven()` method to return the number of meters driven by the car:
 
@@ -41,7 +41,7 @@ car.DistanceDriven();
 // => 5
 ```
 
-### 4. Check for a drained battery
+## 4. Check for a drained battery
 
 Update the `RemoteControlCar.Drive()` method to drain the battery based on the car's battery drain. Also implement the `RemoteControlCar.BatteryDrained()` method that indicates if the battery is drained:
 
@@ -55,7 +55,7 @@ car.BatteryDrained();
 // => false
 ```
 
-### 5. Create the Nitro remote control car
+## 5. Create the Nitro remote control car
 
 The best-selling remote control car is the Nitro, which has a stunning top speed of 50 meters with a battery drain of 4%. Implement the (static) `RemoteControlCar.Nitro()` method to return this type of car:
 
@@ -65,7 +65,7 @@ car.Drive();
 car.DistanceDriven();
 // => 50
 
-### 6. Check if a remote control car can finish a race
+## 6. Check if a remote control car can finish a race
 
 To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `Race.CarCanFinish()` method that takes a `RemoteControlCar` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`:
 

--- a/languages/csharp/exercises/concept/datetimes/.docs/hints.md
+++ b/languages/csharp/exercises/concept/datetimes/.docs/hints.md
@@ -1,26 +1,26 @@
-### General
+## General
 
 - [Tutorial on dates and time by csharp.net][csharp.net-datetimes-working-with-datetimes-time]
 
-### 1. Parse appointment date
+## 1. Parse appointment date
 
 - The `DateTime` class has several methods to [parse][docs.microsoft.com_parsing-date] a `string` to a `DateTime`.
 
-### 2. Check if an appointment has already passed
+## 2. Check if an appointment has already passed
 
 - `DateTime` objects can be compared using the default [comparison operators][docs.microsoft.com_datetime-operators].
 - There is a [property][docs.microsoft.com_datetime-properties] to retrieve the current date and time.
 
-### 3. Check if appointment is in the afternoon
+## 3. Check if appointment is in the afternoon
 
 - Accessing the time portion of a `DateTime` object can de done through one of its [properties][docs.microsoft.com_datetime-properties].
 
-### 4. Describe the time and date of the appointment
+## 4. Describe the time and date of the appointment
 
 - The tests are running as if running on a machine in the United States, which means that when converting a `DateTime` to a `string` will return dates and time in US format.
 - When converting a `DateTime` instance to a `string`, you can use either a [standard format string][docs.microsoft.com_standard-date-and-time-format-strings] or a [custom format string][docs.microsoft.com_custom-date-and-time-format-strings].
 
-### 5. Return the anniversary date
+## 5. Return the anniversary date
 
 - Use one of the various `DateTime` [constructors][constructors] to create a new `DateTime` instance.
 - You can use one of the current date time's [properties][docs.microsoft.com_datetime-properties] to get the current year.

--- a/languages/csharp/exercises/concept/datetimes/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/datetimes/.docs/instructions.md
@@ -9,7 +9,7 @@ You have four tasks, which will all involve appointment dates. The dates and tim
 
 The tests will automatically set the culture to `en-US` - you don't have to set or specify the culture yourselves.
 
-### 1. Parse appointment date
+## 1. Parse appointment date
 
 Implement the (_static_) `Appointment.Schedule()` method to parse a textual representation of an appointment date into the corresponding `DateTime` format:
 
@@ -18,7 +18,7 @@ Appointment.Schedule("7/25/2019 13:45:00")
 // => new DateTime(2019, 7, 25, 13, 45, 0)
 ```
 
-### 2. Check if an appointment has already passed
+## 2. Check if an appointment has already passed
 
 Implement the (_static_) `Appointment.HasPassed()` method that takes an appointment date and checks if the appointment was somewhere in the past:
 
@@ -27,7 +27,7 @@ Appointment.HasPassed(new DateTime(1999, 12, 31, 9, 0, 0))
 // => true
 ```
 
-### 3. Check if appointment is in the afternoon
+## 3. Check if appointment is in the afternoon
 
 Implement the (_static_) `Appointment.IsAfternoonAppointment()` method that takes an appointment date and checks if the appointment is in the afternoon (>= 12:00 and < 18:00):
 
@@ -36,7 +36,7 @@ Appointment.IsAfternoonAppointment(new DateTime(2019, 03, 29, 15, 0, 0))
 // => true
 ```
 
-### 4. Describe the time and date of the appointment
+## 4. Describe the time and date of the appointment
 
 Implement the (_static_) `Appointment.Description()` method that takes an appointment date and returns a description of that date and time:
 
@@ -45,7 +45,7 @@ Appointment.Description(new DateTime(2019, 03, 29, 15, 0, 0))
 // => "You have an appointment on Friday 29 March 2019 at 15:00."
 ```
 
-### 5. Return the anniversary date
+## 5. Return the anniversary date
 
 Implement the (_static_) `Appointment.AnniversaryDate()` method that returns this year's anniversary date, which is September 15th:
 

--- a/languages/csharp/exercises/concept/enums/.docs/hints.md
+++ b/languages/csharp/exercises/concept/enums/.docs/hints.md
@@ -1,17 +1,17 @@
-### General
+## General
 
 - [Tutorial on working with enums][docs.microsoft.com-enumeration-types].
 
-### 1. Parse log level
+## 1. Parse log level
 
 - There is a [method to get a part of a string](https://docs.microsoft.com/en-us/dotnet/api/system.string.substring?view=netcore-3.1).
 - You can use a [`switch` statement](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/switch) to elegantly handle the various log levels.
 
-### 2. Support unknown log level
+## 2. Support unknown log level
 
 - There is a [special switch case](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/switch#the-default-case) that can be used to catch unspecified cases.
 
-### 3. Convert log line to short format
+## 3. Convert log line to short format
 
 - One can [assign specific values to enum members][docs.microsoft.com_creating-an-enumeration-type].
 - Converting an enum to a number can be done through [casting][docs.microsoft.com_enumeration-types-casting] or by using a [format string][docs.microsoft.com_system.enum.tostring].

--- a/languages/csharp/exercises/concept/enums/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/enums/.docs/instructions.md
@@ -13,7 +13,7 @@ These are the different log levels:
 
 You have three tasks.
 
-### 1. Parse log level
+## 1. Parse log level
 
 Define a `LogLevel` enum that has six elements corresponding to the above log levels.
 
@@ -31,7 +31,7 @@ LogLine.ParseLogLevel("[INF]: File deleted")
 // => LogLevel.Info
 ```
 
-### 2. Support unknown log level
+## 2. Support unknown log level
 
 Unfortunately, occasionally some log lines have an unknown log level. To gracefully handle these log lines, add an `Unknown` element to the `LogLevel` enum which should be returned when parsing an unknown log level:
 
@@ -40,7 +40,7 @@ LogLine.ParseLogLevel("[XYZ]: Overly specific, out of context message")
 // => LogLevel.Unknown
 ```
 
-### 3. Convert log line to short format
+## 3. Convert log line to short format
 
 The log level of a log line is quite verbose. To reduce the disk space needed to store the log lines, a short format is developed: `"[<ENCODED_LEVEL>]:<MESSAGE>"`.
 

--- a/languages/csharp/exercises/concept/flag-enums/.docs/hints.md
+++ b/languages/csharp/exercises/concept/flag-enums/.docs/hints.md
@@ -1,17 +1,17 @@
-### 1. Get default permissions for an account type
+## 1. Get default permissions for an account type
 
 - To handle each account type, one could use an `if` statement, but the [`switch` statement][docs.microsoft.com-switch-keyword] is a great alternative.
 - Combining flags means setting a specific bit to `1` using one of the [bitwise operators][docs.microsoft.com-bitwise-and-shift-operators].
 
-### 2. Grant a permission
+## 2. Grant a permission
 
 - Combining flags means setting a specific bit to `1` using one of the [bitwise operators][docs.microsoft.com-bitwise-and-shift-operators].
 
-### 3. Revoke a permission
+## 3. Revoke a permission
 
 - Removing a flag means setting a specific bit to `0` using a combination of two [bitwise operators][docs.microsoft.com-bitwise-and-shift-operators].
 
-### 4. Check for a permission
+## 4. Check for a permission
 
 - Checking a permission can be done by checking the result of applying one of the [bitwise operators][docs.microsoft.com-bitwise-and-shift-operators].
 

--- a/languages/csharp/exercises/concept/flag-enums/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/flag-enums/.docs/instructions.md
@@ -14,7 +14,7 @@ Sometimes individual permissions are modified, for example giving a guest accoun
 
 You have four tasks.
 
-### 1. Get default permissions for an account type
+## 1. Get default permissions for an account type
 
 First, define an `AccountType` enum to represent the three account types. Next, define a `Permission` enum to represent the three permission types and two extra ones: one for having no permissions at all, and for having all permissions.
 
@@ -25,7 +25,7 @@ Permissions.Default(AccountType.Guest)
 // => Permission.Read
 ```
 
-### 2. Grant a permission
+## 2. Grant a permission
 
 Implement the (_static_) `Permissions.Grant()` method that grants (adds) a permission:
 
@@ -34,7 +34,7 @@ Permissions.Grant(current: Permission.None, grant: Permission.Read)
 // => Permission.Read
 ```
 
-### 3. Revoke a permission
+## 3. Revoke a permission
 
 Implement the (_static_) `Permissions.Revoke()` method that revokes (removes) a permission:
 
@@ -43,7 +43,7 @@ Permissions.Revoke(current: Permission.Read, grant: Permission.Read)
 // => Permission.None
 ```
 
-### 4. Check for a permission
+## 4. Check for a permission
 
 Implement the (_static_) `Permissions.Check()` method that takes the current account's permissions and checks if the account is authorized for a given permission:
 

--- a/languages/csharp/exercises/concept/floating-point-numbers/.docs/hints.md
+++ b/languages/csharp/exercises/concept/floating-point-numbers/.docs/hints.md
@@ -1,16 +1,16 @@
-### General
+## General
 
 - [Floating-point numeric types introduction][docs.microsoft.com-floating_point_numeric_types].
 
-### 1. Calculate the interest rate
+## 1. Calculate the interest rate
 
 - By default, any floating-point number defined in C# code is treated as a `double`. To use a different floating-point type (like `float` or `decimal`), one must add the appropriate [suffix][docs.microsoft.com-real_literals] to the number.
 
-### 2. Calculate the annual balance update
+## 2. Calculate the annual balance update
 
 - When calculating the annual yield, it might be useful to temporarily convert a negative balance to a positive one. One could use arithmetic here, or one of the methods in the [`Math` class][docs-microsoft.com-system.math].
 
-### 3. Calculate the years before reaching the desired balance
+## 3. Calculate the years before reaching the desired balance
 
 - To calculate the years, one can keep looping until the desired balance is reached. C# has several [looping constructs][docs.microsoft.com-loops].
 - There is a special [operator][increment-operator] to increment values by 1.

--- a/languages/csharp/exercises/concept/floating-point-numbers/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/floating-point-numbers/.docs/instructions.md
@@ -7,7 +7,7 @@ In this exercise you'll be working with savings accounts. Each year, the balance
 
 You have three tasks, each of which will deal your balance and its interest rate.
 
-### 1. Calculate the interest rate
+## 1. Calculate the interest rate
 
 Implement the (_static_) `SavingsAccount.InterestRate()` method to calculate the interest rate based on the specified balance:
 
@@ -18,7 +18,7 @@ SavingsAccount.InterestRate(balance: 200.75m)
 
 Note that the value returned is a `float`.
 
-### 2. Calculate the annual balance update
+## 2. Calculate the annual balance update
 
 Implement the (_static_) `SavingsAccount.AnnualBalanceUpdate()` method to calculate the annual balance update, taking into account the interest rate:
 
@@ -29,7 +29,7 @@ SavingsAccount.AnnualBalanceUpdate(balance: 200.75m)
 
 Note that the value returned is a `decimal`.
 
-### 3. Calculate the years before reaching the desired balance
+## 3. Calculate the years before reaching the desired balance
 
 Implement the (_static_) `SavingsAccount.YearsBeforeDesiredBalance()` method to calculate the minimum number of years required to reach the desired balance:
 

--- a/languages/csharp/exercises/concept/inheritance/.docs/hints.md
+++ b/languages/csharp/exercises/concept/inheritance/.docs/hints.md
@@ -1,27 +1,27 @@
-### 1. Describe a character
+## 1. Describe a character
 
 - Modify the [constructors][constructor-syntax] of the `Wizard` and `Warrior` classes to pass their character type to the [base class' constructor][instance-constructors].
 - Store the character type as a [field][fields] on the `Character` class.
 - The `Character` class implicitly inherits from the `object` class, which [`ToString()` method you can override][override-tostring].
 
-### 2. Make characters not vulnerable by default
+## 2. Make characters not vulnerable by default
 
 - Implement the `Vulnerable()` method in the `Character` class to always return `false`.
 
-### 3. Allow Wizards to prepare a spell
+## 3. Allow Wizards to prepare a spell
 
 - Add a field to the `Wizard` class to store if a spell was prepared and update this in the `PrepareSpell()` method.
 - The spell should start out as not being prepared.
 
-### 4. Make Wizards vulnerable when not having prepared a spell
+## 4. Make Wizards vulnerable when not having prepared a spell
 
 - Override the `Vulnerable()` method in the `Wizard` class to make Wizards vulnerable if they haven't prepared a spell.
 
-### 5. Calculate the damage points for a Wizard
+## 5. Calculate the damage points for a Wizard
 
 - Use a [conditional statement][if-else] to return the the damage points, taking into account the value of the prepare spell field.
 
-### 6. Calculate the damage points for a Warrior
+## 6. Calculate the damage points for a Warrior
 
 - You can call a method on the passed `Character` instance to determine its vulnerability.
 - Use a [conditional statement][if-else] to return the the damage points, taking into account the vulnerability of the target.

--- a/languages/csharp/exercises/concept/inheritance/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/inheritance/.docs/instructions.md
@@ -16,7 +16,7 @@ In general, characters are never vulnerable. However, Wizards _are_ vulnerable i
 
 You have six tasks that work with Warriors and Wizard characters.
 
-### 1. Describe a character
+## 1. Describe a character
 
 Override the `ToString()` method on the `Character` class to return a description of the character, formatted as `"Character is a <CHARACTER_TYPE>"`.
 
@@ -26,7 +26,7 @@ warrior.ToString();
 // => "Character is a Warrior"
 ```
 
-### 2. Make characters not vulnerable by default
+## 2. Make characters not vulnerable by default
 
 Ensure that the `Character.Vulnerable()` method always returns `false`.
 
@@ -36,7 +36,7 @@ warrior.Vulnerable();
 // => false
 ```
 
-### 3. Allow Wizards to prepare a spell
+## 3. Allow Wizards to prepare a spell
 
 Implement the `Wizard.PrepareSpell()` method to allow a Wizard to prepare a spell in advance.
 
@@ -45,7 +45,7 @@ var wizard = new Wizard();
 wizard.PrepareSpell();
 ```
 
-### 4. Make Wizards vulnerable when not having prepared a spell
+## 4. Make Wizards vulnerable when not having prepared a spell
 
 Ensure that the `Vulnerable()` method returns `true` if the wizard did not prepare a spell; otherwise, return `false`.
 
@@ -55,7 +55,7 @@ wizard.Vulnerable();
 // => true
 ```
 
-### 5. Calculate the damage points for a Wizard
+## 5. Calculate the damage points for a Wizard
 
 Implement the `Wizard.DamagePoints()` method to return the damage points dealt: 12 damage points when a spell has been prepared, 3 damage points when not.
 
@@ -68,7 +68,7 @@ wizard.DamagePoints(warrior);
 // => 12
 ```
 
-### 6. Calculate the damage points for a Warrior
+## 6. Calculate the damage points for a Warrior
 
 Implement the `Warrior.DamagePoints()` method to return the damage points dealt: 10 damage points when the target is vulnerable, 6 damage points when not.
 

--- a/languages/csharp/exercises/concept/method-overloading/.docs/hints.md
+++ b/languages/csharp/exercises/concept/method-overloading/.docs/hints.md
@@ -1,18 +1,18 @@
-### General
+## General
 
 - [Method overloading in C#][member-overloading].
 - [String interpolation][string-interpolation] can be used to format description strings.
 
-### 3. Describe the travel method
+## 3. Describe the travel method
 
 - A [simple conditional][if-statement] can be used for the conditional logic.
 
-### 4. Describe a character traveling to a destination
+## 4. Describe a character traveling to a destination
 
 - You can re-use the existing describe functionality.
 - You can use [expressions in interpolated strings][string-interpolation-expressions], which means you can call methods directly in the interpolated parts of an interpolated string.
 
-### 5. Describe a character traveling to a destination without specifying the travel method
+## 5. Describe a character traveling to a destination without specifying the travel method
 
 - You can re-use the existing functionality that does take an explicit travel method.
 - You can use [optional parameters][optional-arguments] to simplify the amount of code you need.

--- a/languages/csharp/exercises/concept/method-overloading/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/method-overloading/.docs/instructions.md
@@ -2,7 +2,7 @@ In this exercise you're playing a role-playing game named "Wizard and Warriors" 
 
 You have five tasks that have you describe parts of the game to the players.
 
-### 1. Describe a character
+## 1. Describe a character
 
 Each character has a class, level and number of hit points and is described as: `"You're a level <LEVEL> <CLASS> with <HIT_POINTS> hit points."`. Implement the (static) `GameMaster.Describe` method that takes a `Character` as its sole parameter and returns its description.
 
@@ -16,7 +16,7 @@ GameMaster.Describe(character);
 // => "You're a level 4 Wizard with 28 hit points."
 ```
 
-### 2. Describe a destination
+## 2. Describe a destination
 
 Each destination has a name and a number of inhabitants and is described as: `"You've arrived at <NAME>, which has <INHABITANTS> inhabitants."`. Implement the (static) `GameMaster.Describe` method that takes a `Destination` as its sole parameter and returns its description.
 
@@ -29,7 +29,7 @@ GameMaster.Describe(destination);
 // => "You've arrived at Muros, which has 732 inhabitants."
 ```
 
-### 3. Describe the travel method
+## 3. Describe the travel method
 
 Characters can travel to a destination using one of two options:
 
@@ -43,7 +43,7 @@ GameMaster.Describe(TravelMethod.Horseback);
 // => "You're traveling to your destination on horseback."
 ```
 
-### 4. Describe a character traveling to a destination
+## 4. Describe a character traveling to a destination
 
 When a character is traveling to a destination, this is described as a combination of the individual descriptions: `"<CHARACTER> <TRAVEL_METHOD> <DESTINATION>"`. Implement the (static) `GameMaster.Describe` method that takes a `Character`, a `Destination` and a `TravelMethod` as its parameters and return its description.
 
@@ -61,7 +61,7 @@ GameMaster.Describe(character, destination, TravelMethod.Horseback);
 // => "You're a level 4 Wizard with 28 hit points. You're traveling to your destination on horseback. You've arrived at Muros, which has 732 inhabitants."
 ```
 
-### 5. Describe a character traveling to a destination without specifying the travel method
+## 5. Describe a character traveling to a destination without specifying the travel method
 
 In the majority of cases, characters are traveling to a destination by walking. For convenience, players are allowed to omit mentioning their travel method, in which case walking will be assumed to be the travel method. Implement the (static) `GameMaster.Describe` method that takes a `Character` and a `Destination` as its parameters and return its description.
 

--- a/languages/csharp/exercises/concept/nullability/.docs/hints.md
+++ b/languages/csharp/exercises/concept/nullability/.docs/hints.md
@@ -1,14 +1,14 @@
-### 1. Print a badge for an employee
+## 1. Print a badge for an employee
 
 - [String interpolation][string-interpolation] can be used to concisely format the badge.
 - There is a [built-in method to convert a string to uppercase][toupper].
 
-### 2. Print a badge for a new employee
+## 2. Print a badge for a new employee
 
 - You should check if the ID is `null` before using it.
 - [This tutorial goes into detail how to work with nullable value types][nullable-types-tutorial].
 
-### 3. Print a badge for the owner
+## 3. Print a badge for the owner
 
 - You should check if the department is `null` before using it.
 - [This tutorial goes into detail how to work with nullable reference types][nullable-reference-types-tutorial].

--- a/languages/csharp/exercises/concept/nullability/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/nullability/.docs/instructions.md
@@ -1,6 +1,6 @@
 In this exercise you'll be writing code to print name badges for factory employees.
 
-### 1. Print a badge for an employee
+## 1. Print a badge for an employee
 
 Employees have an ID, name and department name. Employee badge labels are formatted as follows: `"[id] - [name] - [DEPARTMENT]"`. Implement the (_static_) `Badge.Print()` method to return an employee's badge label:
 
@@ -11,7 +11,7 @@ Badge.Print(734, "Ernest Johnny Payne", "Strategic Communication");
 
 Note that the department should be uppercased on the label.
 
-### 2. Print a badge for a new employee
+## 2. Print a badge for a new employee
 
 Due to a quirk in the computer system, new employees occasionally don't yet have an ID when they start working at the factory. As badges are required, they will receive a temporary badge without the ID prefix. Modify the (_static_) `Badge.Print()` method to support new employees that don't yet have an ID:
 
@@ -20,7 +20,7 @@ Badge.Print(id: null, "Jane Johnson", "Procurement");
 // => "Jane Johnson - PROCUREMENT"
 ```
 
-### 3. Print a badge for the owner
+## 3. Print a badge for the owner
 
 Even the factory's owner has to wear a badge at all times. However, an owner does not have a department. In this case, the label should print `"OWNER"` instead of the department name. Modify the (_static_) `Badge.Print()` method to print a label for the owner:
 

--- a/languages/csharp/exercises/concept/numbers/.docs/hints.md
+++ b/languages/csharp/exercises/concept/numbers/.docs/hints.md
@@ -1,14 +1,14 @@
-### General
+## General
 
 - [Numbers tutorial][numbers].
 
-### 1. Calculate the production rate per second
+## 1. Calculate the production rate per second
 
 - Determining the success rate can be done through a [conditional statement][if-statement].
 - C# allows for multiplication to be applied to two different number types (such as an `int` and a `double`). It will automatically return the "largest" data type.
 - Numbers can be compared using the built-in [comparison-][comparison-operators] and [equality operators][equality-operators].
 
-### 2. Calculate the number of working items produced per second
+## 2. Calculate the number of working items produced per second
 
 - Whereas an `int` can be automatically converted to a `double`, the reverse does not hold. The reason for this is that an `int` has less precision than a `double` so rounding has to be applied, also the range of numbers an `int` can represent is smaller than a `double`. To force this conversion, one can either use one of the [`Convert` class' methods][convert-class] or [cast to an int][cast-int].
 

--- a/languages/csharp/exercises/concept/numbers/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/numbers/.docs/instructions.md
@@ -9,7 +9,7 @@ At its lowest speed (`1`), `221` cars are produced each hour. The production inc
 
 You have two tasks.
 
-### 1. Calculate the production rate per hour
+## 1. Calculate the production rate per hour
 
 Implement the (_static_) `AssemblyLine.ProductionRatePerHour()` method to calculate the assembly line's production rate per hour, taking into account its success rate:
 
@@ -20,7 +20,7 @@ AssemblyLine.ProductionRatePerHour(6)
 
 Note that the value returned is a `double`.
 
-### 2. Calculate the number of working items produced per minute
+## 2. Calculate the number of working items produced per minute
 
 Implement the (_static_) `AssemblyLine.WorkingItemsPerMinute()` method to calculate how many working cars are produced per minute:
 

--- a/languages/csharp/exercises/concept/properties/.docs/hints.md
+++ b/languages/csharp/exercises/concept/properties/.docs/hints.md
@@ -1,25 +1,25 @@
-### General
+## General
 
 - [Properties][docs.microsoft.com-properties]
 - [Using Properties][docs.microsoft.com-using-properties]
 
-### 1. Allow the weight to be set on the weighing machine
+## 1. Allow the weight to be set on the weighing machine
 
 A property with a private [backing field][docs.microsoft.com-properties-with-backing-fields] is appropriate here.
 
-### 2. Ensure that a negative input weight is rejected.
+## 2. Ensure that a negative input weight is rejected.
 
 Add [validation][stackoverflow.com-validating-properties] to the `InputWeight`'s `set` accessor to throw an exception.
 
-### 3. Allow the US weight to be retrieved
+## 3. Allow the US weight to be retrieved
 
 A property can return a reference to an object.
 
-### 4. Allow the machine's units to be set to pounds
+## 4. Allow the machine's units to be set to pounds
 
 `Units` is a good candidate for an [auto-implemented property][docs.microsoft.com-auto-implemented-properties].
 
-### 5. Allow a tare adjustment to be applied to the weighing machine
+## 5. Allow a tare adjustment to be applied to the weighing machine
 
 Accessors can have [different access levels][docs.microsoft.com-properties-and-restricted-access] to each other.
 

--- a/languages/csharp/exercises/concept/properties/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/properties/.docs/instructions.md
@@ -29,7 +29,7 @@ For Example:
 You have 5 tasks each of which requires you to implement one or
 more properties:
 
-### 1. Allow the weight to be set on the weighing machine
+## 1. Allow the weight to be set on the weighing machine
 
 Implement the `WeigingMachine.InputWeight` property to allow the weight to be get and set:
 
@@ -40,7 +40,7 @@ wm.InputWeight = 60m;
 //  => wm.InputWeight == 60m
 ```
 
-### 2. Ensure that a negative input weight is rejected
+## 2. Ensure that a negative input weight is rejected
 
 Add validation to the `WeighingMachine.InputWeight` property to throw an `ArgumentOutOfRangeException` when trying to set it to a negative weight:
 
@@ -49,7 +49,7 @@ var wm = new WeighingMachine();
 wm.InputWeight = -10m; // Throws an ArgumentException
 ```
 
-### 3. Allow the US weight to be retrieved
+## 3. Allow the US weight to be retrieved
 
 Implement the `WeighingMachine.USDisplayWeight` property and the `USWeight` class:
 
@@ -61,7 +61,7 @@ var usw = wm.USDisplayWeight;
 // => usw.Pounds == 132 && usw.Ounces == 4
 ```
 
-### 4. Allow the machine's units to be set to pounds
+## 4. Allow the machine's units to be set to pounds
 
 Implement the `WeighingMachine.Units` property:
 
@@ -74,7 +74,7 @@ var usw = wm.USDisplayWeight;
 // => usw.Pounds == 175 && usw.Ounces == 8
 ```
 
-### 5. Allow a tare adjustment to be applied to the weighing machine
+## 5. Allow a tare adjustment to be applied to the weighing machine
 
 Implement the `WeighingMachine.TareAdjustment` and `WeighingMachine.DisplayWeight` properties:
 

--- a/languages/csharp/exercises/concept/properties/.docs/introduction.md
+++ b/languages/csharp/exercises/concept/properties/.docs/introduction.md
@@ -18,7 +18,7 @@ accessor and vice versa. A property doesn't have to have both accessors, it can 
 
 The basic syntax to express properties can take two forms:
 
-###### Field/Expression Backed Properties:
+#### Field/Expression Backed Properties:
 
 ```csharp
 private int myField;
@@ -29,7 +29,7 @@ public int MyProperty
 }
 ```
 
-###### Auto-implemented Properties
+#### Auto-implemented Properties
 
 ```
 public int MyProperty { get; private set; } = 42;

--- a/languages/csharp/exercises/concept/strings/.docs/hints.md
+++ b/languages/csharp/exercises/concept/strings/.docs/hints.md
@@ -1,18 +1,18 @@
-### General
+## General
 
 - The [csharp.net strings tutorial][tutorial-csharp.net-strings] has a nice introduction to C# `string`s.
 - The `string` class has many useful [built-in methods][docs-string-methods].
 
-### 1. Get message from a log line
+## 1. Get message from a log line
 
 - Different options to search for text in a string are explored in [this tutorial][tutorial-docs.microsoft.com-search-text-in-string].
 - Removing white space is [built-in][tutorial-docs.microsoft.com-trim-white-space].
 
-### 2. Get log level from a log line
+## 2. Get log level from a log line
 
 - Changing a `string`'s casing is explored in [this tutorial][tutorial-docs.microsoft.com-changing-case].
 
-### 3. Reformat a log line
+## 3. Reformat a log line
 
 - There are several ways to [concatenate strings][tutorial-docs.microsoft.com-concatenate-strings], but the preferred one is usually [string interpolation][tutorial-csharp.net-string-interpolation].
 

--- a/languages/csharp/exercises/concept/strings/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/strings/.docs/instructions.md
@@ -10,7 +10,7 @@ There are three different log levels:
 
 You have three tasks, each of which will take a log line and ask you to do something with it.
 
-### 1. Get message from a log line
+## 1. Get message from a log line
 
 Implement the (_static_) `LogLine.Message()` method to return a log line's message:
 
@@ -26,7 +26,7 @@ LogLine.Message("[WARNING]:  Disk almost full\r\n")
 // => "Disk almost full"
 ```
 
-### 2. Get log level from a log line
+## 2. Get log level from a log line
 
 Implement the (_static_) `LogLine.LogLevel()` method to return a log line's log level, which should be returned in lowercase:
 
@@ -35,7 +35,7 @@ LogLine.LogLevel("[ERROR]: Invalid operation")
 // => "error"
 ```
 
-### 3. Reformat a log line
+## 3. Reformat a log line
 
 Implement the (_static_) `LogLine.Reformat()` method that reformats the log line, putting the message first and the log level after it in parentheses:
 

--- a/languages/elixir/exercises/concept/anonymous-functions/.docs/hints.md
+++ b/languages/elixir/exercises/concept/anonymous-functions/.docs/hints.md
@@ -1,36 +1,36 @@
-### General
+## General
 
 - Make use of [anonymous functions][anon-fns].
 - Use a [closure][closure] to reference the variable from the outer scope.
 
-### 1. Create an adder
+## 1. Create an adder
 
 - Return an anonymous function which adds the parameter from the anonymous function to the parameter passed in to `Secret.secret_add/1`
 
-### 2. Create a subtractor
+## 2. Create a subtractor
 
 - Return an anonymous function which subtracts the parameter passed in to `Secret.secret_subtract/1` from the parameter from the anonymous function.
 
-### 3. Create a multiplier
+## 3. Create a multiplier
 
 - Return an anonymous function which multiplies the parameter from the anonymous function to the parameter passed in to `Secret.secret_multiply/1`
 
-### 4. Create a divider
+## 4. Create a divider
 
 - return an anonymous function which divides the parameter from the anonymous function by the parameter passed in to `Secret.secret_divide/1`
 - make use of [integer division][div]
 
-### 5. Create an "and"-er
+## 5. Create an "and"-er
 
 - Return an anonymous function which performs a [bitwise _and_][bitwise-wiki] operation using the parameter passed in to the anonymous function and the parameter passed in to `Secret.secret_and/1`
 - functions in the [Bitwise module][bitwise-hexdocs] may be of use.
 
-### 6. Create an "xor"-er
+## 6. Create an "xor"-er
 
 - Return an anonymous function which performs a [bitwise _xor_][bitwise-wiki] operation using the parameter passed in to the anonymous function and the parameter passed in to `Secret.secret_xor/1`
 - functions in the [Bitwise module][bitwise-hexdocs] may be of use.
 
-### 7. Create a function combiner
+## 7. Create a function combiner
 
 - Return an anonymous function which [composes the functions][fn-composition] passed in to `Secret.secret_combine/2`
 

--- a/languages/elixir/exercises/concept/anonymous-functions/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/anonymous-functions/.docs/instructions.md
@@ -6,7 +6,7 @@ All functions should expect integer parameters. Integers are also suitable for p
 
 You have seven tasks:
 
-### 1. Create an adder
+## 1. Create an adder
 
 Implement `Secrets.secret_add/1`, have it return a function which takes one parameter and adds it to the parameter passed in to `secret_add`.
 
@@ -16,7 +16,7 @@ adder.(2)
 # => 4
 ```
 
-### 2. Create a subtractor
+## 2. Create a subtractor
 
 Implement `Secrets.secret_subtract/1`, have it return a function which takes one parameter and subtracts the parameter passed in to `secret_subtract`.
 
@@ -26,7 +26,7 @@ subtractor.(3)
 # => 1
 ```
 
-### 3. Create a multiplier
+## 3. Create a multiplier
 
 Implement `Secrets.secret_multiply/1`, have it return a function which takes one parameter and multiplies it by the parameter passed in to `secret_multiply`.
 
@@ -36,7 +36,7 @@ multiplier.(3)
 # => 21
 ```
 
-### 4. Create a divider
+## 4. Create a divider
 
 Implement `Secrets.secret_divide/1`, have it return a function which takes one parameter and divides it by the parameter passed in to `secret_divide`.
 
@@ -48,7 +48,7 @@ divider.(32)
 
 Make use of integer division.
 
-### 5. Create a "and"-er
+## 5. Create a "and"-er
 
 Implement `Secrets.secret_and/1`, have it return a function which takes one parameter and performs a bitwise _and_ operation to the parameter passed in to `secret_and`.
 
@@ -58,7 +58,7 @@ ander.(2)
 # => 0
 ```
 
-### 6. Create a "xor"-er
+## 6. Create a "xor"-er
 
 Implement `Secrets.secret_xor/1`, have it return a function which takes one parameter and performs a bitwise _xor_ operation to the parameter passed in to `secret_xor`.
 
@@ -68,7 +68,7 @@ xorer.(3)
 # => 2
 ```
 
-### 7. Create a function combiner
+## 7. Create a function combiner
 
 Implement `Secrets.secret_combine/2`, have it return a function which applies the functions parameter passed in to `secret_combine` in sequence.
 

--- a/languages/elixir/exercises/concept/anonymous-functions/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/anonymous-functions/.docs/introduction.md
@@ -33,7 +33,7 @@ variable.(1)
 # => 2
 ```
 
-#### Bitwise operations
+### Bitwise operations
 
 Elixir supports many functions for working with bits found in the _Bitwise module_.
 

--- a/languages/elixir/exercises/concept/basics/.docs/hints.md
+++ b/languages/elixir/exercises/concept/basics/.docs/hints.md
@@ -1,27 +1,27 @@
-### General
+## General
 
 - An [integer value][integers] can be defined as one or more consecutive digits.
 
-### 1. Define the expected oven time in minutes
+## 1. Define the expected oven time in minutes
 
 - You need to define a [function][functions] without any arguments.
 - You need to return an [integer][integers].
 
-### 2. Calculate the remaining oven time in minutes
+## 2. Calculate the remaining oven time in minutes
 
 - You need to define a [function][functions] with a single parameter.
 - You have to [implicitly return an integer][return] from a function.
 - The function's parameter is an [integer][integers].
 - You can use the [mathematical operator for subtraction][operators] to subtract values.
 
-### 3. Calculate the preparation time in minutes
+## 3. Calculate the preparation time in minutes
 
 - You need to define a [function][functions] with a single parameter.
 - You have to [implicitly return an integer][return] from a function.
 - The function's parameter is an [integer][integers].
 - You can use the [mathematical operator for multiplicaton][operators] to multiply values.
 
-### 4. Calculate the total working time in minutes
+## 4. Calculate the total working time in minutes
 
 - You need to define a [function][functions] with two parameters.
 - You have to [implicitly return an integer][return] from a function.

--- a/languages/elixir/exercises/concept/basics/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/basics/.docs/instructions.md
@@ -2,7 +2,7 @@ In this exercise you're going to write some code to help you cook a brilliant la
 
 You have four tasks, all related to the time spent cooking the lasagna.
 
-### 1. Define the expected oven time in minutes
+## 1. Define the expected oven time in minutes
 
 Define the `Lasagna.expected_minutes_in_oven/0` method that does not take any parameters and returns how many minutes the lasagna should be in the oven. According to the cooking book, the expected oven time in minutes is 40:
 
@@ -11,7 +11,7 @@ Lasagna.expected_minutes_in_oven()
 # => 40
 ```
 
-### 2. Calculate the remaining oven time in minutes
+## 2. Calculate the remaining oven time in minutes
 
 Define the `Lasagna.remaining_minutes_in_oven/1` method that takes the actual minutes the lasagna has been in the oven as a parameter and returns how many minutes the lasagna still has to remain in the oven, based on the expected oven time in minutes from the previous task.
 
@@ -20,7 +20,7 @@ Lasagna.remaining_minutes_in_oven(30)
 # => 10
 ```
 
-### 3. Calculate the preparation time in minutes
+## 3. Calculate the preparation time in minutes
 
 Define the `Lasagna.preparation_time_in_minutes/1` method that takes the number of layers you added to the lasagna as a parameter and returns how many minutes you spent preparing the lasagna, assuming each layer takes you 2 minutes to prepare.
 
@@ -29,7 +29,7 @@ Lasagna.preparation_time_in_minutes(2)
 # => 4
 ```
 
-### 4. Calculate the total working time in minutes
+## 4. Calculate the total working time in minutes
 
 Define the `Lasagna.total_time_in_minutes/2` method that takes two parameters: the first parameter is the number of layers you added to the lasagna, and the second parameter is the number of minutes the lasagna has been in the oven. The function should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
 

--- a/languages/elixir/exercises/concept/booleans/.docs/hints.md
+++ b/languages/elixir/exercises/concept/booleans/.docs/hints.md
@@ -1,8 +1,8 @@
-### General
+## General
 
 Don't worry about how the paramaters are derived, just focus on combining the parameters to return the intended result.
 
-### 1. Define if pac-man can eat a ghost
+## 1. Define if pac-man can eat a ghost
 
 - You need to define a [named function][named-function] with 2 arguments.
   - The first argument is a [boolean][boolean] value, whether pac-man has a power pellet active.
@@ -10,7 +10,7 @@ Don't worry about how the paramaters are derived, just focus on combining the pa
 - The function must return a [boolean][boolean] value.
 - You can use the [boolean][boolean] operator [`and/2`][boolean-function] to combine the arguments for a result.
 
-### 2. Define if pac-man scores
+## 2. Define if pac-man scores
 
 - You need to define a [named function][named-function] with 2 arguments.
   - The first argument is a [boolean][boolean] value, whether pac-man is touching a power pellet.
@@ -18,7 +18,7 @@ Don't worry about how the paramaters are derived, just focus on combining the pa
 - The function must return a [boolean][boolean] value.
 - You can use the [boolean][boolean] operator [`or/2`][boolean-function] to combine the arguments for a result.
 
-### 3. Define if pac-man loses
+## 3. Define if pac-man loses
 
 - You need to define a [named function][named-function] with 2 arguments.
   - The first argument is a [boolean][boolean] value, whether pac-man has a power pellet active.
@@ -26,7 +26,7 @@ Don't worry about how the paramaters are derived, just focus on combining the pa
 - The function must return a [boolean][boolean] value.
 - You can use the [boolean][boolean] operators [`and/2`][boolean-function] and [`not/1`][boolean-function] to combine the arguments for a result.
 
-### 4. Define if pac-man wins
+## 4. Define if pac-man wins
 
 - You need to define a [named function][named-function] with 3 arguments.
   - The second argument is a [boolean][boolean] value, whether pac-man has eaten all of the dots.

--- a/languages/elixir/exercises/concept/booleans/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/booleans/.docs/instructions.md
@@ -4,7 +4,7 @@ You have four rules to translate, all related to the game states.
 
 > Don't worry about how the parameters are derived, just focus on combining the parameters to return the intended result.
 
-### 1. Define if Pac-Man eats a ghost
+## 1. Define if Pac-Man eats a ghost
 
 Define the `Rules.eat_ghost?/2` function that takes two parameters (_if Pac-Man has a power pellet active_ and _if Pac-Man is touching a ghost_) and returns a boolean value if Pac-Man is able to eat the ghost. The function should return true only if Pac-Man has a power pellet active and is touching a ghost.
 
@@ -13,7 +13,7 @@ Rules.eat_ghost?(false, true)
 # => false
 ```
 
-### 2. Define if Pac-Man scores
+## 2. Define if Pac-Man scores
 
 Define the `Rules.score?/2` function that takes two parameters (_if Pac-Man is touching a power pellet_ and _if Pac-Man is touching a dot_) and returns a boolean value if Pac-Man scored. The function should return true if Pac-Man is touching a power pellet or a dot.
 
@@ -22,7 +22,7 @@ Rules.score?(true, true)
 # => true
 ```
 
-### 3. Define if Pac-Man loses
+## 3. Define if Pac-Man loses
 
 Define the `Rules.lose?/2` function that takes two parameters (_if Pac-Man has a power pellet active_ and _if Pac-Man is touching a ghost_) and returns a boolean value if Pac-Man loses. The function should return true if Pac-Man is touching a ghost and does not have a power pellet active.
 
@@ -31,7 +31,7 @@ Rules.lose?(false, true)
 # => true
 ```
 
-### 4. Define if Pac-Man wins
+## 4. Define if Pac-Man wins
 
 Define the `Rules.win?/3` function that takes three parameters (_if Pac-Man has eaten all of the dots_, _if Pac-Man has a power pellet active_, and _if Pac-Man is touching a ghost_) and returns a boolean value if Pac-Man wins. The function should return true if Pac-Man has eaten all of the dots and has not lost based on the parameters defined in part 3.
 

--- a/languages/elixir/exercises/concept/conditionals/.docs/hints.md
+++ b/languages/elixir/exercises/concept/conditionals/.docs/hints.md
@@ -1,17 +1,17 @@
-### General
+## General
 
 - The [atom type is described here][atom].
 
-### 1. Return the logging code label
+## 1. Return the logging code label
 
 - You can use the [`cond/1` function][cond] to elegantly handle the various log codes.
 - You can use [equality operators][equality] to compare integers for strict type equality.
 
-### 2. Support unknown logging codes
+## 2. Support unknown logging codes
 
 - There is a [way to specify a default branch][cond] in a cond function that can be used to catch unspecified cases.
 
-### 3. Send an alert
+## 3. Send an alert
 
 - You can use the [`cond/1` function][cond] to decide if an alert should be sent.
 - You can use [equality operators][equality] to compare atoms for equality.

--- a/languages/elixir/exercises/concept/conditionals/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/conditionals/.docs/instructions.md
@@ -11,7 +11,7 @@ These are the different log codes:
 
 You have three tasks:
 
-### 1. Return the logging code label
+## 1. Return the logging code label
 
 Implement the `LogLevel.to_label/1` function to return the label of a log line from an integer code:
 
@@ -20,7 +20,7 @@ LogLevel.to_label(1)
 # => :debug
 ```
 
-### 2. Support unknown logging codes
+## 2. Support unknown logging codes
 
 Unfortunately, some log lines occasionally have an unknown log code. To gracefully handle these log lines, add an _unknown_ label to the `LogLevel.to_label/1` function.
 
@@ -29,7 +29,7 @@ LogLevel.to_label(10)
 # => :unknown
 ```
 
-### 3. Send an alert
+## 3. Send an alert
 
 An engineer wants to be alerted when some events occur in the log. They would like to be notified if an `:error`, `:fatal`, or `:unknown` event occurs.
 

--- a/languages/elixir/exercises/concept/lists/.docs/hints.md
+++ b/languages/elixir/exercises/concept/lists/.docs/hints.md
@@ -1,37 +1,37 @@
-### General
+## General
 
 Use the built-in [(linked) list type][list].
 
-### 1. Define a function to return an empty language list
+## 1. Define a function to return an empty language list
 
 - You need to define a [named function][named-function] with 0 arguments.
 
-### 2. Define a function to add a language to the list
+## 2. Define a function to add a language to the list
 
 - You need to define a [named function][named-function] with 2 arguments.
   - The first argument is a [list][list] of language [string-literals][string].
   - The second argument is a language [string-literal][string].
 - You can use list literal notation forms.
 
-### 3. Define a function to remove a language from the list
+## 3. Define a function to remove a language from the list
 
 - You need to define a [named function][named-function] with 1 argument.
   - The first argument is a [list][list] of language [string-literals][string].
 - Elixir [provides a function][list-ref] to return a list with the first item removed.
 
-### 4. Define a function to return the first item in the list
+## 4. Define a function to return the first item in the list
 
 - You need to define a [named function][named-function] with 1 argument.
   - The first argument is a [list][list] of language [string-literals][string].
 - Elixir [provides a function][list-ref] to the first item from a list.
 
-### 5. Define a function to return how many languages are in the list
+## 5. Define a function to return how many languages are in the list
 
 - You need to define a [named function][named-function] with 1 argument.
   - The first argument is a [list][list] of language [string-literals][string].
 - Elixir [provides a function][list-ref] to count the length of a list.
 
-### 6. Define a function to determine if the list is exciting
+## 6. Define a function to determine if the list is exciting
 
 - You need to define a [named function][named-function] with 1 argument.
   - The first argument is a [list][list] of language [string-literals][string].

--- a/languages/elixir/exercises/concept/lists/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/lists/.docs/instructions.md
@@ -1,6 +1,6 @@
 In this exercise you need to implement some functions to manipulate a list of programming languages.
 
-### 1. Define a function to return an empty language list
+## 1. Define a function to return an empty language list
 
 Define the `new/1` function that takes no parameters and returns an empty list.
 
@@ -9,7 +9,7 @@ LanguageList.new()
 # => []
 ```
 
-### 2. Define a function to add a language to the list
+## 2. Define a function to add a language to the list
 
 Define the `add/2` function that takes 2 parameters (a _language list_ and a string literal of a _language_). It should return the resulting list with the new language prepended to the given list.
 
@@ -18,7 +18,7 @@ LanguageList.new() |> LanguageList.add("Clojure")
 # => ["Clojure"]
 ```
 
-### 3. Define a function to remove a language from the list
+## 3. Define a function to remove a language from the list
 
 Define the `remove/2` function that takes 1 parameter1 (a _language list_). It should return the list minus the first item.
 
@@ -27,7 +27,7 @@ LanguageList.new() |> LanguageList.add("Haskell") |> LanguageList.remove()
 # => []
 ```
 
-### 4. Define a function to return the first item in the list
+## 4. Define a function to return the first item in the list
 
 Define the `first/1` function that takes 1 parameter (a _language list_). It should return the string literal of the language that occurs first in the list.
 
@@ -36,7 +36,7 @@ LanguageList.new() |> LanguageList.add("Prolog") |> LanguageList.first()
 # => "Prolog"
 ```
 
-### 5. Define a function to return how many languages are in the list
+## 5. Define a function to return how many languages are in the list
 
 Define the `count/1` function that takes 1 parameter (a _language list_). It should return the number of languages in the list.
 
@@ -45,7 +45,7 @@ LanguageList.new() |> LanguageList.add("Elm") |> LanguageList.first()
 # => 1
 ```
 
-### 6. Define a function to determine if the list is exciting
+## 6. Define a function to determine if the list is exciting
 
 Define the `exciting_list?/1` function which takes 1 parameter (a _language list_). It should return a boolean value. It should return true if _"Elixir"_ is one of the languages in the list.
 

--- a/languages/elixir/exercises/concept/maps/.docs/hints.md
+++ b/languages/elixir/exercises/concept/maps/.docs/hints.md
@@ -1,38 +1,38 @@
-### General
+## General
 
 - A [map][maps] is an associative data structure of key-value pairs.
 - Elixir offers [many useful Map module functions in the standard library][map-module].
 
-### 1. Define a new high score map
+## 1. Define a new high score map
 
 - It should return an empty [map][maps].
 - [Map module][map-module] functions or literal forms can be useful.
 
-### 2. Add players to the high score map
+## 2. Add players to the high score map
 
 - The resulting map should be returned.
 - [Map module][map-module] contains functions useful for manipulating maps.
 
-### 3. Remove players from the score map
+## 3. Remove players from the score map
 
 - The resulting map should be returned.
 - [Map module][map-module] contains functions useful for manipulating maps.
 
-### 4. Reset a player's score
+## 4. Reset a player's score
 
 - The resulting map should be returned with the player's score reset to an initial value.
 - [Map module][map-module] contains functions useful for manipulating maps.
 
-### 5. Update a player's score
+## 5. Update a player's score
 
 - The resulting map should be returned with the player's updated score.
 - [Map module][map-module] contains functions useful for manipulating maps.
 
-### 6. Get a list of players with scores ordered by player name
+## 6. Get a list of players with scores ordered by player name
 
 - [Enum module][enum] functions can be used on maps.
 
-### 7. Get a list of players ordered by player score in decreasing order
+## 7. Get a list of players ordered by player score in decreasing order
 
 - Maps make use of the [Enumerable][enum-protocol] protocol, so they can be used with [Enum module functions][enum].
 - Make sure the highest score is listed first in the ordered result.

--- a/languages/elixir/exercises/concept/maps/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/maps/.docs/instructions.md
@@ -2,7 +2,7 @@ In this exercise, you're implementing a way to keep track of the high scores for
 
 You have 7 functions to implement, all related to returning and manipulating a map of high score data.
 
-### 1. Define a new high score map
+## 1. Define a new high score map
 
 To make a new high score map, define the `HighScore.new/0` function which doesn't take any parameters and returns a new, empty map of high scores.
 
@@ -11,7 +11,7 @@ HighScore.new()
 # => %{}
 ```
 
-### 2. Add players to the high score map
+## 2. Add players to the high score map
 
 To add a player to the high score map, define `HighScore.add_player/3`, which is a function which takes 3 parameters:
 
@@ -28,7 +28,7 @@ score_map = HighScore.add_player(score_map, "José Valim", 486_373)
 # => %{"Dave Thomas" => 0, "José Valim"=> 486_373}
 ```
 
-### 3. Remove players from the score map
+## 3. Remove players from the score map
 
 To remove a player from the high score map, define `HighScore.remove_player/2`, which takes 2 parameters:
 
@@ -44,7 +44,7 @@ score_map = HighScore.remove_player(score_map, "Dave Thomas")
 # => %{}
 ```
 
-### 4. Reset a player's score
+## 4. Reset a player's score
 
 To reset a player's score, define `HighScore.remove_player/2`, which takes 2 parameters:
 
@@ -60,7 +60,7 @@ score_map = HighScore.reset_score(score_map, "José Valim")
 # => %{"José Valim"=> 0}
 ```
 
-### 5. Update a player's score
+## 5. Update a player's score
 
 To update a players score by adding to the previous score, define `HighScore.update_player/2`, which takes 3 parameters:
 
@@ -77,7 +77,7 @@ score_map = HighScore.update_score(score_map, "José Valim", 5)
 # => %{"José Valim"=> 486_378}
 ```
 
-### 6. Get a list of players with scores ordered by player name
+## 6. Get a list of players with scores ordered by player name
 
 To get a list of players ordered by name, define `HighScore.order_by_players/1`, which takes 1 parameter:
 
@@ -94,7 +94,7 @@ HighScore.order_by_players(score_map)
 # => [{"Dave Thomas", 2_374}, {"José Valim", 486_373}]
 ```
 
-### 7. Get a list of players ordered by player score in decreasing order
+## 7. Get a list of players ordered by player score in decreasing order
 
 To get a list of players ordered by scores in decreasing order, define `HighScore.order_by_scores/1`, which takes 1 parameter:
 

--- a/languages/elixir/exercises/concept/strings/.docs/hints.md
+++ b/languages/elixir/exercises/concept/strings/.docs/hints.md
@@ -1,24 +1,24 @@
-### General
+## General
 
 - Read about strings in the official [Getting Started Elixir guide][getting-started-strings].
 - Browse the [functions available in the _String module_][string-module-functions] to discover which operations on strings Elixir's standard library offers.
 
-### 1. Get the name's first letter
+## 1. Get the name's first letter
 
 - There is a [built-in function][string-first] to get the first character from a string.
 - There are multiple [built-in functions][string-trim] to remove leading, trailing, or leading and trailing whitespaces from a string.
 
-### 2. Format the first letter as an initial
+## 2. Format the first letter as an initial
 
 - There is a [built-in function][string-upcase] to convert all characters in a string to their uppercase variant.
 - There is an [operator][kernel-concat] that concatenates two strings.
 
-### 3. Split the full name into the first name and the last name
+## 3. Split the full name into the first name and the last name
 
 - There is a [built-in function][string-split] that splits a string on whitespace characters.
 - A few first elements of a list can be assigned to variables by pattern-matching on the list.
 
-### 4. Put the initials inside of the heart
+## 4. Put the initials inside of the heart
 
 - There is a special syntax for [interpolating][string-interpolation] an expression inside of a string.
 - There is a special syntax for writing [multiline strings][heredoc-syntax] without needing to escape newlines.

--- a/languages/elixir/exercises/concept/strings/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/strings/.docs/instructions.md
@@ -17,7 +17,7 @@ In this exercise, you are going to help high school sweethearts profess their lo
               *
 ```
 
-### 1. Get the name's first letter
+## 1. Get the name's first letter
 
 Implement the `HighSchoolSweetheart.first_letter/1` function. It should take a name and return its first letter. It should clean up any unnecessary whitespace from the name.
 
@@ -26,7 +26,7 @@ HighSchoolSweetheart.first_letter("Jane")
 # => "J"
 ```
 
-### 2. Format the first letter as an initial
+## 2. Format the first letter as an initial
 
 Implement the `HighSchoolSweetheart.initial/1` function. It should take a name and return its first letter, uppercase, followed by a dot. Make sure to reuse `HighSchoolSweetheart.first_letter/1` that you defined in the previous step.
 
@@ -35,7 +35,7 @@ HighSchoolSweetheart.initial("Robert")
 # => "R."
 ```
 
-### 3. Split the full name into the first name and the last name
+## 3. Split the full name into the first name and the last name
 
 Implement the `HighSchoolSweetheart.initials/1` function. It should take a full name, consisting of a first name and a last name separated by a space, and return the initials. Make sure to reuse `HighSchoolSweetheart.initial/1` that you defined in the previous step.
 
@@ -44,7 +44,7 @@ HighSchoolSweetheart.initials("Lance Green")
 # => "L. G."
 ```
 
-### 4. Put the initials inside of the heart
+## 4. Put the initials inside of the heart
 
 Implement the `HighSchoolSweetheart.pair/2` function. It should take two full names and return the initials. Make sure to reuse `HighSchoolSweetheart.initials/1` that you defined in the previous step.
 

--- a/languages/elixir/exercises/concept/tuples/.docs/hints.md
+++ b/languages/elixir/exercises/concept/tuples/.docs/hints.md
@@ -1,25 +1,25 @@
-### General
+## General
 
 - [Tuples][tuple-module] are data structures which are arranged in contiguous memory and can hold any data-type.
 - Atoms may be used to denote finite states, as this exercise uses `:cup`, `:fluid_ounce`, `:teaspoon`, `:tablespoon`, `:millilitre` to denote the units used.
 - You may use `Kernel` or `Tuple` functions or pattern matching to manipulate to manipulate the tuples.
 
-### 1. Get the numeric component from a volume-pair
+## 1. Get the numeric component from a volume-pair
 
 - Consider using a `Kernel` module function to return the volume-pair's numeric component.
 - Remember, one-line functions are best used for short elixir functions.
 
-### 2. Convert the volume-pair to millilitres
+## 2. Convert the volume-pair to millilitres
 
 - Use [multiple clause functions][multi-clause] and [pattern matching][pattern-matching] to reduce conditional control flow logic.
 - Implement the function for all units to millilitres, including millilitres to millilitres.
 
-### 3. Convert the millilitre volume-pair to another unit
+## 3. Convert the millilitre volume-pair to another unit
 
 - Use multiple clause functions and pattern matching to reduce conditional control flow logic.
 - Implement the function for all units to millilitres, including millilitres to millilitres.
 
-### 4. Convert from any unit to any unit
+## 4. Convert from any unit to any unit
 
 - Reuse the functions already created to perform the conversion in the `convert/2` function.
 

--- a/languages/elixir/exercises/concept/tuples/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/tuples/.docs/instructions.md
@@ -12,7 +12,7 @@ Use this conversion chart for your solution:
 
 Being a talented programmer in training, you decide to use millilitres as a transition unit to facilitate the conversion from any unit listed to any other (even itself)
 
-### 1. Get the numeric component from a volume-pair
+## 1. Get the numeric component from a volume-pair
 
 - Given a volume-pair tuple, `{:cup, 2.0}`, return just the numeric component.
 
@@ -21,7 +21,7 @@ KitchenCalculator.get_volume({:cup, 2.0})
 # => 2.0
 ```
 
-### 2. Convert the volume-pair to millilitres
+## 2. Convert the volume-pair to millilitres
 
 - Given a volume-pair tuple, `{:cup, 2.5}`, convert the volume to millilitres using the conversion chart.
 
@@ -34,7 +34,7 @@ KitchenCalculator.to_millilitre({:cup, 2.5})
 # => {:millilitre, 600.0}
 ```
 
-### 3. Convert the millilitre volume-pair to another unit
+## 3. Convert the millilitre volume-pair to another unit
 
 - Given a volume-pair tuple, `{:millilitre, 1320.0}`, and the desired unit, `:cup`, convert the volume to the desired unit using the conversion chart.
 - use multiple function clauses and pattern matching to create the functions for each unit
@@ -45,7 +45,7 @@ KitchenCalculator.from_millilitre({:millilitre, 1320.0}, :cup)
 # => {:cup, 5.5}
 ```
 
-### 4. Convert from any unit to any unit
+## 4. Convert from any unit to any unit
 
 - Given a volume-pair tuple, `{:teaspoons, 9.0}`, and the desired unit, `:tablespoon`, convert the volume to the desired unit
 

--- a/languages/fsharp/exercises/concept/basics/.docs/hints.md
+++ b/languages/fsharp/exercises/concept/basics/.docs/hints.md
@@ -1,24 +1,24 @@
-### General
+## General
 
 - An integer value can be defined as one or more consecutive digits.
 
-### 1. Define the expected oven time in minutes
+## 1. Define the expected oven time in minutes
 
 - You need to define a [binding][bindings].
 
-### 2. Calculate the remaining oven time in minutes
+## 2. Calculate the remaining oven time in minutes
 
 - You need to define a [function][functions] with a single parameter.
 - You can use and refer to the previously defined binding by its name.
 - The last expression in a function is [automatically returned][return-values] from the function; you don't have to explicitly indicate which value to return.
 - You can use the [mathematical operator for subtraction][operators] to subtract values.
 
-### 3. Calculate the preparation time in minutes
+## 3. Calculate the preparation time in minutes
 
 - You need to define a [function][functions] with a single parameter.
 - You can use the [mathematical operator for multiplicaton][operators] to multiply values.
 
-### 4. Calculate the total working time in minutes
+## 4. Calculate the total working time in minutes
 
 - You need to define a [function][functions] with two parameters.
 - You can [call][calling] one of the other functions you've defined previously.

--- a/languages/fsharp/exercises/concept/basics/.docs/instructions.md
+++ b/languages/fsharp/exercises/concept/basics/.docs/instructions.md
@@ -2,7 +2,7 @@ In this exercise you're going to write some code to help you cook a brilliant la
 
 You have four tasks, all related to the time spent cooking the lasasgna.
 
-### 1. Define the expected oven time in minutes
+## 1. Define the expected oven time in minutes
 
 Define the `expectedMinutesInOven` binding to check how many minutes the lasagna should be in the oven. According to the cooking book, the expected oven time in minutes is 40:
 
@@ -11,7 +11,7 @@ expectedMinutesInOven
 // => 40
 ```
 
-### 2. Calculate the remaining oven time in minutes
+## 2. Calculate the remaining oven time in minutes
 
 Define the `remainingMinutesInOven` function that takes the actual minutes the lasagna has been in the oven as a parameter and returns how many minutes the lasagna still has to remain in the oven, based on the expected time oven time in minutes from the previous task.
 
@@ -20,7 +20,7 @@ remainingMinutesInOven 30
 // => 10
 ```
 
-### 3. Calculate the preparation time in minutes
+## 3. Calculate the preparation time in minutes
 
 Define the `preparationTimeInMinutes` function that takes the number of layers you added to the lasagna as a parameter and returns how many minutes you spent preparing the lasagna, assuming each layer takes you 2 minutes to prepare.
 
@@ -29,7 +29,7 @@ preparationTimeInMinutes 2
 // => 4
 ```
 
-### 4. Calculate the total working time in minutes
+## 4. Calculate the total working time in minutes
 
 Define the `totalTimeInMinutes` function that takes two parameters: the first parameter is the number of layers you added to the lasagna, and the second parameter is the number of minutes the lasagna has been in the oven. The function should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
 

--- a/languages/fsharp/exercises/concept/booleans/.docs/hints.md
+++ b/languages/fsharp/exercises/concept/booleans/.docs/hints.md
@@ -1,9 +1,9 @@
-### General
+## General
 
 - There are three [boolean operators][operators] to work with boolean values.
 - Multiple operators can be combined in a single expression.
 
-### 1. Check if a fast attack can be made
+## 1. Check if a fast attack can be made
 
 - The [boolean operators][operators] can also be applied to boolean parameters.
 - Unlike many other languages, boolean negation is _not_ done with the `!` operator.

--- a/languages/fsharp/exercises/concept/booleans/.docs/instructions.md
+++ b/languages/fsharp/exercises/concept/booleans/.docs/instructions.md
@@ -13,7 +13,7 @@ You have four tasks: to implement the logic for determining if the above actions
 
 ## Tasks
 
-### 1. Check if a fast attack can be made
+## 1. Check if a fast attack can be made
 
 Implement the `canFastAttack` function that takes a boolean value that indicates if the knight is awake. This function returns `true` if a fast attack can be made based on the state of the knight. Otherwise, returns `false`:
 
@@ -23,7 +23,7 @@ canFastAttack(knightIsAwake)
 // => false
 ```
 
-### 2. Check if the group can be spied upon
+## 2. Check if the group can be spied upon
 
 Implement the `canSpy` function that takes three boolean values, indicating if the knight, archer and the prisoner, respectively, are awake. The function returns `true` if the group can be spied upon, based on the state of the three characters. Otherwise, returns `false`:
 
@@ -35,7 +35,7 @@ canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)
 // => true
 ```
 
-### 3. Check if the prisoner can be signalled
+## 3. Check if the prisoner can be signalled
 
 Implement the `canSignalPrisoner` function that takes two boolean values, indicating if the archer and the prisoner, respectively, are awake. The function returns `true` if the prisoner can be signalled, based on the state of the two characters. Otherwise, returns `false`:
 
@@ -46,7 +46,7 @@ canSignalPrisoner(archerIsAwake, prisonerIsAwake)
 // => true
 ```
 
-### 4. Check if the prisoner can be freed
+## 4. Check if the prisoner can be freed
 
 Implement the `canFreePrisoner` function that takes four boolean values. The first three parameters indicate if the knight, archer and the prisoner, respectively, are awake. The last parameter indicates if Annalyn's pet dog is present. The function returns `true` if the prisoner can be freed based on the state of the three characters and Annalyn's pet dog presence. Otherwise, it returns `false`:
 

--- a/languages/fsharp/exercises/concept/datetimes/.docs/hints.md
+++ b/languages/fsharp/exercises/concept/datetimes/.docs/hints.md
@@ -1,26 +1,26 @@
-### General
+## General
 
 - To work with the `DateTime` class, the `System` namespace has to be _opened_.
 
-### 1. Parse appointment date
+## 1. Parse appointment date
 
 - The `DateTime` class has a method to [parse][parsing] a `string` to a `DateTime`.
 
-### 2. Check if an appointment has already passed
+## 2. Check if an appointment has already passed
 
 - `DateTime` objects can be compared using the default [comparison operators][operators].
 - There is a [property][properties] to retrieve the current date and time.
 
-### 3. Check if appointment is in the afternoon
+## 3. Check if appointment is in the afternoon
 
 - Accessing the time portion of a `DateTime` object can de done through one of its [properties][properties].
 
-### 4. Describe the time and date of the appointment
+## 4. Describe the time and date of the appointment
 
 - The tests are running as if running on a machine in the United States, which means that when converting a `DateTime` to a `string` will return dates and time in US format.
 - There is a [built-in method][to-string] to convert a `DateTime` instance to a `string`. If you are using `sprintf`, instead of using the `%s` string placeholder, there is [another placeholder][object-placeholder] that will automatically call the aforementioned method.
 
-### 5. Return the anniversary date
+## 5. Return the anniversary date
 
 - Use one of the various `DateTime` [constructors][constructors] to create a new `DateTime` instance.
 - You can use one of the current date time's [properties][properties] to get the current year.

--- a/languages/fsharp/exercises/concept/datetimes/.docs/instructions.md
+++ b/languages/fsharp/exercises/concept/datetimes/.docs/instructions.md
@@ -9,7 +9,7 @@ You have four tasks, which will all involve appointment dates. The dates and tim
 
 The tests will automatically set the culture to `en-US` - you don't have to set or specify the culture yourselves.
 
-### 1. Parse appointment date
+## 1. Parse appointment date
 
 Implement the `schedule` function that can parse a textual representation of an appointment date into the corresponding `DateTime` format:
 
@@ -18,7 +18,7 @@ schedule "7/25/2019 13:45:00"
 // => DateTime(2019, 7, 25, 13, 45, 0)
 ```
 
-### 2. Check if an appointment has already passed
+## 2. Check if an appointment has already passed
 
 Implement the `hasPassed` function that takes an appointment date and checks if the appointment was somewhere in the past:
 
@@ -27,7 +27,7 @@ hasPassed (DateTime(1999, 12, 31, 9, 0, 0))
 // => true
 ```
 
-### 3. Check if appointment is in the afternoon
+## 3. Check if appointment is in the afternoon
 
 Implement the `isAfternoonAppointment` function that takes an appointment date and checks if the appointment is in the afternoon (>= 12:00 and < 18:00):
 
@@ -36,7 +36,7 @@ isAfternoonAppointment (DateTime(2019, 03, 29, 15, 0, 0))
 // => true
 ```
 
-### 4. Describe the time and date of the appointment
+## 4. Describe the time and date of the appointment
 
 Implement the `description` function that takes an appointment date and returns a description of that date and time:
 
@@ -45,7 +45,7 @@ description (DateTime(2019, 03, 29, 15, 0, 0))
 // => "You have an appointment on Friday 29 March 2019 at 15:00."
 ```
 
-### 5. Return the anniversary date
+## 5. Return the anniversary date
 
 Implement the `anniversaryDate` function that returns this year's anniversary date, which is September 15th:
 

--- a/languages/fsharp/exercises/concept/discriminated-unions/.docs/hints.md
+++ b/languages/fsharp/exercises/concept/discriminated-unions/.docs/hints.md
@@ -1,12 +1,12 @@
-### 1. Define the approval
+## 1. Define the approval
 
 - [This page][define] shows how to define a discriminated union.
 
-### 4. Define the activity
+## 4. Define the activity
 
 - [This page][define] shows how to define a discriminated union, both for cases with and without associated data.
 
-### 5. Rate the activity
+## 5. Rate the activity
 
 - The best way to execute logic based on the activity's value is to use [pattern matching][pattern-matching].
 - The pattern to match discriminated union cases (and optionally, their associated data) is through [identifier patterns][identifier-patterns].

--- a/languages/fsharp/exercises/concept/discriminated-unions/.docs/instructions.md
+++ b/languages/fsharp/exercises/concept/discriminated-unions/.docs/instructions.md
@@ -10,25 +10,25 @@ The following ideas are proposed by your partner:
 
 You have six tasks to help choose your Valentine's day activity.
 
-### 1. Define the approval
+## 1. Define the approval
 
 For each idea your partner proposes, you respond with one of three options: yes, no or maybe.
 
 Define the `Approval` discriminated union to represent these options as the following three cases: `Yes`, `No` and `Maybe`.
 
-### 2. Define the cuisines
+## 2. Define the cuisines
 
 Your partner has selected two possible restaurants: one based on the Korean cuisine and the other based on the Turkish cuisine.
 
 Define the `Cuisine` discriminated union to represent these cuisines as the following two cases: `Korean` and `Turkish`.
 
-### 3. Define the movie genres
+## 3. Define the movie genres
 
 There are tons of movies to choose from, so to narrow things down, your partner also lists their genre.
 
 Define the `Genre` discriminated union to represent the following genres as cases: `Crime`, `Horror`, `Romance` and `Thriller`.
 
-### 4. Define the activity
+## 4. Define the activity
 
 As said, your partner has come up with five different activities: playing a board game, chill out, watch a movie, go to a restaurant and taking a walk.
 
@@ -40,7 +40,7 @@ Define the `Activity` discriminated union to represent these activity types:
 - `Restaurant`: has its `Cuisine` as associated data.
 - `Walk`: has an `int` representing the number of kilometers to walk as associated data.
 
-### 5. Rate the activity
+## 5. Rate the activity
 
 Finally, you're ready to rate your partner's ideas. This is how you feel about your partner's idea:
 

--- a/languages/fsharp/exercises/concept/floating-point-numbers/.docs/hints.md
+++ b/languages/fsharp/exercises/concept/floating-point-numbers/.docs/hints.md
@@ -1,8 +1,8 @@
-### 1. Calculate the interest rate
+## 1. Calculate the interest rate
 
 - By default, any floating-point number defined in F# code is treated as a `double`. To use a different floating-point type (like `single` or `decimal`), one must add the appropriate [suffix][literals] to the number.
 
-### 2. Calculate the annual balance update
+## 2. Calculate the annual balance update
 
 - When calculating the annual yield, it might be useful to temporarily convert a negative balance to a positive one. One could use arithmetic, or one of the built-in [math functions][math-functions].
 

--- a/languages/fsharp/exercises/concept/floating-point-numbers/.docs/instructions.md
+++ b/languages/fsharp/exercises/concept/floating-point-numbers/.docs/instructions.md
@@ -9,7 +9,7 @@ Each year the government allows you donate a percentage of your money to charity
 
 You have three tasks, each of which will deal your balance and its interest rate.
 
-### 1. Calculate the interest rate
+## 1. Calculate the interest rate
 
 Implement the `interestRate` function to calculate the interest rate based on the specified balance:
 
@@ -20,7 +20,7 @@ interestRate 200.75m
 
 Note that the value returned is a `single`.
 
-### 2. Calculate the annual balance update
+## 2. Calculate the annual balance update
 
 Implement the `annualBalanceUpdate` function to calculate the annual balance update, taking into account the interest rate:
 
@@ -31,7 +31,7 @@ annualBalanceUpdate 200.75m
 
 Note that the value returned is a `decimal`.
 
-### 3. Calculate how much money to donate
+## 3. Calculate how much money to donate
 
 Implement the `amountToDonate` function to calculate how much money to donate to charities based on the balance and the tax-free percentage that the government allows:
 

--- a/languages/fsharp/exercises/concept/lists/.docs/hints.md
+++ b/languages/fsharp/exercises/concept/lists/.docs/hints.md
@@ -1,24 +1,24 @@
-### 1. Create a new list
+## 1. Create a new list
 
 - How to define an empty list can be found on [this page][create-and-initialize].
 
-### 2. Define an existing list
+## 2. Define an existing list
 
 - How to define and initialize a list with mutliple elements can be found on [this page][create-and-initialize].
 
-### 3. Add a new language to a list
+## 3. Add a new language to a list
 
 - There is a [built-in operator][cons] to add an element to the beginning of a list.
 
-### 4. Count the languages in the list
+## 4. Count the languages in the list
 
 - There is a function in the `List` module to [count the elements in a list][length].
 
-### 5. Reverse the list
+## 5. Reverse the list
 
 - There is a function in the `List` module to [reverse a list][reverse].
 
-### 6. Check if list is exciting
+## 6. Check if list is exciting
 
 - You can use pattern matching using the [cons][cons-pattern]- and [list][list-pattern] patterns to match on specific list structures.
 

--- a/languages/fsharp/exercises/concept/lists/.docs/instructions.md
+++ b/languages/fsharp/exercises/concept/lists/.docs/instructions.md
@@ -2,7 +2,7 @@ In this exercise you'll be writing code to keep track of a list of programming l
 
 You have six tasks, which will all involve dealing with lists.
 
-### 1. Create a new list
+## 1. Create a new list
 
 To keep track of the languages you want to learn, you'll need to create an new list. Define the `newList` binding that contains a new, empty list.
 
@@ -11,7 +11,7 @@ newList
 // => []
 ```
 
-### 2. Define an existing list
+## 2. Define an existing list
 
 Currently, you have a piece of paper listing the languages you want to learn: F#, Clojure and Haskell. Define the `existingList` binding to represent this list.
 
@@ -20,7 +20,7 @@ existingList
 // => ["F#"; "Clojure"; "Haskell"]
 ```
 
-### 3. Add a new language to a list
+## 3. Add a new language to a list
 
 As you explore Exercism and find more interesting languages, you want to add them to your list. Implement the `addLanguage` function to add a new language to the beginning of your list.
 
@@ -29,7 +29,7 @@ addLanguage "TypeScript" ["JavaScript"; "CoffeeScript"]
 // => ["TypeScript"; "JavaScript"; "CoffeeScript"]
 ```
 
-### 4. Count the languages in the list
+## 4. Count the languages in the list
 
 Counting the languages one-by-one is inconvenient. Implement the `countLanguages` function to count the number of languages on your list.
 
@@ -38,7 +38,7 @@ countLanguages ["C#"; "Racket"; "Rust"; "Ruby"]
 // => 4
 ```
 
-### 5. Reverse the list
+## 5. Reverse the list
 
 At some point, you realize that your list is actually ordered backwards! Implement the `reverseList` function to reverse your list.
 
@@ -47,7 +47,7 @@ reverseList ["Prolog"; "C"; "Idris"; "Assembly"]
 // => ["Assembly"; "Idris"; "C"; "Prolog"]
 ```
 
-### 6. Check if list is exciting
+## 6. Check if list is exciting
 
 While you love all languages, F# has a special place in your heart. As such, you're really excited about a list of languages if:
 

--- a/languages/fsharp/exercises/concept/numbers/.docs/hints.md
+++ b/languages/fsharp/exercises/concept/numbers/.docs/hints.md
@@ -1,10 +1,10 @@
-### 1. Calculate the production rate per second
+## 1. Calculate the production rate per second
 
 - Determining the success rate can be done through a [conditional expression][conditional-expression].
 - F# does not allow for multiplication to be applied to two different number types (such as an `int` and a `double`). One thus has to convert one of the number types to the other number type using one of the built-in [conversion operators][conversion-operators].
 - Numbers can be compared using the built-in [comparison operators][comparison-operators].
 
-### 2. Calculate the number of working items produced per second
+## 2. Calculate the number of working items produced per second
 
 - Converting from a `double` to an `int` can be done through one of the built-in [conversion operators][conversion-operators].
 

--- a/languages/fsharp/exercises/concept/numbers/.docs/instructions.md
+++ b/languages/fsharp/exercises/concept/numbers/.docs/instructions.md
@@ -10,7 +10,7 @@ At its lowest speed (`1`), `221` cars are produced each hour. The production inc
 
 You have two tasks.
 
-### 1. Calculate the production rate per hour
+## 1. Calculate the production rate per hour
 
 Implement the `productionRatePerHour` function to calculate the assembly line's production rate per hour, taking into account its success rate:
 
@@ -21,7 +21,7 @@ productionRatePerHour 6
 
 Note that the value returned is a `double`.
 
-### 2. Calculate the number of working items produced per minute
+## 2. Calculate the number of working items produced per minute
 
 Implement the `workingItemsPerMinute` function to calculate how many working cars are produced per minute:
 

--- a/languages/fsharp/exercises/concept/pattern-matching/.docs/hints.md
+++ b/languages/fsharp/exercises/concept/pattern-matching/.docs/hints.md
@@ -1,20 +1,20 @@
-### General
+## General
 
 - [This page][pattern-matching] has a nice introduction to pattern matching in F#.
 
-### 1. Reply to a correct guess
+## 1. Reply to a correct guess
 
 - You can use a [constant pattern][constant-pattern] to match on a specific number.
 
-### 2. Reply to a close guess
+## 2. Reply to a close guess
 
 - You can either use a [constant pattern][constant-pattern] or a [variable pattern][variable-patterns] and a [guard][guards].
 
-### 3. Reply to too low guesses
+## 3. Reply to too low guesses
 
 - You can use a combination of a [variable pattern][variable-patterns] and a [guard][guards].
 
-### 4. Reply to too high guesses
+## 4. Reply to too high guesses
 
 - You can use a combination of a [variable pattern][variable-patterns] and a [guard][guards].
 

--- a/languages/fsharp/exercises/concept/pattern-matching/.docs/instructions.md
+++ b/languages/fsharp/exercises/concept/pattern-matching/.docs/instructions.md
@@ -7,7 +7,7 @@ In this exercise, you are playing a number guessing game with a friend. The rule
 
 You have four tasks to encode the replies to the guesses.
 
-### 1. Reply to a correct guess
+## 1. Reply to a correct guess
 
 Implement the `reply` function to reply to a correct guess:
 
@@ -16,7 +16,7 @@ reply 42
 // => "Correct"
 ```
 
-### 2. Reply to a close guess
+## 2. Reply to a close guess
 
 Modify the `reply` function to reply to close guesses:
 
@@ -25,7 +25,7 @@ reply 41
 // => "So close"
 ```
 
-### 3. Reply to too low guesses
+## 3. Reply to too low guesses
 
 Modify the `reply` function to reply to too low guesses:
 
@@ -34,7 +34,7 @@ reply 25
 // => "Too low"
 ```
 
-### 4. Reply to too high guesses
+## 4. Reply to too high guesses
 
 Modify the `reply` function to reply to too high guesses:
 

--- a/languages/fsharp/exercises/concept/recursion/.docs/hints.md
+++ b/languages/fsharp/exercises/concept/recursion/.docs/hints.md
@@ -1,12 +1,12 @@
-### 1. Define the pizza types and options
+## 1. Define the pizza types and options
 
 - The `Pizza` type is a [recursive type][recursive-types], with the `ExtraSauce` and `ExtraToppings` cases "wrapping" a pizza.
 
-### 2. Calculate the prize of pizza
+## 2. Calculate the prize of pizza
 
 - To handle the `Pizza` type being a [recursive type][recursive-types], define a [recursive function][recursive-functions].
 
-### 3. Calculate the prize of an order
+## 3. Calculate the prize of an order
 
 - If the test fails with a Stack overflow, please use [tail-recursion][tail-recursion] to recursively process the list.
 

--- a/languages/fsharp/exercises/concept/recursion/.docs/instructions.md
+++ b/languages/fsharp/exercises/concept/recursion/.docs/instructions.md
@@ -18,7 +18,7 @@ When customers place and order, an additional fee is added if they only order on
 
 You have three tasks, each of which will work with pizzas and their price.
 
-### 1. Define the pizza types and options
+## 1. Define the pizza types and options
 
 Define the `Pizza` discriminated union to represent the pizza types and the two additional options that can be added to a pizza:
 
@@ -28,7 +28,7 @@ Define the `Pizza` discriminated union to represent the pizza types and the two 
 - `ExtraSauce`
 - `ExtraToppings`
 
-### 2. Calculate the prize of pizza
+## 2. Calculate the prize of pizza
 
 Implement the `pizzaPrice` function to calculate a pizza's price:
 
@@ -37,7 +37,7 @@ pizzaPrice Caprese
 // => 9
 ```
 
-### 3. Calculate the prize of an order
+## 3. Calculate the prize of an order
 
 Implement the `orderPrice` function to calculate a pizza order's price:
 

--- a/languages/fsharp/exercises/concept/strings/.docs/hints.md
+++ b/languages/fsharp/exercises/concept/strings/.docs/hints.md
@@ -1,17 +1,17 @@
-### General
+## General
 
 - The `string` class has many useful [built-in methods][methods].
 
-### 1. Get message from a log line
+## 1. Get message from a log line
 
 - There are [several methods][index-of] to find the index at which some text occurs in a `string`.
 - Removing white space is [built-in][trim].
 
-### 2. Get log level from a log line
+## 2. Get log level from a log line
 
 - A `string` can be converted to lowercase using a [built-in method][to-lower].
 
-### 3. Reformat a log line
+## 3. Reformat a log line
 
 - There are several ways to [concatenate strings][string_concatenation].
 

--- a/languages/fsharp/exercises/concept/strings/.docs/instructions.md
+++ b/languages/fsharp/exercises/concept/strings/.docs/instructions.md
@@ -10,7 +10,7 @@ There are three different log levels:
 
 You have three tasks, each of which will take a log line and ask you to do something with it.
 
-### 1. Get message from a log line
+## 1. Get message from a log line
 
 Implement the `message` function to return a log line's message:
 
@@ -26,7 +26,7 @@ message "[WARNING]:  Disk almost full\r\n"
 // => "Disk almost full"
 ```
 
-### 2. Get log level from a log line
+## 2. Get log level from a log line
 
 Implement the `logLevel` function to return a log line's log level, which should be returned in lowercase:
 
@@ -35,7 +35,7 @@ logLevel "[ERROR]: Invalid operation"
 // => "error"
 ```
 
-### 3. Reformat a log line
+## 3. Reformat a log line
 
 Implement the `reformat` function that reformats the log line, putting the message first and the log level after it in parentheses:
 

--- a/languages/go/exercises/concept/basics/.docs/hints.md
+++ b/languages/go/exercises/concept/basics/.docs/hints.md
@@ -1,13 +1,13 @@
-### General
+## General
 
 - An [integer value][integers] can be defined as one or more consecutive digits.
 
-### 1. Define the expected oven time in minutes
+## 1. Define the expected oven time in minutes
 
 - You need to define a [function][functions] without any arguments.
 - You have to [explicitly return an integer][return] from a function.
 
-### 2. Calculate the remaining oven time in minutes
+## 2. Calculate the remaining oven time in minutes
 
 - You need to define a [function][functions] with a single parameter.
 - You have to [explicitly return an integer][return] from a function.
@@ -15,14 +15,14 @@
 - You can [call][calls] one of the other functions you've defined previously.
 - You can use the [mathematical operator for subtraction][operators] to subtract values.
 
-### 3. Calculate the preparation time in minutes
+## 3. Calculate the preparation time in minutes
 
 - You need to define a [function][functions] with a single parameter.
 - You have to [explicitly return an integer][return] from a function.
 - The function's parameter is an [integer][integers].
 - You can use the [mathematical operator for multiplicaton][operators] to multiply values.
 
-### 4. Calculate the total working time in minutes
+## 4. Calculate the total working time in minutes
 
 - You need to define a [function][functions] with two parameters.
 - You have to [explicitly return an integer][return] from a function.

--- a/languages/go/exercises/concept/basics/.docs/instructions.md
+++ b/languages/go/exercises/concept/basics/.docs/instructions.md
@@ -2,7 +2,7 @@ In this exercise you're going to write some code to help you cook a brilliant la
 
 You have four tasks, all related to the time spent cooking the lasagna.
 
-### 1. Define the expected oven time in minutes
+## 1. Define the expected oven time in minutes
 
 Define the `OvenTime()` function that does not take any parameters and returns how many minutes the lasagna should be in the oven. According to the cooking book, the expected oven time in minutes is 40:
 
@@ -11,7 +11,7 @@ OvenTime()
 // => 40
 ```
 
-### 2. Calculate the remaining oven time in minutes
+## 2. Calculate the remaining oven time in minutes
 
 Define the `RemainingOvenTime()` function that takes the actual minutes the lasagna has been in the oven as a parameter and returns how many minutes the lasagna still has to remain in the oven, based on the expected oven time in minutes from the previous task.
 
@@ -20,7 +20,7 @@ RemainingOvenTime(30)
 // => 10
 ```
 
-### 3. Calculate the preparation time in minutes
+## 3. Calculate the preparation time in minutes
 
 Define the `PreparationTime()` function that takes the number of layers you added to the lasagna as a parameter and returns how many minutes you spent preparing the lasagna, assuming each layer takes you 2 minutes to prepare.
 
@@ -29,7 +29,7 @@ PreparationTime(2)
 // => 4
 ```
 
-### 4. Calculate the elapsed working time in minutes
+## 4. Calculate the elapsed working time in minutes
 
 Define the `ElapsedTime()` function that takes two parameters: the first parameter is the number of layers you added to the lasagna, and the second parameter is the number of minutes the lasagna has been in the oven. The function should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
 

--- a/languages/go/exercises/concept/conditionals/.docs/hints.md
+++ b/languages/go/exercises/concept/conditionals/.docs/hints.md
@@ -1,12 +1,13 @@
 # Hints
 
-### General
+## General
 
 Conditionals are used to check for certain conditions and/or criteria. The most basic way of performing a conditional operation is using a single `if` statement.
 
-### 1. Multiple cases (else if)
+## 1. Multiple cases (else if)
 
-For various cases an `else if` and `else` statements can be used like this: 
+For various cases an `else if` and `else` statements can be used like this:
+
 ```go
 if condition {
     // some code
@@ -18,9 +19,10 @@ if condition {
     // some code
 }
 ```
-The `else` statement is any other case not covered by previous conditions. It should be noted that since Go allows early returns it is common to avoid the `else` statement after a return. 
 
-### 2. Multiple cases (logical operators)
+The `else` statement is any other case not covered by previous conditions. It should be noted that since Go allows early returns it is common to avoid the `else` statement after a return.
+
+## 2. Multiple cases (logical operators)
 
 Another way of checking for different scenarios is by chaining logical operators within the `if` statements like this:
 
@@ -34,7 +36,7 @@ if conditionA ||conditionB {
 }
 ```
 
-### 3. More than 3 cases (switch)
+## 3. More than 3 cases (switch)
 
 When there are 3 or more cases it is often better to use a `switch` statement, which allows to test for multiple conditions. It also has a `default` for managing unmanaged cases. It is used like this:
 
@@ -50,4 +52,5 @@ default:
     // some code
 }
 ```
+
 Note that within each case different logical operators can be chained together to expand the evaluation.

--- a/languages/go/exercises/concept/conditionals/.docs/instructions.md
+++ b/languages/go/exercises/concept/conditionals/.docs/instructions.md
@@ -1,17 +1,17 @@
 # Instructions
 
-In this exercise we will simulate the first turn of a [Blackjack](https://en.wikipedia.org/wiki/Blackjack) game. 
+In this exercise we will simulate the first turn of a [Blackjack](https://en.wikipedia.org/wiki/Blackjack) game.
 
 You will receive two cards and will be able to see the face up card of the dealer. All cards are represented using a string such as "ace", "king", "three", "two", etc. The values of each card are:
 
-|  card | value |  card | value |
-|:-----:|:-----:|:-----:|:-----:|
-|  ace  |   11  | eight |   8   |
-|  two  |   2   |  nine |   9   |
-| three |   3   |  ten  |   10  |
-|  four |   4   |  jack |   10  |
-|  five |   5   | queen |   10  |
-|  six  |   6   |  king |   10  |
+| card  | value | card  | value |
+| :---: | :---: | :---: | :---: |
+|  ace  |  11   | eight |   8   |
+|  two  |   2   | nine  |   9   |
+| three |   3   |  ten  |  10   |
+| four  |   4   | jack  |  10   |
+| five  |   5   | queen |  10   |
+|  six  |   6   | king  |  10   |
 | seven |   7   | other |   0   |
 
 **Note**: Commonly, aces can take the value of 1 or 11 but for simplicity we will assume that they can only take the value of 11.
@@ -33,7 +33,7 @@ Although not optimal yet, you will follow the strategy your friend Alex has been
 
 You have three tasks:
 
-### 1. Calculate the score of any given card
+## 1. Calculate the score of any given card
 
 Implement a function to calculate the numerical value of a card given its name.
 
@@ -43,7 +43,7 @@ fmt.Println(value)
 // Output: 11
 ```
 
-### 2. Determine if two cards make up a Blackjack.
+## 2. Determine if two cards make up a Blackjack.
 
 Implement a function that returns true if two cards form a Blackjack, false otherwise.
 
@@ -53,7 +53,7 @@ fmt.Println(isBlackjack)
 // Output: true
 ```
 
-### 3. Determine the best gameplay choice for your first turn following Alex's strategy.
+## 3. Determine the best gameplay choice for your first turn following Alex's strategy.
 
 Implement a function that returns the string representation of a decision given your cards, the dealer's card and Alex's strategy.
 

--- a/languages/go/exercises/concept/numbers/.docs/hints.md
+++ b/languages/go/exercises/concept/numbers/.docs/hints.md
@@ -1,4 +1,4 @@
-### Arithmetic Operators in Go
+## Arithmetic Operators in Go
 
 Below shows the set of arithmetic operators available in Go in use:
 

--- a/languages/go/exercises/concept/numbers/.docs/instructions.md
+++ b/languages/go/exercises/concept/numbers/.docs/instructions.md
@@ -17,7 +17,7 @@ following table shows how speed influences the success rate:
 
 You have two tasks:
 
-### 1. Calculate the production rate per hour
+## 1. Calculate the production rate per hour
 
 Implement a function to calculate the assembly line's production rate per hour.
 
@@ -29,7 +29,7 @@ fmt.Println(rate)
 
 > Note that the value returned is of type `float64`
 
-### 2. Calculate the number of working items produced per minute
+## 2. Calculate the number of working items produced per minute
 
 Implement a function to calculate how many cars are produced each minute:
 

--- a/languages/go/exercises/concept/numbers/.docs/introduction.md
+++ b/languages/go/exercises/concept/numbers/.docs/introduction.md
@@ -1,4 +1,4 @@
-### Numbers
+## Numbers
 
 Go contains basic numeric types that can represent sets of either integer or
 floating-point values. There a different types depending on the size of value
@@ -26,7 +26,7 @@ following resources:
 Go supports the standard set of arithmetic operators of `+`, `-`, `*`, `/`
 and `%` (remainder not modulo).
 
-### Type Conversion
+## Type Conversion
 
 In Go, assignment of a value between different types requires explicit
 conversion. For example, to convert an `int` to a `float64` you would need to

--- a/languages/go/exercises/concept/slices/.docs/hints.md
+++ b/languages/go/exercises/concept/slices/.docs/hints.md
@@ -1,25 +1,25 @@
-### General
+## General
 
 - slices in Go are zero-based. The first index in a slice is `0`.
 
-### 1. Retrieve a card from a stack
+## 1. Retrieve a card from a stack
 
 - To get the `n`th item of a slice [use an index][go-slices].
 - To check if an item exists in a slice use a conditional and compare the index with the [length of the slice][len-builtin].
 
 Note: a slice always starts with index `0`, `1`, `2`, etc.
 
-### 2. Exchange a card in the stack
+## 2. Exchange a card in the stack
 
 - To set the `n`th item in a slice [use an index][go-slices] and asign a new value to it.
 - To add a new item to a list use the builtin [`append`][append-builtin] function.
 
-### 3. Create a stack of cards
+## 3. Create a stack of cards
 
 - There are several ways to create a new slice. The simplest is `var s []int`. More options you get with the [`make`][make-builtin] function.
 - Use the techniques from 2. to fill the slice with the correct values in a `for` loop.
 
-### 4. Remove a card from the stack
+## 4. Remove a card from the stack
 
 - Removing an item from a slice can be done by appending the part after `index` to the part before index.
 

--- a/languages/go/exercises/concept/slices/.docs/instructions.md
+++ b/languages/go/exercises/concept/slices/.docs/instructions.md
@@ -2,7 +2,7 @@ As a magician-to-be, Elyse needs to practice some basics. She has a stack of car
 
 To make things a bit easier she only uses the cards 1 to 10.
 
-### 1. Retrieve a card from a stack
+## 1. Retrieve a card from a stack
 
 Return the card at position `index` from the given stack.
 
@@ -11,7 +11,7 @@ GetItem([]uint8{1, 2, 4, 1}, 2)
 // Returns: 4
 ```
 
-### 2. Exchange a card in the stack
+## 2. Exchange a card in the stack
 
 Exchange the card at position `index` with the new card provided and return the adjusted stack.
 Note that this will also change the input slice which is ok.
@@ -23,7 +23,7 @@ SetItem([]uint8{1, 2, 4, 1}, index, new_card)
 // Returns: []uint8{1, 2, 6, 1}
 ```
 
-### 3. Create a stack of cards
+## 3. Create a stack of cards
 
 Create a stack of given `length` and fill it with cards of the given `value`.
 
@@ -32,7 +32,7 @@ PrefilledSlice(8, 3)
 // Returns: []int{8, 8, 8}
 ```
 
-### 4. Remove a card from the stack
+## 4. Remove a card from the stack
 
 Remove the card at position `index` from the stack and return the stack.
 

--- a/languages/go/exercises/concept/strings/.docs/hints.md
+++ b/languages/go/exercises/concept/strings/.docs/hints.md
@@ -1,4 +1,4 @@
-### General
+## General
 
 - Strings in Go are based on `[]byte`. For example getting a substring works the same as getting a subslice.
 - The `Go by Example` tutorial has two topics that are helpful here: [String Functions][string-functions] and [String Formatting][string-formatting]
@@ -7,20 +7,20 @@
 - Code that does not check if an index exists in a `slice`, will `panic` if that index does not exist.
   A `panic` should be considered a bug in the code to be fixed. There will be more on panics in a later exercise.
 
-### 1. Get message from a log line
+## 1. Get message from a log line
 
 - Splitting a string at a certain substring is available in the [`strings` package][split-function].
 - Removing white space is [built-in][trimspace-function].
 
-### 2. Get the message length in characters
+## 2. Get the message length in characters
 
 - A string can be converted into a slice of characters (`[]rune`).
 
-### 3. Get log level from a log line
+## 3. Get log level from a log line
 
 - Changing a `string`'s casing to lower can be done with [this function][lowercase-function].
 
-### 4. Reformat a log line
+## 4. Reformat a log line
 
 - You can just add strings to one another with the plus (`+`) operator. The preferred way is to use the [`fmt` packages][sprintf-function] functionality.
 

--- a/languages/go/exercises/concept/strings/.docs/instructions.md
+++ b/languages/go/exercises/concept/strings/.docs/instructions.md
@@ -10,7 +10,7 @@ There are three different log levels:
 
 You have three tasks, each of which will take a log line and ask you to do something with it.
 
-### 1. Get message from a log line
+## 1. Get message from a log line
 
 Implement a method to return a log line's message:
 
@@ -26,7 +26,7 @@ Message("[WARNING]:  Disk almost full\r\n")
 // Returns: "Disk almost full"
 ```
 
-### 2. Get the message length in characters
+## 2. Get the message length in characters
 
 Implement a method to return a log line's message length:
 
@@ -35,7 +35,7 @@ Strings.LogLevel("[ERROR]: Invalid operation \n")
 // Returns: 17
 ```
 
-### 3. Get log level from a log line
+## 3. Get log level from a log line
 
 Implement a method to return a log line's log level, which should be returned in lowercase:
 
@@ -44,7 +44,7 @@ Strings.LogLevel("[ERROR]: Invalid operation")
 // Returns: "error"
 ```
 
-### 4. Reformat a log line
+## 4. Reformat a log line
 
 Implement a method that reformats the log line, putting the message first and the log level after it in parentheses:
 

--- a/languages/go/exercises/concept/strings/.docs/introduction.md
+++ b/languages/go/exercises/concept/strings/.docs/introduction.md
@@ -1,4 +1,4 @@
-### Strings
+## Strings
 
 A `string` in Go is a sequence of `bytes`, which doesn't necessarily have to represent characters.
 That being said, `UTF-8` is a central part of `strings` in Go. It is easy to convert a string to `runes` (`UTF-8` characters) or iterate over `runes` in a string.
@@ -14,7 +14,7 @@ With that said, string types are immutable so operations like s[i] = 'a' are not
 
 [Strings, bytes, runes and characters in Go](https://blog.golang.org/strings) provides a deep dive into this topic.
 
-### Conditionals
+## Conditionals
 
 This exercise also introduces _conditionals_. Here is a little intro:
 [Go by Example: If/Else](https://gobyexample.com/if-else)

--- a/languages/javascript/exercises/concept/array-analysis/.docs/hints.md
+++ b/languages/javascript/exercises/concept/array-analysis/.docs/hints.md
@@ -1,25 +1,25 @@
-### 1. Find the position of a card
+## 1. Find the position of a card
 
 - Array indices starts at `0`.
 - There is a [built-in][indexof_method_docs] method to get given value index.
 
-### 2. Determine if a card is present
+## 2. Determine if a card is present
 
 - There is a [built-in][includes_method_docs] method to check whether the value is present in the array
 
-### 3. Determine if each card is even
+## 3. Determine if each card is even
 
 - There is a [built-in][every_method_docs] method to check if each value passes a predicate
 
-### 4. Check if the stack contains an odd-value card
+## 4. Check if the stack contains an odd-value card
 
 - There is a [built-in][some_method_docs] method to check if at least one value passes a predicate
 
-### 5. Get the first odd card from the stack
+## 5. Get the first odd card from the stack
 
 - There is a [built-in][find_method_docs] method to get the first item that passes a predicate
 
-### 6. Determine the position of the first card that is even
+## 6. Determine the position of the first card that is even
 
 - There is a [built-in][findindex_method_docs] method to get the first index in array that the value
 

--- a/languages/javascript/exercises/concept/array-analysis/.docs/instructions.md
+++ b/languages/javascript/exercises/concept/array-analysis/.docs/instructions.md
@@ -3,7 +3,7 @@ To make things a bit easier, she only uses the cards 1 to 10.
 
 In this exercise, use built-in methods to analyse the contents of an array.
 
-### 1. Find the position of a card
+## 1. Find the position of a card
 
 Elyse wants to know the position (index) of a card in the stack
 
@@ -13,7 +13,7 @@ getCardPosition([9, 7, 3, 2], card)
 // => 3
 ```
 
-### 2. Determine if a card is present
+## 2. Determine if a card is present
 
 Elyse wants to determine if a card is present in the stack -- in other words, if the stack contains a specific `number`.
 
@@ -23,7 +23,7 @@ doesStackIncludeCard([2, 3, 4, 5], card)
 // => true
 ```
 
-### 3. Determine if each card is even
+## 3. Determine if each card is even
 
 Elyse wants to know if every card is even -- in other words, if each number in the stack is an even `number`.
 
@@ -32,7 +32,7 @@ isEachCardEven([2, 4, 6, 7])
 // => false
 ```
 
-### 4. Check if the stack contains an odd-value card
+## 4. Check if the stack contains an odd-value card
 
 Elyse wants to know if there is an odd number in the stack
 
@@ -41,7 +41,7 @@ doesStackIncludeOddCard([3, 2, 6, 4, 8])
 // => true
 ```
 
-### 5. Get the first odd card from the stack
+## 5. Get the first odd card from the stack
 
 Elyse wants to know the value of the first card that is odd
 
@@ -50,7 +50,7 @@ getFirstOddCard([4, 2, 8, 7, 9])
 // => 7
 ```
 
-### 6. Determine the position of the first card that is even
+## 6. Determine the position of the first card that is even
 
 Elyse wants to know the position of the first card that is even
 

--- a/languages/javascript/exercises/concept/arrays/.docs/hints.md
+++ b/languages/javascript/exercises/concept/arrays/.docs/hints.md
@@ -1,34 +1,34 @@
-### 1. Retrieve a card from a stack
+## 1. Retrieve a card from a stack
 
 - Array indices start at `0`.
 - [This page][access_array_elements_resource] has more information on how to access array elements.
 
-### 2. Exchange a card in the stack
+## 2. Exchange a card in the stack
 
 - The array is a mutable structure, you can change its content anytime.
 - You can find an example [here][change_array_elements_resource], inside the 'Changing an Array Element' section.
 
-### 3. Insert a card at the top of the stack
+## 3. Insert a card at the top of the stack
 
 - There is a [built-in][push_method_docs] method to add a new value to the end of the array.
 
-### 4. Remove a card from the stack
+## 4. Remove a card from the stack
 
 - There is a [built-in][splice_method_docs] method that, among other use cases, can be used to remove elements starting at a certain position.
 
-### 5. Remove the top card from the stack
+## 5. Remove the top card from the stack
 
 - There is a [built-in][pop_method_docs] method to remove the last element from the array.
 
-### 6. Insert a card at the bottom of the stack
+## 6. Insert a card at the bottom of the stack
 
 - There is a [built-in][unshift_method_docs] method to add a new value to the beginning of the array.
 
-### 7. Remove a card from the bottom of the stack
+## 7. Remove a card from the bottom of the stack
 
 - There is a [built-in][shift_method_docs] method to remove the first element from the array.
 
-### 8. Check size of the stack
+## 8. Check size of the stack
 
 - Arrays have a [property][length_property_docs] to retrieve their length.
 

--- a/languages/javascript/exercises/concept/arrays/.docs/instructions.md
+++ b/languages/javascript/exercises/concept/arrays/.docs/instructions.md
@@ -2,7 +2,7 @@ As a magician-to-be, Elyse needs to practice some basics. She has a stack of car
 
 To make things a bit easier she only uses the cards 1 to 10.
 
-### 1. Retrieve a card from a stack
+## 1. Retrieve a card from a stack
 
 Return the card at position `index` from the given stack.
 
@@ -12,7 +12,7 @@ getItem([1, 2, 4, 1], index)
 // => 4
 ```
 
-### 2. Exchange a card in the stack
+## 2. Exchange a card in the stack
 
 Exchange the card at position `index` with the new card provided and return the adjusted stack.
 Note that this will also change the input slice which is ok.
@@ -24,7 +24,7 @@ setItem([1, 2, 4, 1], index, newCard)
 // => [1, 2, 6, 1]
 ```
 
-### 3. Insert a card at the of top the stack
+## 3. Insert a card at the of top the stack
 
 Insert new card at the top of the stack and return the stack.
 
@@ -34,7 +34,7 @@ insertItemAtTop([5, 9, 7, 1], newCard)
 // => [5, 9, 7, 1, 8]
 ```
 
-### 4. Remove a card from the stack
+## 4. Remove a card from the stack
 
 Remove the card at position `index` from the stack and return the stack.
 
@@ -44,7 +44,7 @@ removeItem([3, 2, 6, 4, 8], index)
 // => [3, 2, 4, 8]
 ```
 
-### 5. Remove the top card from the stack
+## 5. Remove the top card from the stack
 
 Remove the card at the top of the stack and return the stack.
 
@@ -53,7 +53,7 @@ removeItemFromTop([3, 2, 6, 4, 8])
 // => [3, 2, 6, 4]
 ```
 
-### 6. Insert a card at the bottom of the stack
+## 6. Insert a card at the bottom of the stack
 
 Insert new card at the bottom of the stack and return the stack.
 
@@ -63,7 +63,7 @@ insertItemAtBottom([5, 9, 7, 1], newCard)
 // => [8, 5, 9, 7, 1]
 ```
 
-### 7. Remove a card from the bottom of the stack
+## 7. Remove a card from the bottom of the stack
 
 Remove the card at the bottom of the stack and return the stack.
 
@@ -72,7 +72,7 @@ removeItemAtBottom([8, 5, 9, 7, 1])
 // => [5, 9, 7, 1]
 ```
 
-### 8. Check size of the stack
+## 8. Check size of the stack
 
 Check whether the size of the stack is equal a given `stackSize` or not.
 

--- a/languages/javascript/exercises/concept/basics/.docs/hints.md
+++ b/languages/javascript/exercises/concept/basics/.docs/hints.md
@@ -1,20 +1,20 @@
-### 1. Define the expected oven time in minutes
+## 1. Define the expected oven time in minutes
 
 - Define a [constant][constants] which should contain the [`number`][numbers] value specified in the recipe.
 - [`export`][export] the constant.
 
-### 2. Calculate the remaining oven time in minutes
+## 2. Calculate the remaining oven time in minutes
 
 - [Explicitly return a number][return] from the function.
 - Use the [mathematical operator for subtraction][operators] to subtract values.
 
-### 3. Calculate the preparation time in minutes
+## 3. Calculate the preparation time in minutes
 
 - [Explicitly return a number][return] from the function.
 - Use the [mathematical operator for multiplication][operators] to multiply values.
 - Use the extra constant for the time in minutes per layer.
 
-### 4. Calculate the total working time in minutes
+## 4. Calculate the total working time in minutes
 
 - [Explicitly return a number][return] from the function.
 - [Invoke][invocation] one of the other methods implemented previously.

--- a/languages/javascript/exercises/concept/basics/.docs/instructions.md
+++ b/languages/javascript/exercises/concept/basics/.docs/instructions.md
@@ -2,7 +2,7 @@ In this exercise you're going to write some code to help you cook a brilliant la
 
 You have four tasks, all related to the time spent cooking the lasagna.
 
-### 1. Define the expected oven time in minutes
+## 1. Define the expected oven time in minutes
 
 Define the `EXPECTED_MINUTES_IN_OVEN` constant that returns how many minutes the lasagna should be in the oven. It must be exported. According to the cooking book, the expected oven time in minutes is 40:
 
@@ -11,7 +11,7 @@ EXPECTED_MINUTES_IN_OVEN
 // => 40
 ```
 
-### 2. Calculate the remaining oven time in minutes
+## 2. Calculate the remaining oven time in minutes
 
 Implement the `remainingMinutesInOven` function that takes the actual minutes the lasagna has been in the oven as a parameter and returns how many minutes the lasagna still has to remain in the oven, based on the expected oven time in minutes from the previous task.
 
@@ -20,7 +20,7 @@ remainingMinutesInOven(30)
 // => 10
 ```
 
-### 3. Calculate the preparation time in minutes
+## 3. Calculate the preparation time in minutes
 
 Implement the `preparationTimeInMinutes` function that takes the number of layers you added to the lasagna as a parameter and returns how many minutes you spent preparing the lasagna, assuming each layer takes you 2 minutes to prepare.
 
@@ -29,7 +29,7 @@ preparationTimeInMinutes(2)
 // => 4
 ```
 
-### 4. Calculate the total working time in minutes
+## 4. Calculate the total working time in minutes
 
 Implement the `totalTimeInMinutes` function that takes two parameters: the `numberOfLayers` parameter is the number of layers you added to the lasagna, and the `actualMinutesInOven` parameter is the number of minutes the lasagna has been in the oven. The function should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
 

--- a/languages/javascript/exercises/concept/booleans/.docs/hints.md
+++ b/languages/javascript/exercises/concept/booleans/.docs/hints.md
@@ -1,14 +1,14 @@
-### 1. Check if the 'Fast Attack' action is possible
+## 1. Check if the 'Fast Attack' action is possible
 
 - The logical NOT operator (`!`) can be placed before an expression to negate its value.
 - Check out [this MDN article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_NOT_!) on Logical Operators
 
-### 2. Check if the 'Approach and Spy' action is possible
+## 2. Check if the 'Approach and Spy' action is possible
 
 - Logical expressions are evaluated from left to right and are tested for possible 'short-circuits'.
 - For a more complete understanding of the left-to-right mechanic, you can take a look at [this article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)!
 
-### 3. Check if the 'Signal Prisoner' action is possible
+## 3. Check if the 'Signal Prisoner' action is possible
 
 - Logical operators in the order of their precedence (from highest to lowest): `!`, `&&`, `||`.
 - Check out [this MDN article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#Precedence_And_Associativity) on Operator Precedence

--- a/languages/javascript/exercises/concept/booleans/.docs/instructions.md
+++ b/languages/javascript/exercises/concept/booleans/.docs/instructions.md
@@ -13,7 +13,7 @@ You have four tasks: to implement the logic for determining if the above actions
 
 ## Tasks
 
-### 1. Check if the 'Fast Attack' action is possible
+## 1. Check if the 'Fast Attack' action is possible
 
 Implement a function named `canExecuteFastAttack` that takes a boolean value which indicates if the knight is awake. This function returns `true` if the 'Fast Attack' action is available based on the state of the character. Otherwise, returns `false`:
 
@@ -23,7 +23,7 @@ canExecuteFastAttack(knightIsAwake)
 // => false
 ```
 
-### 2. Check if the 'Spy' action is possible
+## 2. Check if the 'Spy' action is possible
 
 Implement a function named `canSpy` that takes three boolean values, indicating if the knight, archer and the prisoner, respectively, are awake. The function returns `true` if the 'Spy' action is available based on the state of the characters. Otherwise, returns `false`:
 
@@ -35,7 +35,7 @@ canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)
 // => true
 ```
 
-### 3. Check if the 'Signal Prisoner' action is possible
+## 3. Check if the 'Signal Prisoner' action is possible
 
 Implement a function named `canSignalPrisoner` that takes two boolean values, indicating if the archer and the prisoner, respectively, are awake. The function returns `true` if the 'Signal Prisoner' action is available based on the state of the characters. Otherwise, returns `false`:
 
@@ -46,7 +46,7 @@ canSignalPrisoner(archerIsAwake, prisonerIsAwake)
 // => true
 ```
 
-### 4. Check if the 'Free Prisoner' action is possible
+## 4. Check if the 'Free Prisoner' action is possible
 
 Implement a function named `canFreePrisoner` that takes four boolean values. The first three parameters indicate if the knight, archer and the prisoner, respectively, are awake. The last parameter indicates if Annalyn's pet dog is present. The function returns `true` if the 'Free Prisoner' action is available based on the state of the characters and Annalyn's pet dog presence. Otherwise, it returns `false`:
 

--- a/languages/javascript/exercises/concept/numbers/.docs/hints.md
+++ b/languages/javascript/exercises/concept/numbers/.docs/hints.md
@@ -1,6 +1,6 @@
-### 1. Calculate the day rate given an hourly rate
+## 1. Calculate the day rate given an hourly rate
 
-### 2. Calculate the month rate, given an hourly rate and a discount
+## 2. Calculate the month rate, given an hourly rate and a discount
 
 - There is a global built-in function to _parse_ a `string` to a fractional
   number, ignoring non-numeric characters, such as the `%` (percent)-sign.
@@ -10,7 +10,7 @@
 
 [ref-math-object]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math
 
-### 3. Calculate the number of workdays given a budget, rate and discount
+## 3. Calculate the number of workdays given a budget, rate and discount
 
 - There is a function on the `number` (proto)type to return a "fixed" number of
   decimals.

--- a/languages/javascript/exercises/concept/numbers/.docs/instructions.md
+++ b/languages/javascript/exercises/concept/numbers/.docs/instructions.md
@@ -16,7 +16,7 @@ between `0.0%` (no discount) and `90.0%` (maximum discount).
 
 ## Tasks
 
-### 1. Calculate the day rate given an hourly rate
+## 1. Calculate the day rate given an hourly rate
 
 Implement a function to calculate the day rate given an hourly rate:
 
@@ -27,7 +27,7 @@ dayRate(89)
 
 The day rate does not need to be rounded or changed to a "fixed" precision.
 
-### 2. Calculate the month rate, given an hourly rate and a discount
+## 2. Calculate the month rate, given an hourly rate and a discount
 
 Implement a function to calculate the month rate, and apply a discount:
 
@@ -39,7 +39,7 @@ monthRate(89, '42%')
 The discount is always passed as a `string`. The result _must_ be rounded up to
 the nearest whole number.
 
-### 3. Calculate the number of workdays given a budget, rate and discount
+## 3. Calculate the number of workdays given a budget, rate and discount
 
 Implement a function that takes a budget, a rate per hour and a discount, and
 calculates how many days of work that covers, to one decimal place.

--- a/languages/javascript/exercises/concept/promises/.docs/hints.md
+++ b/languages/javascript/exercises/concept/promises/.docs/hints.md
@@ -1,4 +1,4 @@
-### 1. Fetch a translation, ignoring the quality
+## 1. Fetch a translation, ignoring the quality
 
 - Promises are chainable, for example by using `.then`.
 - Promises will forward any value. That means that if a promise resolves, it
@@ -8,18 +8,18 @@
   will forward that rejection until it reaches the end of the chain or a
   `.catch`, which receives the value as its argument and can handle it.
 
-### 2. Fetch a batch of translations, all-or-nothing
+## 2. Fetch a batch of translations, all-or-nothing
 
 - In order to return a promise with an error, create a `Promise` that is
   `rejected` from the start.
 - There is a helper method on `Promise` which waits for an array of promises to
   resolve, before it resolves itself.
 
-### 3. Request a translation, retrying at most 2 times
+## 3. Request a translation, retrying at most 2 times
 
 - Convert the `callback` to a promise using the `new Promise` constructor.
 
-### 4. Fetch a translation, inspect the quality, or request it
+## 4. Fetch a translation, inspect the quality, or request it
 
 - Instead of nesting `.then` and/or `.catch`, `.then` takes a second argument
   which catches everything _before_ (earlier in the chain), ignoring errors

--- a/languages/javascript/exercises/concept/promises/.docs/instructions.md
+++ b/languages/javascript/exercises/concept/promises/.docs/instructions.md
@@ -34,7 +34,7 @@ completely, forever.
 
 ## Tasks
 
-### 1. Fetch a translation, ignoring the quality
+## 1. Fetch a translation, ignoring the quality
 
 Implement a function to fetch a translation, ignoring the quality, and
 forwarding any errors thrown by the API:
@@ -50,7 +50,7 @@ service.free("jIyajbe'")
 - Returns the translation if it can be retrieved, regardless its quality
 - Forwards any error from the translation API
 
-### 2. Fetch a batch of translations, all-or-nothing
+## 2. Fetch a batch of translations, all-or-nothing
 
 Implement a function that batch translates the given texts using the free
 service, returning all the translations, or a single error.
@@ -70,7 +70,7 @@ service.batch([])
 - Rejects with the first error that is encountered
 - Rejects with a `BatchIsEmpty` error if no texts are given
 
-### 3. Request a translation, retrying at most 2 times
+## 3. Request a translation, retrying at most 2 times
 
 Implement a function that requests a translation, with automatic retries, up to a total of 3 calls for the same request.
 
@@ -79,7 +79,7 @@ service.request("jIyajbe'")
 // => Promise<...> resolves (with nothing), can now be retrieved using the fetch API
 ```
 
-### 4. Fetch a translation, inspect the quality, or request it
+## 4. Fetch a translation, inspect the quality, or request it
 
 Implement the function for premium users which fetch a translation, request it
 if it's not available, and only return it if it meets a certain threshold.

--- a/languages/javascript/exercises/concept/strings/.docs/hints.md
+++ b/languages/javascript/exercises/concept/strings/.docs/hints.md
@@ -1,11 +1,11 @@
-### 1. Get the first letter of a sentence
+## 1. Get the first letter of a sentence
 
 - Any `string` in JavaScript has two methods to access characters at a certain
   position: a regular method `.method(position)`, and using `array` style
   indexers `[position]`.
 - `.charAt(position)` will get the character at `position`.
 
-### 2. Capitalize a word
+## 2. Capitalize a word
 
 - Capitalization means having a single Uppercase character, followed by
   lowercase characters.
@@ -13,19 +13,19 @@
   except the first character).
 - `.slice(position)` can slice up a string at a position.
 
-### 3. Get the last letter of a sentence
+## 3. Get the last letter of a sentence
 
 - This is similar to getting the first letter, except that it might be
   preferable to use the number of characters in the string to find the position
   of the last character.
 - The number of characters in a string is given by its `.length` property.
 
-### 4. Trim a sentence
+## 4. Trim a sentence
 
 - `.trim()` method is available on the `String.prototype` (methods
   that work on `string`).
 
-### 5. Be polite
+## 5. Be polite
 
 - There are various ways to concatenate a `string` in JavaScript. It's also
   possible to use `string` templating.

--- a/languages/javascript/exercises/concept/strings/.docs/instructions.md
+++ b/languages/javascript/exercises/concept/strings/.docs/instructions.md
@@ -61,7 +61,7 @@ with the renowned poets.
 
 ## Tasks
 
-### 1. Get the first letter of a sentence
+## 1. Get the first letter of a sentence
 
 Implement a function that returns first letter of a sentence:
 
@@ -70,7 +70,7 @@ frontDoorResponse('Stands so high')
 // => "S"
 ```
 
-### 2. Capitalize a word
+## 2. Capitalize a word
 
 Implement a function that correctly capitalizes a word:
 
@@ -82,7 +82,7 @@ capitalize('horse')
 // => "Horse"
 ```
 
-### 3. Get the last letter of a sentence
+## 3. Get the last letter of a sentence
 
 Implement a function that returns the last letter of a sentence:
 
@@ -91,7 +91,7 @@ backDoorResponse('Stands so high')
 // => "h"
 ```
 
-### 4. Trim a sentence
+## 4. Trim a sentence
 
 Improve the previous function so that it removes whitespace from the end of a sentence and returns the last character:
 
@@ -100,7 +100,7 @@ backDoorResponse('Stands so high   ')
 // => "h"
 ```
 
-### 5. Be polite
+## 5. Be polite
 
 Change the implementation of the `backDoorPassword` function so that it's polite:
 

--- a/languages/julia/exercises/concept/functions-introduction/.docs/hints.md
+++ b/languages/julia/exercises/concept/functions-introduction/.docs/hints.md
@@ -1,4 +1,4 @@
-### General
+## General
 
 You will need to define [functions][functions] and use [arithmetic operators][arithmetics].
 

--- a/languages/julia/exercises/concept/functions-introduction/.docs/instructions.md
+++ b/languages/julia/exercises/concept/functions-introduction/.docs/instructions.md
@@ -2,7 +2,7 @@ In this exercise you're going to write some code to help you cook a brilliant la
 
 You have three tasks, all related to the time spent cooking the lasasgna.
 
-### 1. Calculate the preparation time in minutes
+## 1. Calculate the preparation time in minutes
 
 Define the `preptime` function that takes the number of layers you added to the lasagna as an argument and returns how many minutes you spent preparing the lasagna, assuming each layer takes you 2 minutes to prepare.
 
@@ -11,7 +11,7 @@ julia> preptime(4)
 8
 ```
 
-### 2. Calculate the remaining oven time in minutes
+## 2. Calculate the remaining oven time in minutes
 
 According to the cooking book, lasagna needs to be in the oven for a total of 60 minutes.
 Define the `remaining_time` function that takes the actual minutes the lasagna has been in the oven as a parameter and returns how many minutes the lasagna still has to remain in the oven.
@@ -21,7 +21,7 @@ julia> remaining_time(50)
 10
 ```
 
-### 3. Calculate the total working time in minutes
+## 3. Calculate the total working time in minutes
 
 Define the `total_working_time` function that takes two arguments: the first argument is the number of layers you added to the lasagna, and the second parameter is the number of minutes the lasagna has been in the oven.
 The function should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.

--- a/languages/julia/exercises/concept/functions-introduction/.docs/introduction.md
+++ b/languages/julia/exercises/concept/functions-introduction/.docs/introduction.md
@@ -1,7 +1,7 @@
 The entire Julia track will require you to treat your solution like small libraries, i.e. you need to define functions, types etc. which will then be run against a test suite.
 For that reason, we will introduce named functions as the very first concept.
 
-### Defining functions
+## Defining functions
 
 There are two common ways to define a named function in Julia:
 
@@ -19,7 +19,7 @@ muladd(x, y, z) = x * y + z
 
 The latter is most commonly used for one-line function definitions or mathematical functions.
 
-### Invoking functions
+## Invoking functions
 
 Invoking a function is done by specifying its name and passing arguments for each of the function's parameters:
 
@@ -31,12 +31,12 @@ muladd(10, 5, 1)
 square_plus_one(x) = muladd(x, x, 1)
 ```
 
-### Types
+## Types
 
 Depending on which other programming languages you know, you may expect parameters, variables or return values to have explicit type annotations.
 For now, assume that that Julia will infer the types automagically and don't worry about them, we will get to the specifics of the type system in later exercises.
 
-### Comments
+## Comments
 
 Julia supports two kinds of comments.
 Single line comments are preceded by `#` and multiline comments are inserted between `#=` and `=#`.

--- a/languages/purescript/exercises/concept/booleans/.docs/hints.md
+++ b/languages/purescript/exercises/concept/booleans/.docs/hints.md
@@ -1,11 +1,11 @@
-### 1. Check if the 'Fast Attack' action is possible
+## 1. Check if the 'Fast Attack' action is possible
 
 - The logical NOT operator (`not`) can be placed before an expression to negate its value.
 
-### 2. Check if the 'Approach and Spy' action is possible
+## 2. Check if the 'Approach and Spy' action is possible
 
 - Logical expressions are evaluated from left to right and are tested for possible 'short-circuits'.
 
-### 3. Check if the 'Signal Prisoner' action is possible
+## 3. Check if the 'Signal Prisoner' action is possible
 
 - Logical operators in the order of their precedence (from highest to lowest): `not`, `&&`, `||`.

--- a/languages/purescript/exercises/concept/booleans/.docs/instructions.md
+++ b/languages/purescript/exercises/concept/booleans/.docs/instructions.md
@@ -13,7 +13,7 @@ You have four tasks: to implement the logic for determining if the above actions
 
 ## Tasks
 
-### 1. Check if the 'Fast Attack' action is possible
+## 1. Check if the 'Fast Attack' action is possible
 
 Implement a function named `canExecuteFastAttack` that takes a boolean value which indicates if the knight is awake. This function returns `true` if the 'Fast Attack' action is available based on the state of the character. Otherwise, returns `false`:
 
@@ -25,7 +25,7 @@ canExecuteFastAttack knightIsAwake
 -- => false
 ```
 
-### 2. Check if the 'Spy' action is possible
+## 2. Check if the 'Spy' action is possible
 
 Implement a function named `canSpy` that takes three boolean values, indicating if the knight, archer and the prisoner, respectively, are awake. The function returns `true` if the 'Spy' action is available based on the state of the characters. Otherwise, returns `false`:
 
@@ -43,7 +43,7 @@ canSpy knightIsAwake archerIsAwake prisonerIsAwake
 -- => true
 ```
 
-### 3. Check if the 'Signal Prisoner' action is possible
+## 3. Check if the 'Signal Prisoner' action is possible
 
 Implement a function named `canSignalPrisoner` that takes two boolean values, indicating if the archer and the prisoner, respectively, are awake. The function returns `true` if the 'Signal Prisoner' action is available based on the state of the characters. Otherwise, returns `false`:
 
@@ -57,7 +57,7 @@ prisonerIsAwake = true
 canSignalPrisoner archerIsAwake prisonerIsAwake -- => true
 ```
 
-### 4. Check if the 'Free Prisoner' action is possible
+## 4. Check if the 'Free Prisoner' action is possible
 
 Implement a function named `canFreePrisoner` that takes four boolean values. The first three parameters indicate if the knight, archer and the prisoner, respectively, are awake. The last parameter indicates if Annalyn's pet dog is present. The function returns `true` if the 'Free Prisoner' action is available based on the state of the characters and Annalyn's pet dog presence. Otherwise, it returns `false`:
 

--- a/languages/python/exercises/concept/strings/.docs/hints.md
+++ b/languages/python/exercises/concept/strings/.docs/hints.md
@@ -1,16 +1,16 @@
-### General
+## General
 
 - The [Python documentation for `str`][python-str-doc] has an overview of the Python `str` type.
 
-### 1. Get message from a log line
+## 1. Get message from a log line
 
 - Strings in Python have [lots of convenient instance methods][str-type-methods] for cleaning, splitting, manipulating, and creating new strings. Extracting values from a string could be done by splitting it based on a substring, for example.
 
-### 2. Get log level from a log line
+## 2. Get log level from a log line
 
 - Strings also have methods that help convert letters from lower to uppercase and vice-versa.
 
-### 3. Reformat a log line
+## 3. Reformat a log line
 
 Strings are immutable, but can be combined together to make new strings, or have elements replaced. This goal can be accomplished by using string methods, or operators like `+` or `+=` (which are overloaded to work with strings).
 Python also has a concept of string formatting, like many other languages.

--- a/languages/python/exercises/concept/strings/.docs/instructions.md
+++ b/languages/python/exercises/concept/strings/.docs/instructions.md
@@ -10,7 +10,7 @@ There are three different log levels:
 
 You have three tasks, each of which will take a log line and ask you to do something with it.
 
-### 1. Extract a message from a log line
+## 1. Extract a message from a log line
 
 Implement a function to return a log line's message:
 
@@ -26,7 +26,7 @@ The message should be trimmed of any whitespace.
 'Invalid operation.'
 ```
 
-### 2. Change a message's loglevel.
+## 2. Change a message's loglevel.
 
 Implement a function that replaces a log line's current log level with a new one:
 
@@ -35,7 +35,7 @@ Implement a function that replaces a log line's current log level with a new one
 '[ERROR]: Fatal Error.'
 ```
 
-### 3. Reformat a log line
+## 3. Reformat a log line
 
 Implement a function that reformats the log line, putting the message first and the log level after it in parentheses:
 

--- a/languages/ruby/exercises/concept/basics/.docs/hints.md
+++ b/languages/ruby/exercises/concept/basics/.docs/hints.md
@@ -1,21 +1,21 @@
-### 1. Define the expected oven time in minutes
+## 1. Define the expected oven time in minutes
 
 - You need to define a [constant][constant] which should contain the [integer][integers] value specified in the recipe.
 
-### 2. Calculate the remaining oven time in minutes
+## 2. Calculate the remaining oven time in minutes
 
 - You need to define a [method][methods] with a single parameter for the actual time so far.
 - You can [implicitly return an integer][return] from the method.
 - You can use the [mathematical operator for subtraction][operators] to subtract values.
 
-### 3. Calculate the preparation time in minutes
+## 3. Calculate the preparation time in minutes
 
 - You need to define a [method][methods] with a single parameter for the number of layers.
 - You can [implicitly return an integer][return] from the method.
 - You can use the [mathematical operator for multiplicaton][operators] to multiply values.
 - You could define an extra constant for the time in minutes per layer, or use a "magic number" in the code.
 
-### 4. Calculate the total working time in minutes
+## 4. Calculate the total working time in minutes
 
 - You need to define a [method][methods] with two named parameters: `number_of_layers` and `actual_minutes_in_oven`.
 - You can [implicitly return an integer][return] from the method.

--- a/languages/ruby/exercises/concept/basics/.docs/instructions.md
+++ b/languages/ruby/exercises/concept/basics/.docs/instructions.md
@@ -2,7 +2,7 @@ In this exercise you're going to write some code to help you cook a brilliant la
 
 You have four tasks, all related to the time spent cooking the lasagna.
 
-### 1. Define the expected oven time in minutes
+## 1. Define the expected oven time in minutes
 
 Define the `Lasagna::EXPECTED_MINUTES_IN_OVEN` constant that returns how many minutes the lasagna should be in the oven. According to the cooking book, the expected oven time in minutes is 40:
 
@@ -11,7 +11,7 @@ Lasagna::EXPECTED_MINUTES_IN_OVEN
 # => 40
 ```
 
-### 2. Calculate the remaining oven time in minutes
+## 2. Calculate the remaining oven time in minutes
 
 Define the `Lasagna#remaining_minutes_in_oven` method that takes the actual minutes the lasagna has been in the oven as a parameter and returns how many minutes the lasagna still has to remain in the oven, based on the expected oven time in minutes from the previous task.
 
@@ -21,7 +21,7 @@ lasagna.remaining_minutes_in_oven(30)
 # => 10
 ```
 
-### 3. Calculate the preparation time in minutes
+## 3. Calculate the preparation time in minutes
 
 Define the `Lasagna#preparation_time_in_minutes` method that takes the number of layers you added to the lasagna as a parameter and returns how many minutes you spent preparing the lasagna, assuming each layer takes you 2 minutes to prepare.
 
@@ -31,7 +31,7 @@ lasagna.preparation_time_in_minutes(2)
 # => 4
 ```
 
-### 4. Calculate the total working time in minutes
+## 4. Calculate the total working time in minutes
 
 Define the `Lasagna#total_time_in_minutes` method that takes two named parameters: the `number_of_layers` parameter is the number of layers you added to the lasagna, and the `actual_minutes_in_oven` parameter is the number of minutes the lasagna has been in the oven. The function should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
 

--- a/languages/ruby/exercises/concept/floating-point-numbers/.docs/hints.md
+++ b/languages/ruby/exercises/concept/floating-point-numbers/.docs/hints.md
@@ -1,13 +1,13 @@
-### General
+## General
 
-### 1. Calculate the interest rate
+## 1. Calculate the interest rate
 
 - Using an `if` or `case` statement can be useful when checking conditions.
 
-### 2. Calculate the annual balance update
+## 2. Calculate the annual balance update
 
 - When calculating the annual yield, it might be useful to temporarily convert a negative balance to a positive one. The `Float` class has a method to convert both positive and negative values to their absolute value.
 
-### 3. Calculate the years before reaching the desired balance
+## 3. Calculate the years before reaching the desired balance
 
 - To calculate the years, one can keep looping until the desired balance is reached.

--- a/languages/ruby/exercises/concept/floating-point-numbers/.docs/instructions.md
+++ b/languages/ruby/exercises/concept/floating-point-numbers/.docs/instructions.md
@@ -7,7 +7,7 @@ In this exercise you'll be working with savings accounts. Each year, the balance
 
 You have three tasks, each of which will deal the balance and its interest rate.
 
-### 1. Calculate the interest rate
+## 1. Calculate the interest rate
 
 Implement the `SavingsAccount.interest_rate` method to calculate the interest rate based on the specified balance:
 
@@ -18,7 +18,7 @@ SavingsAccount.interest_rate(200.75)
 
 Note that the value returned is an instance of `Float`.
 
-### 2. Calculate the annual balance update
+## 2. Calculate the annual balance update
 
 Implement the `SavingsAccount.annual_balance_update` method to calculate the annual balance update, taking into account the interest rate:
 
@@ -29,7 +29,7 @@ SavingsAccount.annual_balance_update(200.75)
 
 Note that the value returned is an instance of `Float`.
 
-### 3. Calculate the years before reaching the desired balance
+## 3. Calculate the years before reaching the desired balance
 
 Implement the `SavingsAccount.years_before_desired_balance` method to calculate the minimum number of years required to reach the desired balance:
 

--- a/languages/ruby/exercises/concept/numbers/.docs/hints.md
+++ b/languages/ruby/exercises/concept/numbers/.docs/hints.md
@@ -1,12 +1,12 @@
-### General
+## General
 
-### 1. Calculate the production rate per second
+## 1. Calculate the production rate per second
 
 - Determining the success rate can be done through a [conditional statement][if-else-unless].
 - Multiplication can be done between instances of `Integer` and `Float`. The result will always be an instance of `Float`.
 - Numbers can be compared using the built-in [comparison-operators][comparison-operators].
 
-### 2. Calculate the number of working items produced per second
+## 2. Calculate the number of working items produced per second
 
 - The `Float` class implements a [method][to_i] to return an instance of `Integer`.
 - The `Integer` class implements a [method][to_f] to return an instance of `Float`.

--- a/languages/ruby/exercises/concept/numbers/.docs/instructions.md
+++ b/languages/ruby/exercises/concept/numbers/.docs/instructions.md
@@ -9,7 +9,7 @@ At its slowest speed (`1`), `221` cars are produced each hour. The production in
 
 You have two tasks.
 
-### 1. Calculate the production rate per hour
+## 1. Calculate the production rate per hour
 
 Implement the `AssemblyLine.production_rate_per_hour` method to calculate the assembly line's production rate per hour, taking into account its success rate:
 
@@ -20,7 +20,7 @@ AssemblyLine.production_rate_per_hour(6)
 
 Note that the value returned is an instance of `Float`.
 
-### 2. Calculate the number of working items produced per minute
+## 2. Calculate the number of working items produced per minute
 
 Implement the `AssemblyLine.working_items_per_minute` method to calculate how many working cars are produced per minute:
 

--- a/languages/ruby/exercises/concept/strings/.docs/hints.md
+++ b/languages/ruby/exercises/concept/strings/.docs/hints.md
@@ -1,18 +1,18 @@
-### General
+## General
 
 - The [rubymostas strings guide][ruby-for-beginners.rubymonstas.org-strings] has a nice introduction to Ruby strings.
 - The `String` object has many useful [built-in methods][docs-string-methods].
 
-### 1. Get message from a log line
+## 1. Get message from a log line
 
 - There are different ways to search for text in a string, which can be found on the [Ruby language official documentation][docs-string-methods].
 - There are [built in methods][strip-white-space] to strip white space.
 
-### 2. Get log level from a log line
+## 2. Get log level from a log line
 
 - Ruby `String` objects have a [method][downcase] to perform this operation.
 
-### 3. Reformat a log line
+## 3. Reformat a log line
 
 - There are several ways to [concatenate strings][ruby-for-beginners.rubymonstas.org-strings], but the preferred one is usually [string interpolation][ruby-for-beginners.rubymonstas.org-strings]
 

--- a/languages/ruby/exercises/concept/strings/.docs/instructions.md
+++ b/languages/ruby/exercises/concept/strings/.docs/instructions.md
@@ -10,7 +10,7 @@ There are three different log levels:
 
 You have three tasks, each of which will take a log line and ask you to do something with it.
 
-### 1. Get message from a log line
+## 1. Get message from a log line
 
 Implement a method to return a log line's message:
 
@@ -26,7 +26,7 @@ LogLineParser.message('[WARNING]:  Disk almost full\r\n')
 // Returns: "Disk almost full"
 ```
 
-### 2. Get log level from a log line
+## 2. Get log level from a log line
 
 Implement a method to return a log line's log level, which should be returned in lowercase:
 
@@ -35,7 +35,7 @@ LogLineParser.log_level('[ERROR]: Invalid operation')
 // Returns: "error"
 ```
 
-### 3. Reformat a log line
+## 3. Reformat a log line
 
 Implement a method that reformats the log line, putting the message first and the log level after it in parentheses:
 

--- a/languages/rust/exercises/concept/enums/.docs/hints.md
+++ b/languages/rust/exercises/concept/enums/.docs/hints.md
@@ -1,9 +1,9 @@
-### General
+## General
 
 - [cheats.rs - Basic Types][cheats-types]
 - [Rust By Example - Enums][rbe-enums]
 
-### using match
+## using match
 
 - `match` comes in handy when working with enums. In this case, see how you might use it when figuring how what kind of log message to generate.
 

--- a/languages/rust/exercises/concept/numbers/.docs/instructions.md
+++ b/languages/rust/exercises/concept/numbers/.docs/instructions.md
@@ -8,7 +8,7 @@ At its lowest speed (`1`), `221` cars are produced each hour. The production inc
 
 You have two tasks.
 
-### 1. Calculate the production rate per hour
+## 1. Calculate the production rate per hour
 
 Implement a method to calculate the assembly line's production rate per hour, taking into account its success rate:
 
@@ -19,7 +19,7 @@ numbers::production_rate_per_hour(6)
 
 Note that the value returned is an `f64`.
 
-### 2. Calculate the number of working items produced per minute
+## 2. Calculate the number of working items produced per minute
 
 Implement a method to calculate how many working cars are produced per minute:
 


### PR DESCRIPTION
In [this Elixir PR](https://github.com/exercism/v3/pull/1495), as discrepancy was found in our guidelines for using headings in documentation files. This PR standardizes all headings in documentation files to `##` headings.