### PR TITLE
improve compatibility of bin/format.sh

### DIFF
--- a/bin/format.sh
+++ b/bin/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 DEFAULT_PATTERN='**/*.{md,json}'
 npx prettier@2.0.4 --write "${1:-$DEFAULT_PATTERN}"


### PR DESCRIPTION
On some systems, bash does not exist in `/bin`. I change 2 things for
better compatibility across Unixy environments:
- use `/usr/bin/env` to resolve where the shell is
- use `sh` since we are not doing anything bash specific and `sh` is
decidedly minimal