### PR TITLE
[Elixir] Fix typos and uppercase the language name in various docs

### DIFF
--- a/languages/elixir/exercises/concept/anonymous-functions/.docs/after.md
+++ b/languages/elixir/exercises/concept/anonymous-functions/.docs/after.md
@@ -64,7 +64,7 @@ Enum.map([1, 2, 3], &(&1 + 1))
   &<=/2
   ```
 
-- Bound varables from an outer scope can be used in an inner scope using the bound variable name to [create closures][closure].
+- Bound variables from an outer scope can be used in an inner scope using the bound variable name to [create closures][closure].
 
   ```elixir
   def return_closure(x) do

--- a/languages/elixir/exercises/concept/anonymous-functions/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/anonymous-functions/.docs/instructions.md
@@ -2,7 +2,7 @@ In this exercise, you've been tasked with writing the software for an encryption
 
 For each task, make use of a closure and return a function that can be invoked from the calling scope.
 
-All functions should expect integer parameters. Integers are also suitable for performing bitwise operations in elixir.
+All functions should expect integer parameters. Integers are also suitable for performing bitwise operations in Elixir.
 
 You have seven tasks:
 

--- a/languages/elixir/exercises/concept/anonymous-functions/.meta/design.md
+++ b/languages/elixir/exercises/concept/anonymous-functions/.meta/design.md
@@ -10,7 +10,7 @@ After completing this exercise, the student should:
 
 - Know how to write [anonymous functions][fns].
 - Know how to return a function from a function.
-- Know how to use closures in elixir.
+- Know how to use closures in Elixir.
 - Be exposed to the capture notation in the after.md
 
 ## Out of scope

--- a/languages/elixir/exercises/concept/basics/.docs/hints.md
+++ b/languages/elixir/exercises/concept/basics/.docs/hints.md
@@ -19,7 +19,7 @@
 - You need to define a [function][functions] with a single parameter.
 - You have to [implicitly return an integer][return] from a function.
 - The function's parameter is an [integer][integers].
-- You can use the [mathematical operator for multiplicaton][operators] to multiply values.
+- You can use the [mathematical operator for multiplication][operators] to multiply values.
 
 ## 4. Calculate the total working time in minutes
 

--- a/languages/elixir/exercises/concept/basics/.meta/design.md
+++ b/languages/elixir/exercises/concept/basics/.meta/design.md
@@ -38,7 +38,7 @@ The Concepts this exercise unlocks are:
 
 - `basics`: know what a variable is; know how to define a variable; know how to update a variable; know how to use type inference for variables; know how to define a function; know how to return a value from a function; know how to call a function; know that functions must be defined in classes; know about the `public` access modifier; know how to define an integer; know how to use mathematical operators on integers; know how to define single-line comments.
 
-## Prequisites
+## Prerequisites
 
 There are no prerequisites.
 

--- a/languages/elixir/exercises/concept/booleans/.docs/hints.md
+++ b/languages/elixir/exercises/concept/booleans/.docs/hints.md
@@ -1,6 +1,6 @@
 ## General
 
-Don't worry about how the paramaters are derived, just focus on combining the parameters to return the intended result.
+Don't worry about how the parameters are derived, just focus on combining the parameters to return the intended result.
 
 ## 1. Define if pac-man can eat a ghost
 

--- a/languages/elixir/exercises/concept/conditionals/.docs/after.md
+++ b/languages/elixir/exercises/concept/conditionals/.docs/after.md
@@ -1,7 +1,7 @@
 You can use [atoms][atom] whenever you have a set of constants you want to express. Using [atoms][atom] opens a type-safe way of interacting with constant values. An atom is defined by its name, following the [atom][atom] format:
 
 ```elixir
-# All atoms are preceeded with a ':' then follow with alphanumeric snake-cased characters
+# All atoms are preceded with a ':' then follow with alphanumeric snake-cased characters
 variable = :an_atom
 ```
 

--- a/languages/elixir/exercises/concept/conditionals/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/conditionals/.docs/introduction.md
@@ -1,7 +1,7 @@
 Elixir's `atom` type represents a fixed constant. An atom's value is simply its own name. This gives us a type-safe way to interact with data. Atoms can be defined as follows:
 
 ```elixir
-# All atoms are preceeded with a ':' then follow with alphanumeric snake-cased characters
+# All atoms are preceded with a ':' then follow with alphanumeric snake-cased characters
 variable = :an_atom
 ```
 

