### PR TITLE
[F#] Use float instead of double

### DIFF
--- a/languages/fsharp/exercises/concept/discriminated-unions/.docs/after.md
+++ b/languages/fsharp/exercises/concept/discriminated-unions/.docs/after.md
@@ -15,7 +15,7 @@ type Season =
 // Discriminated union with associated data
 type Number =
     | Integer of int
-    | Double of double
+    | Float of float
     | Invalid
 ```
 
@@ -34,7 +34,7 @@ The preferred way to work with discriminated unions is through [pattern matching
 let describe number =
     match number with
     | Integer i -> sprintf "Integer: %d" i
-    | Double d  -> sprintf "Double: %d" i
+    | Float d  -> sprintf "Float: %d" i
     | Invalid   -> "Invalid"
 ```
 

--- a/languages/fsharp/exercises/concept/discriminated-unions/.docs/introduction.md
+++ b/languages/fsharp/exercises/concept/discriminated-unions/.docs/introduction.md
@@ -15,7 +15,7 @@ Each case of a discriminated union can optionally have data associated with it, 
 ```fsharp
 type Number =
     | Integer of int
-    | Double of double
+    | Float of float
     | Invalid
 ```
 
@@ -34,6 +34,6 @@ While one can use `if/elif/else` expressions to work with discriminated unions, 
 let describe number =
     match number with
     | Integer i -> sprintf "Integer: %d" i
-    | Double d  -> sprintf "Double: %d" i
+    | Float d  -> sprintf "Float: %d" i
     | Invalid   -> "Invalid"
 ```

--- a/languages/fsharp/exercises/concept/floating-point-numbers/.docs/after.md
+++ b/languages/fsharp/exercises/concept/floating-point-numbers/.docs/after.md
@@ -1,11 +1,17 @@
-There are three floating-point types in F#: `double`, `single` and `decimal`. The most commonly used type is `double`, whereas `decimal` is normally used when working with monetary data. A `double` is written as `2.45`, a single as `2.45f` and a decimal as `2.45m`.
+A floating-point number is a number with zero or more digits behind the decimal separator. Examples are `-2.4`, `0.1`, `3.14`, `16.984025` and `1024.0`.
 
-Each floating-point type has its own [precision, approximate range and size][floating-point-types].
+F# has three floating-point types:
+
+- `single`: 4 bytes (~6-9 digits precision). Written as `2.45f` or `2.45F`. The `float32` type can be used as an alias.
+- `float`: 8 bytes (~15-17 digits precision). This is the most common type. Written as `2.45` or using exponent notation as `2.3E+32` or `2.3e+32`. The `double` type can be used as an alias.
+- `decimal`: 16 bytes (28-29 digits precision). Normally used when working with monetary data, as its precision leads to less rounding errors. Written as `2.45m` or `2.45M`.
+
+Each floating-point type has its own [precision, approximate range and size][floating-point-types]. The precision indicates how many digits after the digit separator can be stored. This means that trying to store PI in a `single` will only store the first 6 to 9 digits (with the last digit being rounded).
 
 Converting between different floating-point types is done using the [conversion operators][conversion-operators]:
 
 ```fsharp
-let doubleFromSingle = double 2.45f
+let floatFromSingle = float 2.45f
 ```
 
 Always be careful when checking the values of floating-point types for equality, as values that can appear to represent the same value could actually be different. See [this article][precision-in-comparisons] for more information (the code examples are in C#).

--- a/languages/fsharp/exercises/concept/floating-point-numbers/.docs/hints.md
+++ b/languages/fsharp/exercises/concept/floating-point-numbers/.docs/hints.md
@@ -1,6 +1,6 @@
 ## 1. Calculate the interest rate
 
-- By default, any floating-point number defined in F# code is treated as a `double`. To use a different floating-point type (like `single` or `decimal`), one must add the appropriate [suffix][literals] to the number.
+- By default, any floating-point number defined in F# code is treated as a `float`. To use a different floating-point type (like `single` or `decimal`), one must add the appropriate [suffix][literals] to the number.
 
 ## 2. Calculate the annual balance update
 

--- a/languages/fsharp/exercises/concept/floating-point-numbers/.docs/introduction.md
+++ b/languages/fsharp/exercises/concept/floating-point-numbers/.docs/introduction.md
@@ -1,11 +1,9 @@
 A floating-point number is a number with zero or more digits behind the decimal separator. Examples are `-2.4`, `0.1`, `3.14`, `16.984025` and `1024.0`.
 
-Different floating-point types can store different numbers of digits after the digit separator - this is referred to as its precision.
-
 F# has three floating-point types:
 
 - `single`: 4 bytes (~6-9 digits precision). Written as `2.45f`.
-- `double`: 8 bytes (~15-17 digits precision). This is the most common type. Written as `2.45`.
+- `float`: 8 bytes (~15-17 digits precision). This is the most common type. Written as `2.45`.
 - `decimal`: 16 bytes (28-29 digits precision). Normally used when working with monetary data, as its precision leads to less rounding errors. Written as `2.45m`.
 
-As can be seen, each type can store a different number of digits. This means that trying to store PI in a `single` will only store the first 6 to 9 digits (with the last digit being rounded).
+Different floating-point types can store different numbers of digits after the digit separator - this is referred to as its precision. This means that trying to store PI in a `single` will only store the first 6 to 9 digits (with the last digit being rounded).

--- a/languages/fsharp/exercises/concept/floating-point-numbers/.meta/Example.fs
+++ b/languages/fsharp/exercises/concept/floating-point-numbers/.meta/Example.fs
@@ -12,7 +12,10 @@ let private annualYield (balance: decimal): decimal =
 
 let annualBalanceUpdate (balance: decimal): decimal = balance + annualYield balance
 
-let amountToDonate (balance: decimal) (taxFreePercentage: double): int =
-    if balance > 0.0m
-    then int (balance * decimal (taxFreePercentage / 100.0 * 2.0))
-    else 0
+let amountToDonate (balance: decimal) (taxFreePercentage: float): int =
+    if balance > 0.0m then
+        int
+            (balance
+             * decimal (taxFreePercentage / 100.0 * 2.0))
+    else
+        0

--- a/languages/fsharp/exercises/concept/floating-point-numbers/FloatingPointNumbers.fs
+++ b/languages/fsharp/exercises/concept/floating-point-numbers/FloatingPointNumbers.fs
@@ -1,8 +1,10 @@
 module FloatingPointNumbers
 
-let interestRate (balance: decimal): single = failwith "Please implement the 'interestRate' function"
+let interestRate (balance: decimal): single =
+    failwith "Please implement the 'interestRate' function"
 
-let annualBalanceUpdate (balance: decimal): decimal = failwith "Please implement the 'annualBalanceUpdate' function"
+let annualBalanceUpdate (balance: decimal): decimal =
+    failwith "Please implement the 'annualBalanceUpdate' function"
 
-let amountToDonate (balance: decimal) (taxFreePercentage: double): int =
+let amountToDonate (balance: decimal) (taxFreePercentage: float): int =
     failwith "Please implement the 'amountToDonate' function"

--- a/languages/fsharp/exercises/concept/numbers/.docs/after.md
+++ b/languages/fsharp/exercises/concept/numbers/.docs/after.md
@@ -1,10 +1,10 @@
 One of the key aspects of working with numbers in F# is the distinction between integers (numbers with no digits after the decimal separator) and floating-point numbers (numbers with zero or more digits after the decimal separator).
 
-The two most commonly used numeric types in F# are `int` (a 32-bit integer) and `double` (a 64-bit floating-point number).
+The two most commonly used numeric types in F# are `int` (a 32-bit integer) and `float` (a 64-bit floating-point number).
 
 ```fsharp
 let i = 123   // Type is `int`
-let d = 54.29 // Type is `double`
+let d = 54.29 // Type is `float`
 ```
 
 Both integers and floating-point numbers can use the `_` character as a _digit separator_, which can help when defining large numbers:
@@ -13,7 +13,7 @@ Both integers and floating-point numbers can use the `_` character as a _digit s
 let largeInt = 1_000_000
 // => 1000000
 
-let largeDouble = 9_876_543.21
+let largeFloat = 9_876_543.21
 // => 9876543.21
 ```
 

--- a/languages/fsharp/exercises/concept/numbers/.docs/hints.md
+++ b/languages/fsharp/exercises/concept/numbers/.docs/hints.md
@@ -1,12 +1,12 @@
 ## 1. Calculate the production rate per second
 
 - Determining the success rate can be done through a [conditional expression][conditional-expression].
-- F# does not allow for multiplication to be applied to two different number types (such as an `int` and a `double`). One thus has to convert one of the number types to the other number type using one of the built-in [conversion operators][conversion-operators].
+- F# does not allow for multiplication to be applied to two different number types (such as an `int` and a `float`). One thus has to convert one of the number types to the other number type using one of the built-in [conversion operators][conversion-operators].
 - Numbers can be compared using the built-in [comparison operators][comparison-operators].
 
 ## 2. Calculate the number of working items produced per second
 
-- Converting from a `double` to an `int` can be done through one of the built-in [conversion operators][conversion-operators].
+- Converting from a `float` to an `int` can be done through one of the built-in [conversion operators][conversion-operators].
 
 [conditional-expression]: https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/conditional-expressions-if-then-else
 [conversion-operators]: https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/casting-and-conversions#arithmetic-types

--- a/languages/fsharp/exercises/concept/numbers/.docs/instructions.md
+++ b/languages/fsharp/exercises/concept/numbers/.docs/instructions.md
@@ -19,7 +19,7 @@ productionRatePerHour 6
 // => 1193.4
 ```
 
-Note that the value returned is a `double`.
+Note that the value returned is a `float`.
 
 ## 2. Calculate the number of working items produced per minute
 

--- a/languages/fsharp/exercises/concept/numbers/.docs/introduction.md
+++ b/languages/fsharp/exercises/concept/numbers/.docs/introduction.md
@@ -3,7 +3,7 @@ There are two different types of numbers in F#:
 - Integers: numbers with no digits behind the decimal separator (whole numbers). Examples are `-6`, `0`, `1`, `25`, `976` and `500000`.
 - Floating-point numbers: numbers with zero or more digits behind the decimal separator. Examples are `-2.4`, `0.1`, `3.14`, `16.984025` and `1024.0`.
 
-The two most common numeric types in F# are `int` and `double`. An `int` is a 32-bit integer and a `double` is a 64-bit floating-point number.
+The two most common numeric types in F# are `int` and `float`. An `int` is a 32-bit integer and a `float` is a 64-bit floating-point number.
 
 Arithmetic is done using the standard arithmetic operators. Numbers can be compared using the standard numeric comparison operators and the equality (`=`) and inequality (`<>`) operators.
 

--- a/languages/fsharp/exercises/concept/numbers/.meta/Example.fs
+++ b/languages/fsharp/exercises/concept/numbers/.meta/Example.fs
@@ -2,14 +2,17 @@ module Numbers
 
 let private ProductionRatePerHourForDefaultSpeed = 221
 
-let private successRate (speed: int): double =
+let private successRate (speed: int): float =
     if speed = 10 then 0.77
     elif speed = 9 then 0.8
     elif speed >= 5 then 0.9
     else 1.0
 
-let private productionRatePerHourForSpeed (speed: int) = ProductionRatePerHourForDefaultSpeed * speed
+let private productionRatePerHourForSpeed (speed: int) =
+    ProductionRatePerHourForDefaultSpeed * speed
 
-let productionRatePerHour (speed: int): double = float (productionRatePerHourForSpeed speed) * successRate speed
+let productionRatePerHour (speed: int): float =
+    float (productionRatePerHourForSpeed speed)
+    * successRate speed
 
 let workingItemsPerMinute (speed: int): int = int (productionRatePerHour speed / 60.0)

--- a/languages/fsharp/exercises/concept/numbers/.meta/design.md
+++ b/languages/fsharp/exercises/concept/numbers/.meta/design.md
@@ -1,25 +1,25 @@
 ## Goal
 
-The goal of this exercise is to teach the student how the Concept of Numbers is implemented in F#. It will introduce this concept through the two most common numeric types in F#: `int` (whole number) and `double` (floating-point number).
+The goal of this exercise is to teach the student how the Concept of Numbers is implemented in F#. It will introduce this concept through the two most common numeric types in F#: `int` (whole number) and `float` (floating-point number).
 
 ## Learning objectives
 
-- Know of the existence of the two most commonly used number types, `int` and `double`.
-- Understand that an `int` represents whole numbers, and a `double` represents floating-point numbers.
+- Know of the existence of the two most commonly used number types, `int` and `float`.
+- Understand that an `int` represents whole numbers, and a `float` represents floating-point numbers.
 - Know of basic operators such as multiplication and comparison.
 - Know how to convert from one numeric type to another; know that one always has to be explicit.
 - Know how to conditionally execute code using an `if/elif/else` statement.
 
 ## Out of scope
 
-- Any other numeric types besides `int` and `double` (so no `float`, `byte`, etc.).
-- Parsing a `string` to an `int` or `double`.
-- Converting an `int` or `double` to a `string`.
+- Any other numeric types besides `int` and `float` (so no `single`, `byte`, etc.).
+- Parsing a `string` to an `int` or `float`.
+- Converting an `int` or `float` to a `string`.
 - Overflows.
 
 ## Concepts
 
-- `numbers`: know of the existence of the two most commonly used number types, `int` and `double`; understand that the former represents whole numbers, and the latter floating-point numbers; Know of basic operators such as multiplication, comparison and equality; know how to convert from one numeric type to another using conversion operators.
+- `numbers`: know of the existence of the two most commonly used number types, `int` and `float`; understand that the former represents whole numbers, and the latter floating-point numbers; Know of basic operators such as multiplication, comparison and equality; know how to convert from one numeric type to another using conversion operators.
 - `conditionals`: know how to conditionally execute code using an `if` expressions.
 
 ## Prequisites

--- a/languages/fsharp/exercises/concept/numbers/Numbers.fs
+++ b/languages/fsharp/exercises/concept/numbers/Numbers.fs
@@ -1,5 +1,7 @@
 module Numbers
 
-let productionRatePerHour (speed: int): double = failwith "Please implement the 'productionRatePerHour' function"
+let productionRatePerHour (speed: int): float =
+    failwith "Please implement the 'productionRatePerHour' function"
 
-let workingItemsPerMinute (speed: int): int = failwith "Please implement the 'workingItemsPerMinute' function"
+let workingItemsPerMinute (speed: int): int =
+    failwith "Please implement the 'workingItemsPerMinute' function"


### PR DESCRIPTION
I found that we used `double` in a lot of places. This is a remnant of it being a C# port, as in F#, the `float` type is preferred (`double` _is_ an alias for that type though). This PR fixes that.