### PR TITLE
[Nim] Add initial `config.json`

### DIFF
--- a/languages/nim/README.md
+++ b/languages/nim/README.md
@@ -27,10 +27,10 @@ Before launch, we need all of the following parts to be completed:
 
 - [ ] Implemented 20+ Concept Exercises
 - [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
+  - [x] Added `version` key
+  - [x] Added online editor settings
+    - [x] Added `indent_style`
+    - [x] Added `indent_size`
   - [ ] Added Concept Exercises
   - [ ] Added Concepts for all Practice Exercises
 

--- a/languages/nim/config.json
+++ b/languages/nim/config.json
@@ -1,0 +1,14 @@
+{
+  "language": "Nim",
+  "active": true,
+  "blurb": "Nim is a system and applications programming language that is statically typed and compiled, designed to be efficient, expressive, and elegant. Being general-purpose it can fill a wide range of uses but has found a niche in game development and systems programming including embedded systems.",
+  "version": 3,
+  "online_editor": {
+    "indent_style": "space",
+    "indent_size": 2
+  },
+  "exercises": {
+    "concept": [],
+    "practice": []
+  }
+}


### PR DESCRIPTION
Migrated from the old [`config.json`](https://github.com/exercism/nim/blob/master/config.json).

Note that we should probably improve the `blurb` sometime. The `blurb` here is just the old one.