--- a/languages/elixir/exercises/concept/conditionals/.meta/design.md
+++ b/languages/elixir/exercises/concept/conditionals/.meta/design.md
@@ -18,7 +18,7 @@ After completing this exercise, the student should:
 - Pattern matching.
 - Function overloading.
 - `case` flow control structures.
-- Converstion of string to atoms.
+- Conversion of string to atoms.
 
 ## Concepts
 
@@ -27,7 +27,7 @@ The Concepts this exercise unlocks are:
 - `conditionals`: know of the existence of the `cond` control flow structure; know how to use boolean expressions to control flow;
 - `atoms`: know how to use `atom` values.
 
-## Prequisites
+## Prerequisites
 
 This exercise's prerequisites Concepts are:
 

--- a/languages/elixir/exercises/concept/maps/.docs/after.md
+++ b/languages/elixir/exercises/concept/maps/.docs/after.md
@@ -1,4 +1,4 @@
-Great work, knowing how to effectivly use [maps][maps] is an important skill to use Elixir fluently.
+Great work, knowing how to effectively use [maps][maps] is an important skill to use Elixir fluently.
 
 ## Key points
 
@@ -22,7 +22,7 @@ Great work, knowing how to effectivly use [maps][maps] is an important skill to 
   %{"a" => 2.0}
 
   # A map with the map key %{} with the list value [1,2,3]
-  %{%{}, [1,2,3]}
+  %{%{} => [1,2,3]}
   ```
 
 - Maps can also be instantiated using [`Map.new`][map-new] in the [Map module][map-module].

--- a/languages/elixir/exercises/concept/maps/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/maps/.docs/introduction.md
@@ -27,7 +27,7 @@ Maps also implement the _Enumerable protocol_, which allow them to be used in _E
 
 ## Module attributes as constants
 
-In elixir, we can define module attributes which can be used as constants in our functions.
+In Elixir, we can define module attributes which can be used as constants in our functions.
 
 ```elixir
 defmodule Example do

--- a/languages/elixir/exercises/concept/maps/.meta/design.md
+++ b/languages/elixir/exercises/concept/maps/.meta/design.md
@@ -13,7 +13,7 @@ The goal of this exercise is to teach the student the basics of maps in Elixir.
 - Know how to update values from a map.
 - Know the limitations and guarantees of maps in Elixir.
   - Know that it is not an ordered collection (though appears that way at small sizes)
-  - Know that it is O(log n) rather than O(1) as it mayt be in other languages
+  - Know that it is O(log n) rather than O(1) as it may be in other languages
 - Know how to find and use the Map module functions
 - Know how to use the map-update syntax.
 - Know how what types can be values and keys (all types).
@@ -30,7 +30,7 @@ The Concepts this exercise unlocks are:
 
 - `maps`: See above goals
 
-## Prequisites
+## Prerequisites
 
 - `string-literals`: know how to write string literals in code (alphanumeric unicode graphemes surrounded by double quotes)
 - `anonymous-functions`: know how to write anonymous functions, pass functions as data

--- a/languages/elixir/exercises/concept/maps/test/high_score_test.exs
+++ b/languages/elixir/exercises/concept/maps/test/high_score_test.exs
@@ -95,7 +95,7 @@ defmodule HighScoreTest do
   end
 
   describe "reset_score/2" do
-    test "reseting score for non-existent player sets player score to 0" do
+    test "resetting score for non-existent player sets player score to 0" do
       {jose, _score} = @jose
       scores =
         HighScore.new()
@@ -104,7 +104,7 @@ defmodule HighScoreTest do
       assert scores == %{jose => 0}
     end
 
-    test "reseting score for existing player sets previous player score to 0" do
+    test "resetting score for existing player sets previous player score to 0" do
       {jose, score} = @jose
       scores =
         HighScore.new()

--- a/languages/elixir/exercises/concept/multiple-clause-functions/.docs/after.md
+++ b/languages/elixir/exercises/concept/multiple-clause-functions/.docs/after.md
@@ -7,7 +7,7 @@
 
 ## Guards
 
-- [Guards][guards] are used to prevent elixir from invoking functions or prevent pattern matching.
+- [Guards][guards] are used to prevent Elixir from invoking functions or prevent pattern matching.
 - [Guard][guards] functions are special functions which:
   - Must be [pure][pure-function] and not mutate any global states.
   - Must return strict `true` or `false` values.
