### PR TITLE
[CI] /format fallback to HTTPS on forks

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -10,7 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/format')
     steps:
+      - name: 'Check fork status'
+        id: fork_check
+        run: |
+          IS_FORK="$(jq '.pull_request.head.repo.fork' "$GITHUB_EVENT_PATH")"
+          echo "::set-output name=fork::$IS_FORK"
+          
       - name: 'Setup SSH deploy key'
+        if: steps.fork_check.outputs.fork == "false"
         run: |
           mkdir ~/.ssh
           echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_ed25519
@@ -24,7 +31,13 @@ jobs:
             xargs curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -o "$PR_DATA" --url
 
           HEAD_REF=$(jq -r ".head.ref" "$PR_DATA")
-          HEAD_REPO=$(jq -r '.head.repo.ssh_url' "$PR_DATA")
+          
+          if [ ${{ steps.fork_check.outputs.fork }} == "false" ]; then
+            # Setup repo using ssh
+            HEAD_REPO=$(jq -r '.head.repo.ssh_url' "$PR_DATA")
+          else
+            HEAD_REPO=$(jq -r '.head.repo.clone_url | sub("https://"; "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@")' "$PR_DATA")
+          fi
 
           git clone $HEAD_REPO .
           git checkout -b "$HEAD_REF" "origin/$HEAD_REF"

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -36,6 +36,7 @@ jobs:
             # Setup repo using ssh
             HEAD_REPO=$(jq -r '.head.repo.ssh_url' "$PR_DATA")
           else
+            # Setup repo using HTTPS
             HEAD_REPO=$(jq -r '.head.repo.clone_url | sub("https://"; "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@")' "$PR_DATA")
           fi
 


### PR DESCRIPTION
The deploy key doesn't have access to push to forks, even if the "allow edits by maintainers" checkbox is enabled. This commit implements a fallback so that /format will still run on PRs from forks, but not trigger CI. If it's not a fork, the deploy key can push to the branch, and CI will be triggered automatically.

* If the PR branch is on a fork, use HTTPS. This will *not* trigger CI to run on the commit automatically.
* If the PR branch is on the exercism/v3 repo, use SSH.

---

It's hard to test if something works on a fork with just one user account (and GH doesn't permit more than that for human accounts), so this is untested. Ping me on Slack if you want to give it a try on a different testing repo.