### PR TITLE
[Rust] start tuples concept exercise

### DIFF
--- a/languages/rust/exercises/concept/tuples/.docs/instructions.md
+++ b/languages/rust/exercises/concept/tuples/.docs/instructions.md
@@ -23,7 +23,7 @@ get_volume((Unit::USCup, 1))
 
 ## 2. Convert the tuple to millilitres
 
-- Given a volume-pair tuple, `(Unit::USCup, 2.5)`, convert the volume to millilitres using the conversion chart
+Implement the `to_millilitres` function that takes a unit/volume pair tuple as its parameter, and returns a new tuple with its volume converted to millilitres using the conversion chart.
 
 ```rust
 to_millilitres((Unit::USCup, 2.5))

--- a/languages/rust/exercises/concept/tuples/.docs/instructions.md
+++ b/languages/rust/exercises/concept/tuples/.docs/instructions.md
@@ -12,7 +12,7 @@ Use the following chart in your program:
 | US teaspoon     | 1      | 5                   |
 | US tablespoon   | 1      | 15                  |
 
-## 1. Extract the numeric component from a tuple describing volume
+## 1. Extract the volume from a unit/volume pair
 
 Implement the `get_volume` function that takes a unit/volume pair tuple as its parameter, and returns the volume part.
 

--- a/languages/rust/exercises/concept/tuples/.docs/instructions.md
+++ b/languages/rust/exercises/concept/tuples/.docs/instructions.md
@@ -14,7 +14,7 @@ Use the following chart in your program:
 
 ## 1. Extract the numeric component from a tuple describing volume
 
-- Given the following tuple `(Unit::USCup, 1)`, return the 2nd element.
+Implement the `get_volume` function that takes a unit/volume pair tuple as its parameter, and returns the volume part.
 
 ```rust
 get_volume((Unit::USCup, 1))

--- a/languages/rust/exercises/concept/tuples/.docs/instructions.md
+++ b/languages/rust/exercises/concept/tuples/.docs/instructions.md
@@ -1,0 +1,56 @@
+# Instructions
+
+In this exercise you'll explore tuples in Rust by building a kitchen calculator. Imagine you are following a sensible gingersnap cookie recipe but it uses American units for measuring ingredients. You are most familiar with metric units. Being an intrepid programmer, you want to automate that work by writing a kitchen calculator.
+
+Use the following chart in your program:
+
+| Unit to convert | volume | in millilitres (mL) |
+| --------------- | ------ | ------------------- |
+| mL              | 1      | 1                   |
+| US cup          | 1      | 240                 |
+| US fluid ounce  | 1      | 30                  |
+| US teaspoon     | 1      | 5                   |
+| US tablespoon   | 1      | 15                  |
+
+## 1. Extract the numeric component from a tuple describing volume
+
+- Given the following tuple `(Unit::USCup, 1)`, return the 2nd element.
+
+```rust
+get_volume((Unit::USCup, 1))
+// 1
+```
+
+## 2. Convert the tuple to millilitres
+
+- Given a volume-pair tuple, `(Unit::USCup, 2.5)`, convert the volume to millilitres using the conversion chart
+
+```rust
+to_millilitres((Unit::USCup, 2.5))
+// (Unit::Millilitre, 600.0)
+```
+
+- Do the same for each `Unit` variant.
+
+```rust
+to_millilitres((Unit::Teaspoon, 1))
+// (Unit::Millilitre, 5)
+```
+
+## 3. Convert the volume tuple in millilitres to another unit
+
+- Given a tuple, `(Unit::Millilitre, 600.0)`, and the desired unit, `Unit::UsCup`, convert the volume to the desired unit using the conversion chart.
+
+```rust
+to_cup((Unit::Millilitre, 600.0))
+// (Unit::UsCup, 2.5)
+```
+
+## 4. Convert between any units
+
+- Given a volume tuple, `(Unit::UsCup, 2.5)` and destination unit, preform the conversion
+
+```rust
+convert((Unit::UsCup, 1), Unit::UsTablespoon)
+// (Unit::UsTablespoon, 13.51488)
+```

--- a/languages/rust/exercises/concept/tuples/.meta/design.md
+++ b/languages/rust/exercises/concept/tuples/.meta/design.md
@@ -24,3 +24,4 @@ The Concepts this exercise unlocks are:
 This exercise's prerequisites Concepts are:
 
 - structs
+- numbers

--- a/languages/rust/exercises/concept/tuples/.meta/design.md
+++ b/languages/rust/exercises/concept/tuples/.meta/design.md
@@ -3,8 +3,8 @@
 After completing the exercise, the user should:
 
 - know how to create tuples
-- understand tuple access syntax `a_tuple.0`
-- know how to destructure tuples into new variables, e.g. `let (x, y) = a_point;`
+- understand tuple access syntax `a_volume_pair.0`
+- know how to destructure tuples into new variables, e.g. `let (unit, measurement) = a_volume_pair;`
 
 ## Out of scope
 
@@ -24,11 +24,3 @@ The Concepts this exercise unlocks are:
 This exercise's prerequisites Concepts are:
 
 - structs
-
-## Representer
-
-No changes required
-
-## Analyzer
-
-No changes required

--- a/languages/rust/exercises/concept/tuples/.meta/design.md
+++ b/languages/rust/exercises/concept/tuples/.meta/design.md
@@ -3,8 +3,8 @@
 After completing the exercise, the user should:
 
 - know how to create tuples