@@ -22,7 +22,7 @@
 def number(n \\ 13), do: "That's not my favorite"
 ```
 
-- During compilation, elixir creates a function definition for `number/0` (no arguments), and `number/1` (one argument).
+- During compilation, Elixir creates a function definition for `number/0` (no arguments), and `number/1` (one argument).
 - If more than one argument has default values, the default values will be applied to the function from left to right to fill in for missing parameters.
 - If the function has multiple clauses, it is required to write a [function header][function-header] for the default arguments.
 

--- a/languages/elixir/exercises/concept/multiple-clause-functions/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/multiple-clause-functions/.docs/introduction.md
@@ -13,13 +13,13 @@ def number(_n) do
 end
 ```
 
-At run-time, elixir will test, from top to bottom of the source file, which function clause to invoke.
+At run-time, Elixir will test, from top to bottom of the source file, which function clause to invoke.
 
 Variables that are unused in the function body should be prefixed with an underscore.
 
 ## Guards
 
-Guards are used to prevent elixir from invoking functions based on evaluation of the parameters by guard functions. Guards begin with the `when` keyword, followed by a boolean expression. Guard functions are special functions which:
+Guards are used to prevent Elixir from invoking functions based on evaluation of the parameters by guard functions. Guards begin with the `when` keyword, followed by a boolean expression. Guard functions are special functions which:
 
 - Must be pure and not mutate any global states.
 - Must return strict `true` or `false` values.
@@ -28,7 +28,7 @@ A list of common guards are found in the [Elixir documentation][kernel-guards]
 
 ## Default arguments
 
-Functions may declare default values for one or more arguments. When compiled, elixir creates a function definition for `number/0` (no arguments), and `number/1` (one argument).
+Functions may declare default values for one or more arguments. When compiled, Elixir creates a function definition for `number/0` (no arguments), and `number/1` (one argument).
 
 ```elixir
 def number(n \\ 13), do: "That's not my favorite"

--- a/languages/elixir/exercises/concept/multiple-clause-functions/.meta/design.md
+++ b/languages/elixir/exercises/concept/multiple-clause-functions/.meta/design.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-The goal for this exercise is to teach more about functions in elixir and how to use multiple functions clauses, guards
+The goal for this exercise is to teach more about functions in Elixir and how to use multiple functions clauses, guards
 
 ## Learning objectives
 

--- a/languages/elixir/exercises/concept/tuples/.docs/after.md
+++ b/languages/elixir/exercises/concept/tuples/.docs/after.md
@@ -1,4 +1,4 @@
-Great job! [Tuples][tuple-doc] are used commonly to group information informally. A common pattern through elixir is to group function return values with a status
+Great job! [Tuples][tuple-doc] are used commonly to group information informally. A common pattern through Elixir is to group function return values with a status
 
 ```elixir
 File.read("hello.txt")
@@ -8,7 +8,7 @@ File.read("invalid.txt")
 # => {:error, :enoent}
 ```
 
-Then when writing elixir functions, we can made use of an [assertive style][assertive-style] with [pattern matching][pattern-match-doc]:
+Then when writing Elixir functions, we can made use of an [assertive style][assertive-style] with [pattern matching][pattern-match-doc]:
 
 ```elixir
 def read_file() do
@@ -17,7 +17,7 @@ def read_file() do
 end
 ```
 
-It might occur to you that this function may crash if the file does not exist. Don't worry, in Elixir it is often said to [**let it crash**][let-it-crash], because in elixir applications, a supervising process will restart the application to a known-good state.
+It might occur to you that this function may crash if the file does not exist. Don't worry, in Elixir it is often said to [**let it crash**][let-it-crash], because in Elixir applications, a supervising process will restart the application to a known-good state.
 
 ## Tuples
 

--- a/languages/elixir/exercises/concept/tuples/.docs/hints.md
+++ b/languages/elixir/exercises/concept/tuples/.docs/hints.md
@@ -7,7 +7,7 @@
 ## 1. Get the numeric component from a volume-pair
 
 - Consider using a `Kernel` module function to return the volume-pair's numeric component.
-- Remember, one-line functions are best used for short elixir functions.
+- Remember, one-line functions are best used for short Elixir functions.
 
 ## 2. Convert the volume-pair to millilitres
 

--- a/languages/elixir/exercises/concept/tuples/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/tuples/.docs/introduction.md
@@ -22,7 +22,7 @@ Float.ratio(0.25)
 
 ## Pattern matching basics with tuples
 
-The use of pattern matching is dominant in assertive, idiomatic Elixir code. You might recall that `=/2` is described as a match operator rather than as an assignment operator. When elixir invokes the `=/2` function, if the pattern on the left matches the right, any variables on the left are bound, and the function returns the value of the right side. A `MatchError` is raised if there is no match.
+The use of pattern matching is dominant in assertive, idiomatic Elixir code. You might recall that `=/2` is described as a match operator rather than as an assignment operator. When Elixir invokes the `=/2` function, if the pattern on the left matches the right, any variables on the left are bound, and the function returns the value of the right side. A `MatchError` is raised if there is no match.
 
 ```elixir
 2 = 2

