### PR TITLE
[Docs] Remove top-level header from design.md files

### DIFF
--- a/languages/clojure/exercises/concept/lists/.meta/design.md
+++ b/languages/clojure/exercises/concept/lists/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to introduce the student to [Lists in Clojure](https://clojure.org/reference/data_structures#Lists).

--- a/languages/cpp/exercises/concept/strings/.meta/design.md
+++ b/languages/cpp/exercises/concept/strings/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Strings in [C++][docs.string].

--- a/languages/csharp/exercises/concept/arrays/.meta/design.md
+++ b/languages/csharp/exercises/concept/arrays/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Arrays in C#.

--- a/languages/csharp/exercises/concept/basics/.meta/design.md
+++ b/languages/csharp/exercises/concept/basics/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of programming in C#.

--- a/languages/csharp/exercises/concept/booleans/.meta/design.md
+++ b/languages/csharp/exercises/concept/booleans/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Booleans in C#.

--- a/languages/csharp/exercises/concept/classes/.meta/design.md
+++ b/languages/csharp/exercises/concept/classes/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the Concept of Classes in C#.

--- a/languages/csharp/exercises/concept/constructors/.meta/design.md
+++ b/languages/csharp/exercises/concept/constructors/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the Concept of Constructors in C#.

--- a/languages/csharp/exercises/concept/datetimes/.meta/design.md
+++ b/languages/csharp/exercises/concept/datetimes/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Dates through [C#][docs.microsoft.com-datetime].

--- a/languages/csharp/exercises/concept/enums/.meta/design.md
+++ b/languages/csharp/exercises/concept/enums/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of enums through [C#][docs.microsoft.com-enum].

--- a/languages/csharp/exercises/concept/flag-enums/.meta/design.md
+++ b/languages/csharp/exercises/concept/flag-enums/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student advanced aspects of the Concept of Enums in [C#][docs.microsoft.com-bitwise-and-shift-operators]. We'll do this in the form of working with [flag][docs.microsoft.com-flagsattribute] enums, which are enums whose values are interpreted as bitwise flags that can be manipulated through bitwise operations.

--- a/languages/csharp/exercises/concept/floating-point-numbers/.meta/design.md
+++ b/languages/csharp/exercises/concept/floating-point-numbers/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student how the Concept of floating-point numbers is implemented in [C#][docs.microsoft.com-floating-point-numeric-types]. It will show the available floating-point types and discuss their differences.

--- a/languages/csharp/exercises/concept/inheritance/.meta/design.md
+++ b/languages/csharp/exercises/concept/inheritance/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the Concept of Inheritance in C#.

--- a/languages/csharp/exercises/concept/method-overloading/.meta/design.md
+++ b/languages/csharp/exercises/concept/method-overloading/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the Concept of Method Overloading in C#.

--- a/languages/csharp/exercises/concept/nullability/.meta/design.md
+++ b/languages/csharp/exercises/concept/nullability/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to introduce the student to the concept of [Nullability in C#][null-keyword].

--- a/languages/csharp/exercises/concept/numbers/.meta/design.md
+++ b/languages/csharp/exercises/concept/numbers/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student how the Concept of Numbers is implemented in [C#][docs.microsoft.com-numbers]. It will introduce this concept through the two most common numeric types in C#: `int` (whole number) and `double` (floating-point number).

--- a/languages/csharp/exercises/concept/properties/.meta/design.md
+++ b/languages/csharp/exercises/concept/properties/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to introduce the student to C# properties and to teach the student how the concept of properties is implemented in [C#][docs.microsoft.com-properties]. We'll teach the student about properties by having the student work with classes that expose contrasting forms of properties. The students will learn to work with properties with backing fields and auto-implemented properties.

--- a/languages/csharp/exercises/concept/strings/.meta/design.md
+++ b/languages/csharp/exercises/concept/strings/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Strings in [C#][docs.microsoft.com-string].

--- a/languages/elixir/exercises/concept/anonymous-functions/.meta/design.md
+++ b/languages/elixir/exercises/concept/anonymous-functions/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach students how to use anonymous functions, return functions from functions, use closures in code.

--- a/languages/elixir/exercises/concept/basics/.meta/design.md
+++ b/languages/elixir/exercises/concept/basics/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of programming in Elixir.

--- a/languages/elixir/exercises/concept/booleans/.meta/design.md
+++ b/languages/elixir/exercises/concept/booleans/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of booleans and boolean logical expressions in Elixir through the expression of game rule logic(1).

--- a/languages/elixir/exercises/concept/conditionals/.meta/design.md
+++ b/languages/elixir/exercises/concept/conditionals/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach students how to use conditional control flow structures

--- a/languages/elixir/exercises/concept/lists/.meta/design.md
+++ b/languages/elixir/exercises/concept/lists/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to introduce the student to the list type in Elixir.

--- a/languages/elixir/exercises/concept/maps/.meta/design.md
+++ b/languages/elixir/exercises/concept/maps/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of maps in Elixir.

--- a/languages/elixir/exercises/concept/numbers/.meta/design.md
+++ b/languages/elixir/exercises/concept/numbers/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach how to use floating point numbers in Elixir.

--- a/languages/elixir/exercises/concept/recursion/.meta/design.md
+++ b/languages/elixir/exercises/concept/recursion/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise to learn how to do simple recursion in Elixir.

--- a/languages/elixir/exercises/concept/strings/.meta/design.md
+++ b/languages/elixir/exercises/concept/strings/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student how strings are implemented and used in Elixir.

--- a/languages/elixir/exercises/concept/tuples/.meta/design.md
+++ b/languages/elixir/exercises/concept/tuples/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of tuples and common conventions in Elixir to return multiple values.

--- a/languages/fsharp/exercises/concept/arrays/.meta/design.md
+++ b/languages/fsharp/exercises/concept/arrays/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Arrays in F#.

--- a/languages/fsharp/exercises/concept/basics/.meta/design.md
+++ b/languages/fsharp/exercises/concept/basics/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of programming in [F#][values].

--- a/languages/fsharp/exercises/concept/booleans/.meta/design.md
+++ b/languages/fsharp/exercises/concept/booleans/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Booleans in F#.

--- a/languages/fsharp/exercises/concept/datetimes/.meta/design.md
+++ b/languages/fsharp/exercises/concept/datetimes/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Dates through [F#][docs.microsoft.com-datetime].

--- a/languages/fsharp/exercises/concept/discriminated-unions/.meta/design.md
+++ b/languages/fsharp/exercises/concept/discriminated-unions/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Discriminated Unions in [F#][discriminated-unions].

--- a/languages/fsharp/exercises/concept/floating-point-numbers/.meta/design.md
+++ b/languages/fsharp/exercises/concept/floating-point-numbers/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student how the Concept of Floating-point numbers is implemented in [F#][floating-point-numbers]. It will show the available floating-point types and discuss their differences.

--- a/languages/fsharp/exercises/concept/lists/.meta/design.md
+++ b/languages/fsharp/exercises/concept/lists/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Lists in [F#][lists].

--- a/languages/fsharp/exercises/concept/numbers/.meta/design.md
+++ b/languages/fsharp/exercises/concept/numbers/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student how the Concept of Numbers is implemented in F#. It will introduce this concept through the two most common numeric types in F#: `int` (whole number) and `double` (floating-point number).

--- a/languages/fsharp/exercises/concept/pattern-matching/.meta/design.md
+++ b/languages/fsharp/exercises/concept/pattern-matching/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Pattern Matching in [F#][pattern-matching].

--- a/languages/fsharp/exercises/concept/records/.meta/design.md
+++ b/languages/fsharp/exercises/concept/records/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Records in F#.

--- a/languages/fsharp/exercises/concept/recursion/.meta/design.md
+++ b/languages/fsharp/exercises/concept/recursion/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Recursion in [F#][recursion]. It will do this both by teaching about recursive functions as well as recursive types.

--- a/languages/fsharp/exercises/concept/strings/.meta/design.md
+++ b/languages/fsharp/exercises/concept/strings/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Strings in [F#][string].

--- a/languages/go/exercises/concept/basics/.meta/design.md
+++ b/languages/go/exercises/concept/basics/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of programming in Go.

--- a/languages/go/exercises/concept/conditionals/.meta/design.md
+++ b/languages/go/exercises/concept/conditionals/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Conditionals in Go.

--- a/languages/go/exercises/concept/maps/.meta/design.md
+++ b/languages/go/exercises/concept/maps/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal is to introduce the student to maps.

--- a/languages/go/exercises/concept/numbers/.meta/design.md
+++ b/languages/go/exercises/concept/numbers/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student how to deal with numbers in Go.

--- a/languages/go/exercises/concept/strings/.meta/design.md
+++ b/languages/go/exercises/concept/strings/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Strings in Go.

--- a/languages/julia/exercises/concept/functions-introduction/.meta/design.md
+++ b/languages/julia/exercises/concept/functions-introduction/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the fundamentals of the Concept of functions in Julia, so that they are able to understand the basic structure of Exercism exercises.

--- a/languages/python/exercises/concept/strings/.meta/design.md
+++ b/languages/python/exercises/concept/strings/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student about Python strings, and familiarize them with string manipulation in Python.

--- a/languages/ruby/exercises/concept/basics/.meta/design.md
+++ b/languages/ruby/exercises/concept/basics/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of programming in Ruby.

--- a/languages/ruby/exercises/concept/floating-point-numbers/.meta/design.md
+++ b/languages/ruby/exercises/concept/floating-point-numbers/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the concept of floating-point numbers and introduce them to loops.

--- a/languages/ruby/exercises/concept/numbers/.meta/design.md
+++ b/languages/ruby/exercises/concept/numbers/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student how the concept of numbers is implemented in Ruby. It will introduce this concept through the two most common numeric types in Ruby: [`Integer`][integer-ruby] (whole number) and [`Float`][float-ruby] (floating-point number).

--- a/languages/ruby/exercises/concept/strings/.meta/design.md
+++ b/languages/ruby/exercises/concept/strings/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Strings in [Ruby][ruby-doc.org-string].

--- a/languages/rust/exercises/concept/entry-api/.meta/design.md
+++ b/languages/rust/exercises/concept/entry-api/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to introduce the student to the [Entry API](https://doc.rust-lang.org/std/collections/hash_map/enum.Entry.html) on `HashMap`s/`BTreeMap`s in Rust, how to use it to fetch an `Entry` from a `HashMap`, as well as use the methods on `Entry` to manipulate it.

--- a/languages/rust/exercises/concept/enums/.meta/design.md
+++ b/languages/rust/exercises/concept/enums/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to explore the concept of [enums][thebook] in Rust.

--- a/languages/rust/exercises/concept/numbers/.meta/design.md
+++ b/languages/rust/exercises/concept/numbers/.meta/design.md
@@ -1,5 +1,3 @@
-# Design
-
 ## Goal
 
 The goal of this exercise is to teach how numbers are implemented in Rust. Because Rust doesn't have implicit casting, this automatically includes teaching about primitive bit sizes and type casting.


### PR DESCRIPTION
As per [the style guide](https://github.com/exercism/v3/blob/master/docs/maintainers/style-guide.md#headers):

> Use level 2 headers

Apparently, I forgot to also apply this to the `design.md` document. This PR fixes that.