-- understand tuple access syntax `a_volume_pair.0`
-- know how to destructure tuples into new variables, e.g. `let (unit, measurement) = a_volume_pair;`
+- understand tuple access syntax `a_tuple.0`
+- know how to destructure tuples into new variables, e.g. `let (x, y) = a_point;`
 
 ## Out of scope
 

--- a/languages/rust/exercises/concept/tuples/.meta/design.md
+++ b/languages/rust/exercises/concept/tuples/.meta/design.md
@@ -1,0 +1,34 @@
+## Learning Objectives
+
+After completing the exercise, the user should:
+
+- know how to create tuples
+- understand tuple access syntax `a_tuple.0`
+- know how to destructure tuples into new variables, e.g. `let (x, y) = a_point;`
+
+## Out of scope
+
+- tuple structs
+- unit structs
+- enums with tuple structs
+
+## Concepts
+
+The Concepts this exercise unlocks are:
+
+- tuples
+- destructuring
+
+## Prequisites
+
+This exercise's prerequisites Concepts are:
+
+- structs
+
+## Representer
+
+No changes required
+
+## Analyzer
+
+No changes required

--- a/languages/rust/exercises/concept/tuples/.meta/example.rs
+++ b/languages/rust/exercises/concept/tuples/.meta/example.rs
@@ -1,21 +1,66 @@
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Unit {
-    Millilitres,
+    Millilitre,
     UsCup,
     UsFluidOnce,
     UsTeaspoon,
     UsTablespoon,
-}   
+}
 
 pub fn get_volume(volume: &(Unit, f32)) -> f32 {
     volume.1
 }
 
 pub fn to_cup(volume: &(Unit, f32)) -> (Unit, f32) {
-    unimplemented!("Solve me!")
+    match volume {
+        (Unit::Millilitre, volume)  => {
+            let converted = volume * (1.0/240.0);
+            (Unit::UsCup, format!("{:.2}", converted).parse::<f32>().unwrap())
+        }
+        (_, _) => unimplemented!("Not supported yet")
+    }
 }
 pub fn to_millilitres(volume: &(Unit, f32)) -> (Unit, f32) {
-    unimplemented!("Solve me!")
+    match volume {
+        (Unit::UsCup, volume)  => {
+            let converted = volume * 240.0;
+            (Unit::Millilitre, format!("{:.2}", converted).parse::<f32>().unwrap())
+        }
+        (_, _) => unimplemented!("Not supported yet")
+    }
 }
 pub fn convert(volume: &(Unit, f32), destination: Unit) -> (Unit, f32) {
-    unimplemented!("Solve me!")
+    match (&volume.0, destination) {
+        (Unit::UsCup, Unit::UsTablespoon) => {
+            (destination, &volume.1 * 13.51)
+        }
+        (Unit::Millilitre, Unit::UsTablespoon) => {
+            (destination, &volume.1 / 15.0)
+        }
+        (_, _) => unimplemented!("Not supported yet")
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn get_volume_works() {
+        assert_eq!(get_volume(&(Unit::UsCup, 2.0)) , 2.0);
+    }
+    #[test]
+    fn to_cup_works() {
+        assert_eq!(to_cup(&(Unit::Millilitre, 240.0)), (Unit::UsCup, 1.0));
+    }
+    #[test]
+    fn to_cup_fractional() {
+        assert_eq!(to_cup(&(Unit::Millilitre, 840.0)), (Unit::UsCup, 3.5));
+    }
+    #[test]
+    fn to_millilitres_works() {
+        assert_eq!(to_millilitres(&(Unit::UsCup, 1.0)), (Unit::Millilitre, 240.0));
+    }
+    #[test]
+    fn convert_cup_to_millilitres() {
+        assert_eq!(convert(&(Unit::Millilitre, 15.0), Unit::UsTablespoon), (Unit::UsTablespoon, 1.0));
+    }
 }

--- a/languages/rust/exercises/concept/tuples/.meta/example.rs
+++ b/languages/rust/exercises/concept/tuples/.meta/example.rs
@@ -1,0 +1,21 @@
+pub enum Unit {
+    Millilitres,
+    UsCup,
+    UsFluidOnce,
+    UsTeaspoon,
+    UsTablespoon,
+}   
+
+pub fn get_volume(volume: &(Unit, f32)) -> f32 {
+    volume.1
+}
+
+pub fn to_cup(volume: &(Unit, f32)) -> (Unit, f32) {
+    unimplemented!("Solve me!")
+}
+pub fn to_millilitres(volume: &(Unit, f32)) -> (Unit, f32) {
+    unimplemented!("Solve me!")
+}
+pub fn convert(volume: &(Unit, f32), destination: Unit) -> (Unit, f32) {
+    unimplemented!("Solve me!")
+}


### PR DESCRIPTION
Begin work for #1302. 

I shamelessly copied @neenjaw and the elixirs team work in #1447. (thank you!)

I used standalone functions and an enum for simplicity. For a real-world or idiomatic approach, I feel like [From](https://doc.rust-lang.org/std/convert/trait.From.html) and Into would be nicer. But that perhaps adds one too many prerequisites.

## high level todos
- add rounding to the 2nd or 3rd decimal place.
- update numbers to be a requirement