--- a/languages/elixir/exercises/concept/tuples/.meta/design.md
+++ b/languages/elixir/exercises/concept/tuples/.meta/design.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-The goal of this exercise is to teach the student the basics of tuples and common conventions in elixir to return multiple values.
+The goal of this exercise is to teach the student the basics of tuples and common conventions in Elixir to return multiple values.
 
 This is done through the implementation of a basic kitchen calculator.
 
@@ -25,7 +25,7 @@ This is done through the implementation of a basic kitchen calculator.
 The exercise's prerequisites are:
 
 - `atoms`: needs to be able to define and use atoms for return values
-- `multiple-clause-functions`: need to know that a named function can be overloaded and elixir will attempt to use them all until one found
+- `multiple-clause-functions`: need to know that a named function can be overloaded and Elixir will attempt to use them all until one found
 - `floating-point-numbers`: need to know how to use floating point numbers to convert
 
 ## Concepts unlocked

--- a/languages/elixir/exercises/concept/tuples/test/kitchen_calculator_test.exs
+++ b/languages/elixir/exercises/concept/tuples/test/kitchen_calculator_test.exs
@@ -78,7 +78,7 @@ defmodule KitchenCalculatorTest do
       assert KC.convert({:cup, 4}, :fluid_ounce) == {:fluid_ounce, 32}
     end
 
-    test "fluid ounces to teapoons" do
+    test "fluid ounces to teaspoons" do
       assert KC.convert({:fluid_ounce, 4}, :teaspoon) == {:teaspoon, 24}
     end
 

--- a/languages/elixir/reference/README.md
+++ b/languages/elixir/reference/README.md
@@ -260,13 +260,13 @@ The concept exercises use the following concepts:
 | concept                          | interpretation                                                                                 |
 | -------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `anonymous-functions`            | Intro to anonymous functions, functions as data                                                |
-| `atoms`                          | Intro to elixir atom type.                                                                     |
+| `atoms`                          | Intro to Elixir atom type.                                                                     |
 | `basics`                         | Introduction to functions, modules, variables, returning values, integers, invoking functions. |
 | `bit manipulation`               | Introduction to bit manipulation using the Bitwise module functions                            |
 | `booleans`                       | Introduction to the boolean type and strict boolean operators -- and/2, or/2, not/1            |
 | `default-arguments`              | Introduction to default arguments in named functions, function headers                         |
-| `closures`                       | How to implement closures in elixir                                                            |
-| `conditionals`                   | Intro to elixir `cond/1` function.                                                             |
+| `closures`                       | How to implement closures in Elixir                                                            |
+| `conditionals`                   | Intro to Elixir `cond/1` function.                                                             |
 | `floating-point-numbers`         | How to use floating point numbers to represent real numbers                                    |
 | `guards`                         | What guards are, how to use guards in function heads                                           |
 | `lists`                          | Introduction to the lists type basic list functions -- hd/1, tl/1, length/1, in/2              |

--- a/languages/elixir/reference/exercise-concepts/pangram.md
+++ b/languages/elixir/reference/exercise-concepts/pangram.md
@@ -45,7 +45,7 @@ end
     - dialyxir
 - dynamic typing
 - matching
-- pipline operator
+- pipeline operator
 - standard library modules
   - Kernel
     - to_charlist/1


### PR DESCRIPTION
I am dealing with my lack of inspiration for writing docs for new exercises by procrastinating by doing this, not very important cleanup 🤷‍♀️