### PR TITLE
[C#] Add exercise User-defined Exceptions

### DIFF
--- a/languages/csharp/config.json
+++ b/languages/csharp/config.json
@@ -138,7 +138,7 @@
       {
         "slug": "user-defined-exceptions",
         "uuid": "1be577b0-95db-4c09-aff4-ddc68fb7520d",
-        "concepts": ["user-defined-exceptions, exception-filtering"],
+        "concepts": ["user-defined-exceptions", "exception-filtering"],
         "prerequisites": [
           "exceptions",
           "inheritance",

--- a/languages/csharp/config.json
+++ b/languages/csharp/config.json
@@ -134,6 +134,19 @@
         "uuid": "eda235a5-37de-4fb6-a5c5-cf7aa2309987",
         "concepts": ["strings"],
         "prerequisites": ["basics"]
+      },
+      {
+        "slug": "user-defined-exceptions",
+        "uuid": "1be577b0-95db-4c09-aff4-ddc68fb7520d",
+        "concepts": ["user-defined-exceptions, exception-filtering"],
+        "prerequisites": [
+          "exceptions",
+          "inheritance",
+          "strings",
+          "conditionals",
+          "arithmetic-overflow",
+          "signed-integers"
+        ]
       }
     ],
     "practice": []

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
@@ -1,5 +1,23 @@
-- [Create user-defined exceptions][create-user-defined-exceptions]: how to create user-defined exceptions
+A user-defined exception is any class defined in your code that is derived from `System.Exception`. It is subject to all the rules of class inheritance but in addition the compiler and language runtime treat such classes in a special way allowing their instances to be thrown and caught outside the normal control flow as discussed in the `exceptions` exercise. User-defined exceptions can be used in every way like runtime and Microsoft Base Class Library exceptions.
+
+This special treatment applies only to `Exception`-derived classes. You cannot throw instances of any other type.
+
+User-defined exceptions are often used to carry extra information such as a message and other relevant data to be made available to the catching routines. This can then be recorded in logs, reported to a user or perhaps used in a retry operation. `System.Exception` has convenient data members and appropriate constructors to hold a message and the "inner" exception.
+
+Whilst using user-defined exceptionss to wrap and enhance third party exceptions is a frequently seen pattern, the general advice is not to use them outside of this use case too liberally in your own code. It is considered an anti-pattern. There are challenges to this view and you can see both sides of the argument in this [Stack Exchange post][se-exceptions].
+
+This [article][create-user-defined-exceptons] is a good introduction to user-defined exceptions.
+
+## Exception Filters
+
+The following articles are of general interest:
+
 - [Exception filters][exception-filters]: how to filter user-defined-exceptions.
+
+talk about not making exceptions part of the regular control flow.
+should be reserved for circumstances that can't be oredicted in advance
+such as IO errors,
 
 [create-user-defined-exceptions]: https://docs.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-user-defined-exceptions
 [exception-filters]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/when
+[se-udfs]: https://softwareengineering.stackexchange.com/questions/189222/are-exceptions-as-control-flow-considered-a-serious-antipattern-if-so-why

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
@@ -1,2 +1,5 @@
 - [Create user-defined exceptions][create-user-defined-exceptions]: how to create user-defined exceptions
 - [Exception filters][exception-filters]: how to filter user-defined-exceptions.
+
+[create-user-defined-exceptions]: https://docs.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-user-defined-exceptions
+[exception-filters]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/when

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
@@ -12,8 +12,22 @@ This [article][create-user-defined-exceptons] is a good introduction to user-def
 
 ## Exception Filters
 
-`When` is the key word in filtering exceptions. It is placed after the catch
+`when` is the key word in filtering exceptions. It is placed after the catch
 statement and can take a boolean expression containing any values in scope at the time. They don't just have to be members of the exception itself. If the expression evaluates to true then the block associated with that `catch` statement is executed otherwise the next `catch` statement, if any, is checked.
+
+```csharp
+try {
+    // do stuff
+}
+catch (Exception ex) when (ex.Message != "")
+{
+    // output the message
+}
+catch (Exception ex)
+{
+    // show stack trace or something.
+}
+```
 
 - This [Exception filters][exception-filters] article shows how to filter exceptions.
 

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
@@ -4,19 +4,18 @@ This special treatment applies only to `Exception`-derived classes. You cannot t
 
 User-defined exceptions are often used to carry extra information such as a message and other relevant data to be made available to the catching routines. This can then be recorded in logs, reported to a user or perhaps used in a retry operation. `System.Exception` has convenient data members and appropriate constructors to hold a message and the "inner" exception.
 
+By convention exception class names end with "Exception", e.g. `MyTerribleException`.
+
 Whilst using user-defined exceptionss to wrap and enhance third party exceptions is a frequently seen pattern, the general advice is not to use them outside of this use case too liberally in your own code. It is considered an anti-pattern. There are challenges to this view and you can see both sides of the argument in this [Stack Exchange post][se-exceptions].
 
 This [article][create-user-defined-exceptons] is a good introduction to user-defined exceptions.
 
 ## Exception Filters
 
-The following articles are of general interest:
+`When` is the key word in filtering exceptions. It is placed after the catch
+statement and can take a boolean expression containing any values in scope at the time. They don't just have to be members of the exception itself. If the expression evaluates to true then the block associated with that `catch` statement is executed otherwise the next `catch` statement, if any, is checked.
 
-- [Exception filters][exception-filters]: how to filter user-defined-exceptions.
-
-talk about not making exceptions part of the regular control flow.
-should be reserved for circumstances that can't be oredicted in advance
-such as IO errors,
+- This [Exception filters][exception-filters] article shows how to filter exceptions.
 
 [create-user-defined-exceptions]: https://docs.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-user-defined-exceptions
 [exception-filters]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/when

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
@@ -8,16 +8,16 @@ By convention exception class names end with "Exception", e.g. `MyTerribleExcept
 
 Whilst using user-defined exceptions to wrap and enhance third party exceptions is a frequently seen pattern, the general advice is not to use them outside of this use case too liberally in your own code. It is considered an anti-pattern. There are challenges to this view and you can see both sides of the argument in this [Stack Exchange post][se-exceptions].
 
-This [article][create-user-defined-exceptons] is a good introduction to user-defined exceptions.
+This [article][create-user-defined-exceptions] is a good introduction to user-defined exceptions.
 
 As part of their guidance on [creating and throwing exceptions][exceptions-guidance] the .NET team recommend that user defined exceptions have a number of [convenience constructors][convenience-constructors]. For most purposes the combination illustrated below is appropriate.
 
 ```csharp
-public class IncompleteExercisetException : System.Exception
+public class IncompleteExerciseException : System.Exception
 {
-    public IncompleteExercisetException() : base() { }
-    public IncompleteExercisetException(string message) : base(message) { }
-    public IncompleteExercisetException(string message, System.Exception inner) : base(message, inner) { }
+    public IncompleteExerciseException() : base() { }
+    public IncompleteExerciseException(string message) : base(message) { }
+    public IncompleteExerciseException(string message, System.Exception inner) : base(message, inner) { }
 }
 ```
 
@@ -33,7 +33,7 @@ try
 }
 catch (Exception ex) when (ex.Message != "")
 {
-    // output the message
+    // output the message when it is not empty
 }
 catch (Exception ex)
 {
@@ -46,5 +46,5 @@ catch (Exception ex)
 [create-user-defined-exceptions]: https://docs.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-user-defined-exceptions
 [exception-filters]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/when
 [se-exceptions]: https://softwareengineering.stackexchange.com/questions/189222/are-exceptions-as-control-flow-considered-a-serious-antipattern-if-so-why
-[exceptions-guidance]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/exceptions/creating-and-throwing-exceptions#defining-exception-classes
+[exceptions-guidance]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/exceptions/creating-and-throwing-exceptions
 [convenience-constructors]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/exceptions/creating-and-throwing-exceptions#defining-exception-classes

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
@@ -10,10 +10,21 @@ Whilst using user-defined exceptions to wrap and enhance third party exceptions 
 
 This [article][create-user-defined-exceptons] is a good introduction to user-defined exceptions.
 
+As part of their guidance on [creating and throwing exceptions][exceptions-guidance] the .NET team recommend that user defined exceptions have a number of [convenience constructors][convenience-constructors]. For most purposes the combination illustrated below is appropriate.
+
+```csharp
+public class IncompleteExercisetException : System.Exception
+{
+    public IncompleteExercisetException() : base() { }
+    public IncompleteExercisetException(string message) : base(message) { }
+    public IncompleteExercisetException(string message, System.Exception inner) : base(message, inner) { }
+}
+```
+
 ## Exception Filters
 
 `when` is the keyword in filtering exceptions. It is placed after the catch
-statement and can take a boolean expression containing any values in scope at the time. They don't just have to be members of the exception itself. If the expression evaluates to true then the block associated with that `catch` statement is executed otherwise the next `catch` statement, if any, is checked.
+statement and can take a boolean expression containing any values in scope at the time. They don't just have to be members of the exception itself. If the type of the exception matches and the expression evaluates to true then the block associated with that `catch` statement is executed otherwise the next `catch` statement, if any, is checked.
 
 ```csharp
 try
@@ -35,3 +46,5 @@ catch (Exception ex)
 [create-user-defined-exceptions]: https://docs.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-user-defined-exceptions
 [exception-filters]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/when
 [se-exceptions]: https://softwareengineering.stackexchange.com/questions/189222/are-exceptions-as-control-flow-considered-a-serious-antipattern-if-so-why
+[exceptions-guidance]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/exceptions/creating-and-throwing-exceptions#defining-exception-classes
+[convenience-constructors]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/exceptions/creating-and-throwing-exceptions#defining-exception-classes

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
@@ -6,7 +6,7 @@ User-defined exceptions are often used to carry extra information such as a mess
 
 By convention exception class names end with "Exception", e.g. `MyTerribleException`.
 
-Whilst using user-defined exceptionss to wrap and enhance third party exceptions is a frequently seen pattern, the general advice is not to use them outside of this use case too liberally in your own code. It is considered an anti-pattern. There are challenges to this view and you can see both sides of the argument in this [Stack Exchange post][se-exceptions].
+Whilst using user-defined exceptions to wrap and enhance third party exceptions is a frequently seen pattern, the general advice is not to use them outside of this use case too liberally in your own code. It is considered an anti-pattern. There are challenges to this view and you can see both sides of the argument in this [Stack Exchange post][se-exceptions].
 
 This [article][create-user-defined-exceptons] is a good introduction to user-defined exceptions.
 

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
@@ -1,0 +1,2 @@
+- [Create user-defined exceptions][create-user-defined-exceptions]: how to create user-defined exceptions
+- [Exception filters][exception-filters]: how to filter user-defined-exceptions.

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/after.md
@@ -12,11 +12,12 @@ This [article][create-user-defined-exceptons] is a good introduction to user-def
 
 ## Exception Filters
 
-`when` is the key word in filtering exceptions. It is placed after the catch
+`when` is the keyword in filtering exceptions. It is placed after the catch
 statement and can take a boolean expression containing any values in scope at the time. They don't just have to be members of the exception itself. If the expression evaluates to true then the block associated with that `catch` statement is executed otherwise the next `catch` statement, if any, is checked.
 
 ```csharp
-try {
+try
+{
     // do stuff
 }
 catch (Exception ex) when (ex.Message != "")
@@ -33,4 +34,4 @@ catch (Exception ex)
 
 [create-user-defined-exceptions]: https://docs.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-user-defined-exceptions
 [exception-filters]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/when
-[se-udfs]: https://softwareengineering.stackexchange.com/questions/189222/are-exceptions-as-control-flow-considered-a-serious-antipattern-if-so-why
+[se-exceptions]: https://softwareengineering.stackexchange.com/questions/189222/are-exceptions-as-control-flow-considered-a-serious-antipattern-if-so-why

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/hints.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/hints.md
@@ -1,5 +1,22 @@
+## General
+
 - [Create user-defined exceptions][create-user-defined-exceptions]: how to create user-defined exceptions
 - [Exception filters][exception-filters]: how to filter user-defined-exceptions.
 
+## 1. Complete the definition of the user-defined exception `CalculationException`
+
+The constructors of the `Exception` base class are discussed [here][exception-constructors].
+
+## 2. Implement the `Multiply()` method
+
+`try-catch` blocks are discussd [here][try-catch] as well as in the `exceptions` exercise.
+
+## 3. Implement the `TestMultiplication()` method
+
+This [article][try-catch-when] has an example of the use of `when`.
+
 [create-user-defined-exceptions]: https://docs.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-user-defined-exceptions
 [exception-filters]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/when
+[exception-constructors]: https://docs.microsoft.com/en-us/dotnet/api/system.exception.-ctor?view=netcore-3.1
+[try-catch]: https://docs.microsoft.com/en-us/dotnet/standard/exceptions/how-to-use-the-try-catch-block-to-catch-exceptions
+[try-catch-when]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/try-catch

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/hints.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/hints.md
@@ -1,2 +1,5 @@
 - [Create user-defined exceptions][create-user-defined-exceptions]: how to create user-defined exceptions
 - [Exception filters][exception-filters]: how to filter user-defined-exceptions.
+
+[create-user-defined-exceptions]: https://docs.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-user-defined-exceptions
+[exception-filters]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/when

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/hints.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/hints.md
@@ -11,7 +11,7 @@
 
 - `try-catch` blocks are discussed [here][try-catch] as well as in the `exceptions` exercise.
 
-## 3. Implement the `TestMultiplication()` method
+## 4. Implement the `TestMultiplication()` method
 
 - This [article][try-catch-when] has an example of the use of `when`.
 

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/hints.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/hints.md
@@ -1,0 +1,2 @@
+- [Create user-defined exceptions][create-user-defined-exceptions]: how to create user-defined exceptions
+- [Exception filters][exception-filters]: how to filter user-defined-exceptions.

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/hints.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/hints.md
@@ -5,15 +5,15 @@
 
 ## 1. Complete the definition of the user-defined exception `CalculationException`
 
-The constructors of the `Exception` base class are discussed [here][exception-constructors].
+- The constructors of the `Exception` base class are discussed [here][exception-constructors].
 
 ## 2. Implement the `Multiply()` method
 
-`try-catch` blocks are discussd [here][try-catch] as well as in the `exceptions` exercise.
+- `try-catch` blocks are discussed [here][try-catch] as well as in the `exceptions` exercise.
 
 ## 3. Implement the `TestMultiplication()` method
 
-This [article][try-catch-when] has an example of the use of `when`.
+- This [article][try-catch-when] has an example of the use of `when`.
 
 [create-user-defined-exceptions]: https://docs.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-user-defined-exceptions
 [exception-filters]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/when

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
@@ -7,14 +7,14 @@ modified.
 
 Complete the definition of the constructor of `CalculationException` which will need to store the exception
 that it wraps as well as the operand that is being processed at the
-time the exception is thrown.
+time the exception is thrown. Implment `GetOperand()` to return the stored value.
 
-## 2. Implement the `Calculate` routine
+## 2. Implement the `Calculate()` method
 
-The `Calculate` routine should call the `TestHarnessOperations.HandleInt` routine
-passing in the value that is passed into `Calculate`. `HandleInt` is
+The `Calculate()` routine should call the `TestHarnessOperations.HandleInt()` routine
+passing in the value that is passed into `Calculate()`. `HandleInt()` is
 guaranteed to throw an `Sytem.OverflowException`. This exception
-should be wrapped in a `CalculationException` and the value being
+should be caught wrapped in a `CalculationException` and the value being
 passed around should be stored as the operand. The newly
 created exception should be thrown.
 
@@ -24,10 +24,10 @@ cth.Calulate(123);
 // => throws an instance of CalculationException
 ```
 
-## 3. Implement the Run routine
+## 3. Implement the `Run()` method
 
-Implement a method `Run` tthat can either call
-`Calculate` or `TestHarnessOperations.HandleInt` directly depending on the value
+Implement a method `Run()` that can either call
+`Calculate` or `TestHarnessOperations.HandleInt()` directly depending on the value
 of the first (test name) argument to the method. It catches an instance of either
 `CalculationException` or a `System.OverflowException` and the method
 returns an appropriate message to the caller (see below). If

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
@@ -1,4 +1,4 @@
-While working at _Instruments of Texas_, you are tasked to work on an experimental calculator written in C#. You are building a test harness to verify a number of calculator functions starting with multiplication.
+While working at _Instruments of Texas_, you are tasked to work on an experimental calculator written in C#. You are building a test harness to verify a number of calculator functions starting with multiplication.  You will see that there is particular concern when the two operands of the multiplication are negative.
 
 The `Calculator` class has been provided for you and should not be
 modified.

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
@@ -1,0 +1,55 @@
+While working at _Instruments of Texas_, you are tasked to work on an experimental calculator written in C#. Your team is having a problem with some operations raising errors and crashing the process. You have been tasked to write a function which wraps the operation function so that the errors can be handled in the normal program flow.
+
+A static class, `TestHarnessOperations` has been provided for you and should not be
+modified.
+
+## 1. Complete the definition of the user-defined exception `CalculationException`
+
+Complete the definition of the constructor of `CalculationException` which will need to store the exception
+that it wraps as well as the operand that is being processed at the
+time the exception is thrown.
+
+## 2. Implement the `Calculate` routine
+
+The `Calculate` routine should call the `TestHarnessOperations.HandleInt` routine
+passing in the value that is passed into `Calculate`. `HandleInt` is
+guaranteed to throw an `Sytem.OverflowException`. This exception
+should be wrapped in a `CalculationException` and the value being
+passed around should be stored as the operand. The newly
+created exception should be thrown.
+
+```csharp
+var cth = new CalculatorTestHarness();
+cth.Calulate(123);
+// => throws an instance of CalculationException
+```
+
+## 3. Implement the Run routine
+
+Implement a method `Run` tthat can either call
+`Calculate` or `TestHarnessOperations.HandleInt` directly depending on the value
+of the first (test name) argument to the method. It catches an instance of either
+`CalculationException` or a `System.OverflowException` and the method
+returns an appropriate message to the caller (see below). If
+the operand contained in the instance of `CalculationException` is 0 then
+a special message is returned.
+
+If an unrecognized test name is passed in then an empty string is returned.
+
+The example code below shows the appropriate values for the
+parameters and corresponding messages to be returned.
+
+```csharp
+var cth = new CalculatorTestHarness();
+cth.Run("Calculate", 0);
+// => "Calculate failed for a zero value. " + innerException.Message
+
+cth.Run("Calculate", 123);
+// => "Calculate failed for a non-zero value. " + innerException.Message
+
+cth.Run("HandleInt", 42);
+// => "FakeOp failure"
+
+cth.Run("Foo", 123);
+// => string.Empty
+```

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
@@ -7,35 +7,35 @@ modified.
 
 Complete the definition of the constructor of `CalculationException` which will need to store (wrap) any exception thrown by the calculator as well as the operands that are being processed at the time the exception is thrown.
 
-## 2. Implement the `TestMultiplication()` method
+## 2. Implement the `Multiply()` method
 
-The `TestMultiplication()` routine should call the `Calclator.Multiply()` routine
-passing in x and y integer values. The y value is always positive, the x value may be negative. If an overflow occurs then an `OverflowException` will be thrown by the `Calculator`. This exception should be caught in `TestMultiplication` and wrapped in a `CalculationException` and the x and y values being passed around should be stored as the exception's operands. The newly created `CalculationException` object should be thrown. The test has no interest in the value returned by `Multiply` if it is successful.
-
-```csharp
-var cth = new CalculatorTestHarness(new Calculator());
-cth.TestMultiplication(Int32.MaxValue, Int32.MaxValue);
-// => throws an instance of CalculationException
-
-var cth2 = new CalculatorTestHarness(new Calculator());
-cth2.TestMultiplication(3, 2);
-// => silently exits
-```
-
-## 3. Implement the `Multiply()` method
-
-- `Multiply()` takes two integers and calls `TestMultiplication`.
-- If all goes well it returns "Multiply succeeded".
-- If an exception is thrown by `TestMultipliction` this is caught.
-- An error message is returned depending on whether the first of the two operands was negative. See the examples below for exact text.
+The `Multiply()` routine should call the `Calclator.Multiply()` routine
+passing in x and y integer values. If an overflow occurs then an `OverflowException` will be thrown by the `Calculator`. This exception should be caught in `Multiply` and wrapped in a `CalculationException` and the x and y values being passed around should be stored as the exception's operands. The newly created `CalculationException` object should be thrown. The test has no interest in the value returned by `Calculator.Multiply` if it is successful.
 
 ```csharp
 var cth = new CalculatorTestHarness(new Calculator());
 cth.Multiply(Int32.MaxValue, Int32.MaxValue);
-// => "Multiply failed for a positive value. " + innerException.Message
+// => throws an instance of CalculationException
 
-cth.Multiply(-2, Int32.MaxValue);
-// => "Multiply failed for a negative value. " + innerException.Message
+var cth2 = new CalculatorTestHarness(new Calculator());
+cth2.Multiply(3, 2);
+// => silently exits
+```
+
+## 3. Implement the `TestMultiplication()` method
+
+- `TestMultiplication()` takes two integers and calls `Multiply`.
+- If all goes well it returns "Multiply succeeded".
+- If an exception is thrown by `Nultiply` this is caught.
+- An error message is returned depending on whether the first of the two operands was negative. See the examples below for exact text.
+
+```csharp
+var cth = new CalculatorTestHarness(new Calculator());
+cth.TestMultiplication(Int32.MaxValue, Int32.MaxValue);
+// => "Multiply failed for mixed or positive operands. " + innerException.Message
+
+cth.TestMultiplication(-2, -Int32.MaxValue);
+// => "Multiply failed for negative operands. " + innerException.Message
 
 cth.Multiply(6, 7);
 // => "Multiply succeeded. " + innerException.Message

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
@@ -9,8 +9,8 @@ Complete the definition of the constructor of `CalculationException` which will 
 
 ## 2. Implement the `TestMultiplication()` method
 
-The `TestMultiplication()` routine should call the `Calclator.Multiplication()` routine
-passing in x and y integer values. The y value is always positive, the x value may be negative. If an overflow occurs then an `OverflowException` will be thrown by the `Calculator`. This exception should be caught in `TestMultiplication` and wrapped in a `CalculationException` and the x and y values being passed around should be stored as the exception's operands. The newly created `CalculationException` object should be thrown. Otherwise the product of x and y should be returned by `TestMultiplication`.
+The `TestMultiplication()` routine should call the `Calclator.Multiply()` routine
+passing in x and y integer values. The y value is always positive, the x value may be negative. If an overflow occurs then an `OverflowException` will be thrown by the `Calculator`. This exception should be caught in `TestMultiplication` and wrapped in a `CalculationException` and the x and y values being passed around should be stored as the exception's operands. The newly created `CalculationException` object should be thrown. The test has no interest in the value returned by `Multiply` if it is successful.
 
 ```csharp
 var cth = new CalculatorTestHarness(new Calculator());
@@ -19,7 +19,7 @@ cth.TestMultiplication(Int32.MaxValue, Int32.MaxValue);
 
 var cth2 = new CalculatorTestHarness(new Calculator());
 cth2.TestMultiplication(3, 2);
-// => 6
+// => silently exits
 ```
 
 ## 3. Implement the `Multiply()` method

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
@@ -1,4 +1,4 @@
-While working at _Instruments of Texas_, you are tasked to work on an experimental calculator written in C#. You are building a test harness to verify a number of calculator functions starting with multiplication.  You will see that there is particular concern when the two operands of the multiplication are negative.
+While working at _Instruments of Texas_, you are tasked to work on an experimental calculator written in C#. You are building a test harness to verify a number of calculator functions starting with multiplication. You will see that there is particular concern when the two operands of the multiplication are negative.
 
 The `Calculator` class has been provided for you and should not be
 modified.
@@ -27,7 +27,7 @@ cth2.Multiply(3, 2);
 - `TestMultiplication()` takes two integers and calls `Multiply`.
 - If all goes well it returns "Multiply succeeded".
 - If an exception is thrown by `Nultiply` this is caught.
-- An error message is returned depending on whether the first of the two operands was negative. See the examples below for exact text.
+- The error message returned depends on whether or not both the operands are negative. See the examples below for exact text.
 
 ```csharp
 var cth = new CalculatorTestHarness(new Calculator());
@@ -38,5 +38,5 @@ cth.TestMultiplication(-2, -Int32.MaxValue);
 // => "Multiply failed for negative operands. " + innerException.Message
 
 cth.Multiply(6, 7);
-// => "Multiply succeeded. " + innerException.Message
+// => "Multiply succeeded"
 ```

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
@@ -1,7 +1,6 @@
 While working at _Instruments of Texas_, you are tasked to work on an experimental calculator written in C#. You are building a test harness to verify a number of calculator functions starting with multiplication. You will see that there is particular concern when the two operands of the multiplication are negative.
 
-The `Calculator` class has been provided for you and should not be
-modified.
+The `Calculator` class has been provided for you and should not be modified.
 
 ## 1. Complete the definition of the user-defined exception `CalculationException`
 
@@ -9,8 +8,8 @@ Complete the definition of the constructor of `CalculationException` which will 
 
 ## 2. Implement the `Multiply()` method
 
-The `Multiply()` routine should call the `Calclator.Multiply()` routine
-passing in x and y integer values. If an overflow occurs then an `OverflowException` will be thrown by the `Calculator`. This exception should be caught in `Multiply` and wrapped in a `CalculationException` and the x and y values being passed around should be stored as the exception's operands. The newly created `CalculationException` object should be thrown. The test has no interest in the value returned by `Calculator.Multiply` if it is successful.
+Implement the `CalculatorTestHarness.Multiply()` method, which should call the `Calculator.Multiply()` method of the `Calculator` instance passed to the constructor.
+passing in x and y integer values. If an overflow occurs in the `Calculator.Multiply()` method, it will throw an `OverflowException`. This exception should be caught in the  `CalculatorTestHarness.Multiply()` method and wrapped in a `CalculationException` and the x and y values being passed around should be stored as the exception's operands. The newly created `CalculationException` object should be thrown. You can ignore the value returned by the `Calculator.Multiply()` method if it is successful.
 
 ```csharp
 var cth = new CalculatorTestHarness(new Calculator());
@@ -24,10 +23,13 @@ cth2.Multiply(3, 2);
 
 ## 3. Implement the `TestMultiplication()` method
 
-- `TestMultiplication()` takes two integers and calls `Multiply`.
-- If all goes well it returns "Multiply succeeded".
-- If an exception is thrown by `Nultiply` this is caught.
-- The error message returned depends on whether or not both the operands are negative. See the examples below for exact text.
+Implement the `CalculatorTestHarness.TestMultiplication()` method which takes two integers and calls the `CalculatorTestHarness.Multiply()` method. There are three possible return values:
+
+- `"Multiply succeeded"`: returned if the multiplication was successful (no exception was thrown).
+- `"Multiply failed for negative operands. <INNER_EXCEPTION_MESSAGE>"`: returned if a `CalculationException` was thrown by the `CalculatorTestHarness.Multiply()` method and both integers are negative (less than zero).
+- `"Multiply failed for mixed or positive operands. <INNER_EXCEPTION_MESSAGE>"`: returned if a `CalculationException` was thrown by the `CalculatorTestHarness.Multiply()` method and neither of the integers are negative (less than zero). 
+
+ The `<INNER_EXCEPTION_MESSAGE>` placeholder hould be replaced with the `CalculationException`'s inner exception's message.
 
 ```csharp
 var cth = new CalculatorTestHarness(new Calculator());

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
@@ -6,10 +6,10 @@ The `Calculator` class has been provided for you and should not be modified.
 
 Complete the definition of the constructor of `CalculationException` which will need to store (wrap) any exception thrown by the calculator as well as the operands that are being processed at the time the exception is thrown.
 
-## 2. Implement the `Multiply()` method
+## 2. Handle overflow conditions in the calculator and provide enhanced information to the caller
 
 Implement the `CalculatorTestHarness.Multiply()` method, which should call the `Calculator.Multiply()` method of the `Calculator` instance passed to the constructor.
-passing in x and y integer values. If an overflow occurs in the `Calculator.Multiply()` method, it will throw an `OverflowException`. This exception should be caught in the  `CalculatorTestHarness.Multiply()` method and wrapped in a `CalculationException` and the x and y values being passed around should be stored as the exception's operands. The newly created `CalculationException` object should be thrown. You can ignore the value returned by the `Calculator.Multiply()` method if it is successful.
+passing in x and y integer values. If an overflow occurs in the `Calculator.Multiply()` method, it will throw an `OverflowException`. This exception should be caught in the `CalculatorTestHarness.Multiply()` method and wrapped in a `CalculationException` and the x and y values being passed around should be stored as the exception's operands. The newly created `CalculationException` object should be thrown. You can ignore the value returned by the `Calculator.Multiply()` method if it is successful.
 
 ```csharp
 var cth = new CalculatorTestHarness(new Calculator());
@@ -21,24 +21,38 @@ cth2.Multiply(3, 2);
 // => silently exits
 ```
 
-## 3. Implement the `TestMultiplication()` method
+## 3. Test the multiplication operation for valid inputs
 
-Implement the `CalculatorTestHarness.TestMultiplication()` method which takes two integers and calls the `CalculatorTestHarness.Multiply()` method. There are three possible return values:
+Implement the `CalculatorTestHarness.TestMultiplication()` method which takes two integers and calls the `CalculatorTestHarness.Multiply()` method. `"Multiply succeeded"` is returned.
 
-- `"Multiply succeeded"`: returned if the multiplication was successful (no exception was thrown).
-- `"Multiply failed for negative operands. <INNER_EXCEPTION_MESSAGE>"`: returned if a `CalculationException` was thrown by the `CalculatorTestHarness.Multiply()` method and both integers are negative (less than zero).
-- `"Multiply failed for mixed or positive operands. <INNER_EXCEPTION_MESSAGE>"`: returned if a `CalculationException` was thrown by the `CalculatorTestHarness.Multiply()` method and neither of the integers are negative (less than zero). 
+The `<INNER_EXCEPTION_MESSAGE>` placeholder should be replaced with the `CalculationException`'s inner exception's message.
 
- The `<INNER_EXCEPTION_MESSAGE>` placeholder hould be replaced with the `CalculationException`'s inner exception's message.
+```csharp
+var cth = new CalculatorTestHarness(new Calculator());
+cth.Multiply(6, 7);
+// => "Multiply succeeded"
+```
+
+## 4. Test the multiplication operation for negative inputs
+
+Modify the `CalculatorTestHarness.TestMultiplication()` method so that `"Multiply failed for negative operands. <INNER_EXCEPTION_MESSAGE>"`is returned if both integer arguments are negative (less than zero).
+
+The `<INNER_EXCEPTION_MESSAGE>` placeholder should be replaced with the `CalculationException`'s inner exception's message.
+
+```csharp
+var cth = new CalculatorTestHarness(new Calculator());
+cth.TestMultiplication(-2, -Int32.MaxValue);
+// => "Multiply failed for negative operands. " + innerException.Message
+```
+
+## 5. Test the multiplication operation for positive inputs
+
+Modify the `CalculatorTestHarness.TestMultiplication()` method so that `"Multiply failed for mixed or positive operands. <INNER_EXCEPTION_MESSAGE>"` is returned if at least one of the integer arguments is not negative.
+
+The `<INNER_EXCEPTION_MESSAGE>` placeholder should be replaced with the `CalculationException`'s inner exception's message.
 
 ```csharp
 var cth = new CalculatorTestHarness(new Calculator());
 cth.TestMultiplication(Int32.MaxValue, Int32.MaxValue);
 // => "Multiply failed for mixed or positive operands. " + innerException.Message
-
-cth.TestMultiplication(-2, -Int32.MaxValue);
-// => "Multiply failed for negative operands. " + innerException.Message
-
-cth.Multiply(6, 7);
-// => "Multiply succeeded"
 ```

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
@@ -25,8 +25,6 @@ cth2.Multiply(3, 2);
 
 Implement the `CalculatorTestHarness.TestMultiplication()` method which takes two integers and calls the `CalculatorTestHarness.Multiply()` method. `"Multiply succeeded"` is returned.
 
-The `<INNER_EXCEPTION_MESSAGE>` placeholder should be replaced with the `CalculationException`'s inner exception's message.
-
 ```csharp
 var cth = new CalculatorTestHarness(new Calculator());
 cth.Multiply(6, 7);

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
@@ -12,7 +12,7 @@ time the exception is thrown. Implment `GetOperand()` to return the stored value
 ## 2. Implement the `Calculate()` method
 
 The `Calculate()` routine should call the `TestHarnessOperations.HandleInt()` routine
-passing in the value that is passed into `Calculate()`. `HandleInt()` is
+passing in the value, `testValue` that is passed into `Calculate()`. `HandleInt()` is
 guaranteed to throw an `Sytem.OverflowException`. This exception
 should be caught wrapped in a `CalculationException` and the value being
 passed around should be stored as the operand. The newly

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/instructions.md
@@ -1,55 +1,42 @@
-While working at _Instruments of Texas_, you are tasked to work on an experimental calculator written in C#. Your team is having a problem with some operations raising errors and crashing the process. You have been tasked to write a function which wraps the operation function so that the errors can be handled in the normal program flow.
+While working at _Instruments of Texas_, you are tasked to work on an experimental calculator written in C#. You are building a test harness to verify a number of calculator functions starting with multiplication.
 
-A static class, `TestHarnessOperations` has been provided for you and should not be
+The `Calculator` class has been provided for you and should not be
 modified.
 
 ## 1. Complete the definition of the user-defined exception `CalculationException`
 
-Complete the definition of the constructor of `CalculationException` which will need to store the exception
-that it wraps as well as the operand that is being processed at the
-time the exception is thrown. Implment `GetOperand()` to return the stored value.
+Complete the definition of the constructor of `CalculationException` which will need to store (wrap) any exception thrown by the calculator as well as the operands that are being processed at the time the exception is thrown.
 
-## 2. Implement the `Calculate()` method
+## 2. Implement the `TestMultiplication()` method
 
-The `Calculate()` routine should call the `TestHarnessOperations.HandleInt()` routine
-passing in the value, `testValue` that is passed into `Calculate()`. `HandleInt()` is
-guaranteed to throw an `Sytem.OverflowException`. This exception
-should be caught wrapped in a `CalculationException` and the value being
-passed around should be stored as the operand. The newly
-created exception should be thrown.
+The `TestMultiplication()` routine should call the `Calclator.Multiplication()` routine
+passing in x and y integer values. The y value is always positive, the x value may be negative. If an overflow occurs then an `OverflowException` will be thrown by the `Calculator`. This exception should be caught in `TestMultiplication` and wrapped in a `CalculationException` and the x and y values being passed around should be stored as the exception's operands. The newly created `CalculationException` object should be thrown. Otherwise the product of x and y should be returned by `TestMultiplication`.
 
 ```csharp
-var cth = new CalculatorTestHarness();
-cth.Calulate(123);
+var cth = new CalculatorTestHarness(new Calculator());
+cth.TestMultiplication(Int32.MaxValue, Int32.MaxValue);
 // => throws an instance of CalculationException
+
+var cth2 = new CalculatorTestHarness(new Calculator());
+cth2.TestMultiplication(3, 2);
+// => 6
 ```
 
-## 3. Implement the `Run()` method
+## 3. Implement the `Multiply()` method
 
-Implement a method `Run()` that can either call
-`Calculate` or `TestHarnessOperations.HandleInt()` directly depending on the value
-of the first (test name) argument to the method. It catches an instance of either
-`CalculationException` or a `System.OverflowException` and the method
-returns an appropriate message to the caller (see below). If
-the operand contained in the instance of `CalculationException` is 0 then
-a special message is returned.
-
-If an unrecognized test name is passed in then an empty string is returned.
-
-The example code below shows the appropriate values for the
-parameters and corresponding messages to be returned.
+- `Multiply()` takes two integers and calls `TestMultiplication`.
+- If all goes well it returns "Multiply succeeded".
+- If an exception is thrown by `TestMultipliction` this is caught.
+- An error message is returned depending on whether the first of the two operands was negative. See the examples below for exact text.
 
 ```csharp
-var cth = new CalculatorTestHarness();
-cth.Run("Calculate", 0);
-// => "Calculate failed for a zero value. " + innerException.Message
+var cth = new CalculatorTestHarness(new Calculator());
+cth.Multiply(Int32.MaxValue, Int32.MaxValue);
+// => "Multiply failed for a positive value. " + innerException.Message
 
-cth.Run("Calculate", 123);
-// => "Calculate failed for a non-zero value. " + innerException.Message
+cth.Multiply(-2, Int32.MaxValue);
+// => "Multiply failed for a negative value. " + innerException.Message
 
-cth.Run("HandleInt", 42);
-// => "FakeOp failure"
-
-cth.Run("Foo", 123);
-// => string.Empty
+cth.Multiply(6, 7);
+// => "Multiply succeeded. " + innerException.Message
 ```

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/introduction.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/introduction.md
@@ -14,7 +14,7 @@ try
 }
 catch (Exception ex) when (ex.Message != "")
 {
-    // output the message
+    // output the message when it is not empty
 }
 catch (Exception ex)
 {

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/introduction.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/introduction.md
@@ -4,5 +4,19 @@ User-defined exceptions are often used to carry extra information such as a mess
 
 ## Exception Filters
 
-`When` is the key word in filtering exceptions. It is placed after the catch
+`when` is the key word in filtering exceptions. It is placed after the catch
 statement and can take a boolean expression containing any values in scope at the time. If the expression evaluates to true then the block associated with that `catch` statement is executed otherwise the next `catch` statement, if any, is checked.
+
+```csharp
+try {
+    // do stuff
+}
+catch (Exception ex) when (ex.Message != "")
+{
+    // output the message
+}
+catch (Exception ex)
+{
+    // show stack trace or something.
+}
+```

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/introduction.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/introduction.md
@@ -8,7 +8,8 @@ User-defined exceptions are often used to carry extra information such as a mess
 statement and can take a boolean expression containing any values in scope at the time. If the expression evaluates to true then the block associated with that `catch` statement is executed otherwise the next `catch` statement, if any, is checked.
 
 ```csharp
-try {
+try
+{
     // do stuff
 }
 catch (Exception ex) when (ex.Message != "")

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.docs/introduction.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.docs/introduction.md
@@ -1,0 +1,8 @@
+A user-defined exception is any class defined in your code that is derived from `System.Exception`. It is subject to all the rules of class inheritance but in addition the compiler and language runtime treat such classes in a special way allowing their instances to be thrown and caught outside the normal control flow as discussed in the `exceptions` exercise.
+
+User-defined exceptions are often used to carry extra information such as a message and other relevant data to be made available to the catching routines.
+
+## Exception Filters
+
+`When` is the key word in filtering exceptions. It is placed after the catch
+statement and can take a boolean expression containing any values in scope at the time. If the expression evaluates to true then the block associated with that `catch` statement is executed otherwise the next `catch` statement, if any, is checked.

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.meta/Example.cs
@@ -1,6 +1,6 @@
 using System;
 
-public class CalculationException_example : Exception
+public class CalculationException : Exception
 {
     public CalculationException(int operand1, int operand2, string message, Exception inner) : base(message, inner)
     {
@@ -12,11 +12,11 @@ public class CalculationException_example : Exception
     public int Operand2 { get; }
 }
 
-public class CalculatorTestHarness_example
+public class CalculatorTestHarness
 {
     private Calculator calculator;
 
-    public CalculatorTestHarness_example(Calculator calculator)
+    public CalculatorTestHarness(Calculator calculator)
     {
         this.calculator = calculator;
     }
@@ -55,7 +55,7 @@ public class CalculatorTestHarness_example
 // Please do not modify the code below.
 // If there is an overflow in the multiplication operation
 // then a System.OverflowException is thrown.
-public class Calculator_example
+public class Calculator
 {
     public int Multiply(int x, int y)
     {

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.meta/Example.cs
@@ -3,7 +3,6 @@ using System;
 public class CalculationException : Exception
 {
     public CalculationException(int operand1, int operand2, string message, Exception inner) : base(message, inner)
-    // TODO: complete the definition of the constructor
     {
         Operand1 = operand1;
         Operand2 = operand2;

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.meta/Example.cs
@@ -1,6 +1,6 @@
 using System;
 
-public class CalculationException : Exception
+public class CalculationException_example : Exception
 {
     public CalculationException(int operand1, int operand2, string message, Exception inner) : base(message, inner)
     {
@@ -12,34 +12,33 @@ public class CalculationException : Exception
     public int Operand2 { get; }
 }
 
-public class CalculatorTestHarness
+public class CalculatorTestHarness_example
 {
     private Calculator calculator;
 
-    public CalculatorTestHarness(Calculator calculator)
+    public CalculatorTestHarness_example(Calculator calculator)
     {
         this.calculator = calculator;
     }
 
-    public string Multiply(int x, int y)
+    public string TestMultiplication(int x, int y)
     {
         try
         {
-            TestMultiplication(x, y);
+            Multiply(x, y);
+            return "Multiply succeeded";
         }
-        catch (CalculationException cex) when (cex.Operand1 < 0)
+        catch (CalculationException cex) when (cex.Operand1 < 0 && cex.Operand2 < 0)
         {
-            return "Multiply failed for a negative value. " + cex.InnerException.Message;
+            return "Multiply failed for negative operands. " + cex.InnerException.Message;
         }
         catch (CalculationException cex)
         {
-            return "Multiply failed for a positive value. " + cex.InnerException.Message;
+            return "Multiply failed for mixed or positive operands. " + cex.InnerException.Message;
         }
-
-        return "Multiply succeeded";
     }
 
-    public void TestMultiplication(int x, int y)
+    public void Multiply(int x, int y)
     {
         try
         {
@@ -52,10 +51,11 @@ public class CalculatorTestHarness
     }
 }
 
+
 // Please do not modify the code below.
 // If there is an overflow in the multiplication operation
 // then a System.OverflowException is thrown.
-public class Calculator
+public class Calculator_example
 {
     public int Multiply(int x, int y)
     {

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.meta/Example.cs
@@ -1,6 +1,7 @@
 using System;
 
 public class CalculationException : Exception
+    // TODO: complete the definition of the constructor
 {
     private int operand;
     public CalculationException(int operand, string message, Exception inner) : base(message, inner)

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.meta/Example.cs
@@ -1,0 +1,76 @@
+using System;
+
+public class CalculationException : Exception
+{
+    private int operand;
+    public CalculationException(int operand, string message, Exception inner) : base(message, inner)
+    {
+        this.operand = operand;
+    }
+
+    public int GetOperand()
+    {
+        return operand;
+    }
+}
+
+public class CalculatorTestHarness
+{
+    public string Run(string testName, int testValue)
+    {
+        try
+        {
+            if (testName == "Calculate")
+            {
+                Calculate(testValue);
+            }
+            else if (testName == "HandleInt")
+            {
+                TestHarnessOperations.HandleInt(testValue);
+            }
+        }
+        catch (OverflowException ofex)
+        {
+            return "HandleInt failure";
+        }
+        catch (CalculationException cex) when (cex.GetOperand() == 0)
+        {
+            return "Calculate failed for a zero value. " + cex.InnerException.Message;
+        }
+        catch (CalculationException cex)
+        {
+            return "Calculate failed for a non-zero value. " + cex.InnerException.Message;
+        }
+
+        return string.Empty;
+    }
+
+    public void Calculate(int testNum)
+    {
+        try
+        {
+            TestHarnessOperations.HandleInt(testNum);
+        }
+        catch (OverflowException ofex)
+        {
+            throw new CalculationException(testNum, "Calculate: operation failed in FakeOp", ofex);
+        }
+    }
+}
+
+
+// Please do not modify the code below.  In a more realistic
+// scenario this would be in a different library and would actually
+// do something meaningful.  This code will always throw
+// a Sysem.OverflowException
+public static class TestHarnessOperations
+{
+    public static int HandleInt(int testNum)
+    {
+        int trouble = Int32.MaxValue;
+        checked
+        {
+            return Int32.MaxValue * trouble;
+        }
+    }
+}

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.meta/Example.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.meta/Example.cs
@@ -1,77 +1,68 @@
 using System;
 
 public class CalculationException : Exception
-    // TODO: complete the definition of the constructor
 {
-    private int operand;
-    public CalculationException(int operand, string message, Exception inner) : base(message, inner)
+    public CalculationException(int operand1, int operand2, string message, Exception inner) : base(message, inner)
+    // TODO: complete the definition of the constructor
     {
-        this.operand = operand;
+        Operand1 = operand1;
+        Operand2 = operand2;
     }
 
-    public int GetOperand()
-    {
-        return operand;
-    }
+    public int Operand1 { get; }
+    public int Operand2 { get; }
 }
 
 public class CalculatorTestHarness
 {
-    public string Run(string testName, int testValue)
+    private Calculator calculator;
+
+    public CalculatorTestHarness(Calculator calculator)
+    {
+        this.calculator = calculator;
+    }
+
+    public string Multiply(int x, int y)
     {
         try
         {
-            if (testName == "Calculate")
-            {
-                Calculate(testValue);
-            }
-            else if (testName == "HandleInt")
-            {
-                TestHarnessOperations.HandleInt(testValue);
-            }
+            TestMultiplication(x, y);
         }
-        catch (OverflowException ofex)
+        catch (CalculationException cex) when (cex.Operand1 < 0)
         {
-            return "HandleInt failure";
-        }
-        catch (CalculationException cex) when (cex.GetOperand() == 0)
-        {
-            return "Calculate failed for a zero value. " + cex.InnerException.Message;
+            return "Multiply failed for a negative value. " + cex.InnerException.Message;
         }
         catch (CalculationException cex)
         {
-            return "Calculate failed for a non-zero value. " + cex.InnerException.Message;
+            return "Multiply failed for a positive value. " + cex.InnerException.Message;
         }
 
-        return string.Empty;
+        return "Multiply succeeded";
     }
 
-    public void Calculate(int testNum)
+    public void TestMultiplication(int x, int y)
     {
         try
         {
-            TestHarnessOperations.HandleInt(testNum);
+            calculator.Multiply(x, y);
         }
         catch (OverflowException ofex)
         {
-            throw new CalculationException(testNum, "Calculate: operation failed in FakeOp", ofex);
+            throw new CalculationException(x, y, string.Empty, ofex);
         }
     }
 }
 
-
-// Please do not modify the code below.  In a more realistic
-// scenario this would be in a different library and would actually
-// do something meaningful.  This code will always throw
-// a Sysem.OverflowException
-public static class TestHarnessOperations
+// Please do not modify the code below.
+// If there is an overflow in the multiplication operation
+// then a System.OverflowException is thrown.
+public class Calculator
 {
-    public static int HandleInt(int testNum)
+    public int Multiply(int x, int y)
     {
-        int trouble = Int32.MaxValue;
         checked
         {
-            return Int32.MaxValue * trouble;
+            return x * y;
         }
     }
 }

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.meta/config.json
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.meta/config.json
@@ -1,0 +1,8 @@
+{
+  "authors": [
+    {
+      "github_username": "mikedamay",
+      "exercism_username": "mikedamay"
+    }
+  ]
+}

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.meta/config.json
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.meta/config.json
@@ -4,5 +4,6 @@
       "github_username": "mikedamay",
       "exercism_username": "mikedamay"
     }
-  ]
+  ],
+  "forked_from": ["elixir/errors"]
 }

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.meta/design.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.meta/design.md
@@ -1,0 +1,25 @@
+## Learning objectives
+
+- Know how to define a user-defined exception.
+- Know how to use exception filtering.
+
+## Out of scope
+
+- Memory and performance characteristics.
+
+## Concepts
+
+This Concepts Exercise's Concepts are:
+
+- `user-defined-exceptions`: know how to define a user-defined exception.
+- `exception-filtering`: know how to use exception filtering.
+
+Any data types used in this exercise (e.g. `strings`) should also be added as prerequisites.
+
+## Prequisites
+
+This Concept Exercise's prerequisites Concepts are:
+
+- `exceptions`: know how to work with exceptions.
+- `inheritance`: inheriting from the `Exception` class for the custom exception.
+

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.meta/design.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.meta/design.md
@@ -2,6 +2,8 @@
 
 - Know how to define a user-defined exception.
 - Know how to use exception filtering.
+- Know that using errors as control logic is an anti-pattern
+- throwing non-exception types (discussion only)
 
 ## Out of scope
 
@@ -22,4 +24,5 @@ This Concept Exercise's prerequisites Concepts are:
 
 - `exceptions`: know how to work with exceptions.
 - `inheritance`: inheriting from the `Exception` class for the custom exception.
-
+- `strings`: converting an into a string
+- `conditionals`: use of simple `if`/`else`

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.meta/design.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.meta/design.md
@@ -15,8 +15,6 @@ This Concepts Exercise's Concepts are:
 - `user-defined-exceptions`: know how to define a user-defined exception.
 - `exception-filtering`: know how to use exception filtering.
 
-Any data types used in this exercise (e.g. `strings`) should also be added as prerequisites.
-
 ## Prequisites
 
 This Concept Exercise's prerequisites Concepts are:
@@ -25,3 +23,5 @@ This Concept Exercise's prerequisites Concepts are:
 - `inheritance`: inheriting from the `Exception` class for the custom exception.
 - `strings`: converting an into a string
 - `conditionals`: use of simple `if`/`else`
+- `arithmetic-overflow`
+- `signed-integers`: `Int32.MaxValue`

--- a/languages/csharp/exercises/concept/user-defined-exceptions/.meta/design.md
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/.meta/design.md
@@ -3,7 +3,6 @@
 - Know how to define a user-defined exception.
 - Know how to use exception filtering.
 - Know that using errors as control logic is an anti-pattern
-- throwing non-exception types (discussion only)
 
 ## Out of scope
 

--- a/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptions.csproj
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptions.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="xunit" Version="2.4.1" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    </ItemGroup>
+
+</Project>

--- a/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptionsTests.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptionsTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 public class UserDefinedExceptionsTests
 {
     [Fact]
-    public void Call_Multiply()
+    public void Multiply_with_overflow_throws_calculationexception()
     {
         var cth = new CalculatorTestHarness(new Calculator());
 
@@ -12,7 +12,7 @@ public class UserDefinedExceptionsTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Call_TestMultiplication_with_negative()
+    public void TestMultiplication_with_negative_overflow()
     {
         var cth = new CalculatorTestHarness(new Calculator());
         Assert.Equal("Multiply failed for negative operands. Arithmetic operation resulted in an overflow.",
@@ -20,7 +20,7 @@ public class UserDefinedExceptionsTests
     }
 
     [Fact(Skip = "Remove this Skip property to run this test")]
-    public void Call_TestMultiplication_with_positive()
+    public void TestMultiplication_with_positive_overflow()
     {
         var cth = new CalculatorTestHarness(new Calculator());
         Assert.Equal("Multiply failed for mixed or positive operands. Arithmetic operation resulted in an overflow.",
@@ -33,5 +33,4 @@ public class UserDefinedExceptionsTests
         var cth = new CalculatorTestHarness(new Calculator());
         Assert.Equal("Multiply succeeded", cth.TestMultiplication(6, 7));
     }
-
 }

--- a/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptionsTests.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptionsTests.cs
@@ -1,40 +1,37 @@
+using System;
 using Xunit;
 
 public class UserDefinedExceptionsTests
 {
     [Fact]
-    public void Call_Calculate()
+    public void Call_TestMultiplication()
     {
-        var cth = new CalculatorTestHarness();
+        var cth = new CalculatorTestHarness(new Calculator());
 
-        Assert.Throws<CalculationException>( () => cth.Calculate(123) );
+        Assert.Throws<CalculationException>(() => cth.TestMultiplication(Int32.MaxValue, Int32.MaxValue));
     }
 
     [Fact /*(Skip = "Remove this Skip property to run this test")*/]
-    public void Call_Run_Calculate_with_0()
+    public void Call_Multiply_with_negative()
     {
-        var cth = new CalculatorTestHarness();
-        Assert.Equal("Calculate failed for a zero value. Arithmetic operation resulted in an overflow.", cth.Run("Calculate", 0));
+        var cth = new CalculatorTestHarness(new Calculator());
+        Assert.Equal("Multiply failed for a negative value. Arithmetic operation resulted in an overflow.",
+            cth.Multiply(-2, Int32.MaxValue));
     }
 
     [Fact /*(Skip = "Remove this Skip property to run this test")*/]
-    public void Call_Run_Calculate_with_non_0()
+    public void Call_Multiply_with_positive()
     {
-        var cth = new CalculatorTestHarness();
-        Assert.Equal("Calculate failed for a non-zero value. Arithmetic operation resulted in an overflow.", cth.Run("Calculate", 123));
+        var cth = new CalculatorTestHarness(new Calculator());
+        Assert.Equal("Multiply failed for a positive value. Arithmetic operation resulted in an overflow.",
+            cth.Multiply(Int32.MaxValue, Int32.MaxValue));
     }
 
     [Fact /*(Skip = "Remove this Skip property to run this test")*/]
-    public void Call_Run_Calculate_with_nonsense()
+    public void Call_Multiply_with_success()
     {
-        var cth = new CalculatorTestHarness();
-        Assert.Equal(string.Empty, cth.Run("Foo", 123));
+        var cth = new CalculatorTestHarness(new Calculator());
+        Assert.Equal("Multiply succeeded", cth.Multiply(6, 7));
     }
 
-    [Fact /*(Skip = "Remove this Skip property to run this test")*/]
-    public void Call_Run_HandleInt()
-    {
-        var cth = new CalculatorTestHarness();
-        Assert.Equal("HandleInt failure", cth.Run("HandleInt", 123));
-    }
 }

--- a/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptionsTests.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptionsTests.cs
@@ -4,34 +4,34 @@ using Xunit;
 public class UserDefinedExceptionsTests
 {
     [Fact]
-    public void Call_TestMultiplication()
+    public void Call_Multiply()
     {
         var cth = new CalculatorTestHarness(new Calculator());
 
-        Assert.Throws<CalculationException>(() => cth.TestMultiplication(Int32.MaxValue, Int32.MaxValue));
+        Assert.Throws<CalculationException>(() => cth.Multiply(Int32.MaxValue, Int32.MaxValue));
     }
 
-    [Fact /*(Skip = "Remove this Skip property to run this test")*/]
-    public void Call_Multiply_with_negative()
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Call_TestMultiplication_with_negative()
     {
         var cth = new CalculatorTestHarness(new Calculator());
-        Assert.Equal("Multiply failed for a negative value. Arithmetic operation resulted in an overflow.",
-            cth.Multiply(-2, Int32.MaxValue));
+        Assert.Equal("Multiply failed for negative operands. Arithmetic operation resulted in an overflow.",
+            cth.TestMultiplication(-2, -Int32.MaxValue));
     }
 
-    [Fact /*(Skip = "Remove this Skip property to run this test")*/]
-    public void Call_Multiply_with_positive()
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Call_TestMultiplication_with_positive()
     {
         var cth = new CalculatorTestHarness(new Calculator());
-        Assert.Equal("Multiply failed for a positive value. Arithmetic operation resulted in an overflow.",
-            cth.Multiply(Int32.MaxValue, Int32.MaxValue));
+        Assert.Equal("Multiply failed for mixed or positive operands. Arithmetic operation resulted in an overflow.",
+            cth.TestMultiplication(Int32.MaxValue, Int32.MaxValue));
     }
 
-    [Fact /*(Skip = "Remove this Skip property to run this test")*/]
-    public void Call_Multiply_with_success()
+    [Fact(Skip = "Remove this Skip property to run this test")]
+    public void Call_TestMultiplication_with_success()
     {
         var cth = new CalculatorTestHarness(new Calculator());
-        Assert.Equal("Multiply succeeded", cth.Multiply(6, 7));
+        Assert.Equal("Multiply succeeded", cth.TestMultiplication(6, 7));
     }
 
 }

--- a/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptionsTests.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptionsTests.cs
@@ -1,0 +1,40 @@
+using Xunit;
+
+public class UserDefinedExceptionsTests
+{
+    [Fact]
+    public void Call_Calculate()
+    {
+        var cth = new CalculatorTestHarness();
+
+        Assert.Throws<CalculationException>( () => cth.Calculate(123) );
+    }
+
+    [Fact /*(Skip = "Remove this Skip property to run this test")*/]
+    public void Call_Run_Calculate_with_0()
+    {
+        var cth = new CalculatorTestHarness();
+        Assert.Equal("Calculate failed for a zero value. Arithmetic operation resulted in an overflow.", cth.Run("Calculate", 0));
+    }
+
+    [Fact /*(Skip = "Remove this Skip property to run this test")*/]
+    public void Call_Run_Calculate_with_non_0()
+    {
+        var cth = new CalculatorTestHarness();
+        Assert.Equal("Calculate failed for a non-zero value. Arithmetic operation resulted in an overflow.", cth.Run("Calculate", 123));
+    }
+
+    [Fact /*(Skip = "Remove this Skip property to run this test")*/]
+    public void Call_Run_Calculate_with_nonsense()
+    {
+        var cth = new CalculatorTestHarness();
+        Assert.Equal(string.Empty, cth.Run("Foo", 123));
+    }
+
+    [Fact /*(Skip = "Remove this Skip property to run this test")*/]
+    public void Call_Run_HandleInt()
+    {
+        var cth = new CalculatorTestHarness();
+        Assert.Equal("HandleInt failure", cth.Run("HandleInt", 123));
+    }
+}

--- a/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptons.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptons.cs
@@ -1,0 +1,44 @@
+using System;
+
+public class CalculationException_template : Exception
+{
+    private int operand;
+
+    public CalculationException_template(int operand, string message, Exception inner)
+    {
+
+    }
+
+    public int GetOperand()
+    {
+        throw new NotImplementedException($"Please implement the GetOperand() method");
+    }
+}
+
+public class CalculatorTestHarness_template
+{
+    public string Run(string testName, int testValue)
+    {
+        throw new NotImplementedException($"Please implement the Run() method");
+    }
+
+    public void Calculate(int testNum)
+    {
+    }
+}
+
+// Please do not modify the code below.  In a more realistic
+// scenario this would be in a different library and would actually
+// do something meaningful.  This code will always throw
+// a Sysem.OverflowException
+public static class TestHarnessOperations_template
+{
+    public static int HandleInt(int testNum)
+    {
+        int trouble = Int32.MaxValue;
+        checked
+        {
+            return Int32.MaxValue * trouble;
+        }
+    }
+}

--- a/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptons.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptons.cs
@@ -22,12 +22,12 @@ public class CalculatorTestHarness
 
     public string TestMultiplication(int x, int y)
     {
-        throw new NotImplementedException($"Please implement the Multiply() method");
+        throw new NotImplementedException("Please implement the CalculatorTestHarness.TestMultiplication() method");
     }
 
     public void Multiply(int x, int y)
     {
-        throw new NotImplementedException($"Please implement the TestMultiplication() method");
+        throw new NotImplementedException("Please implement the CalculatorTestHarness.Multiply() method");
     }
 }
 

--- a/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptons.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptons.cs
@@ -2,44 +2,45 @@ using System;
 
 public class CalculationException_template : Exception
 {
-    private int operand;
-
-    public CalculationException_template(int operand, string message, Exception inner)
+    public CalculationException_template(int operand1, int operand2, string message, Exception inner) : base(message, inner)
     // TODO: complete the definition of the constructor
     {
-
     }
 
-    public int GetOperand()
-    {
-        throw new NotImplementedException($"Please implement the GetOperand() method");
-    }
+    public int Operand1 { get; }
+    public int Operand2 { get; }
 }
 
 public class CalculatorTestHarness_template
 {
-    public string Run(string testName, int testValue)
+    private Calculator_template calculator;
+
+    public CalculatorTestHarness_template(Calculator_template calculator)
     {
-        throw new NotImplementedException($"Please implement the Run() method");
+        this.calculator = calculator;
     }
 
-    public void Calculate(int testNum)
+    public string Multiply(int x, int y)
     {
+        throw new NotImplementedException($"Please implement the Multiply() method");
+    }
+
+    public void TestMultiplication(int x, int y)
+    {
+        throw new NotImplementedException($"Please implement the TestMultiplication() method");
     }
 }
 
-// Please do not modify the code below.  In a more realistic
-// scenario this would be in a different library and would actually
-// do something meaningful.  This code will always throw
-// a Sysem.OverflowException
-public static class TestHarnessOperations_template
+// Please do not modify the code below.
+// If there is an overflow in the multiplication operation
+// then a System.OverflowException is thrown.
+public class Calculator_template
 {
-    public static int HandleInt(int testNum)
+    public int Multiply(int x, int y)
     {
-        int trouble = Int32.MaxValue;
         checked
         {
-            return Int32.MaxValue * trouble;
+            return x * y;
         }
     }
 }

--- a/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptons.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptons.cs
@@ -2,7 +2,7 @@ using System;
 
 public class CalculationException : Exception
 {
-    public CalculationException(int operand1, int operand2, string message, Exception inner) : base(message, inner)
+    public CalculationException(int operand1, int operand2, string message, Exception inner)
     // TODO: complete the definition of the constructor
     {
     }
@@ -15,26 +15,27 @@ public class CalculatorTestHarness
 {
     private Calculator calculator;
 
-    public CalculatorTestHarness_template(Calculator_template calculator)
+    public CalculatorTestHarness(Calculator calculator)
     {
         this.calculator = calculator;
     }
 
-    public string Multiply(int x, int y)
+    public string TestMultiplication(int x, int y)
     {
         throw new NotImplementedException($"Please implement the Multiply() method");
     }
 
-    public void TestMultiplication(int x, int y)
+    public void Multiply(int x, int y)
     {
         throw new NotImplementedException($"Please implement the TestMultiplication() method");
     }
 }
 
+
 // Please do not modify the code below.
 // If there is an overflow in the multiplication operation
 // then a System.OverflowException is thrown.
-public class Calculator_template
+public class Calculator
 {
     public int Multiply(int x, int y)
     {

--- a/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptons.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptons.cs
@@ -1,8 +1,8 @@
 using System;
 
-public class CalculationException_template : Exception
+public class CalculationException : Exception
 {
-    public CalculationException_template(int operand1, int operand2, string message, Exception inner) : base(message, inner)
+    public CalculationException(int operand1, int operand2, string message, Exception inner) : base(message, inner)
     // TODO: complete the definition of the constructor
     {
     }
@@ -11,9 +11,9 @@ public class CalculationException_template : Exception
     public int Operand2 { get; }
 }
 
-public class CalculatorTestHarness_template
+public class CalculatorTestHarness
 {
-    private Calculator_template calculator;
+    private Calculator calculator;
 
     public CalculatorTestHarness_template(Calculator_template calculator)
     {

--- a/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptons.cs
+++ b/languages/csharp/exercises/concept/user-defined-exceptions/UserDefinedExceptons.cs
@@ -5,6 +5,7 @@ public class CalculationException_template : Exception
     private int operand;
 
     public CalculationException_template(int operand, string message, Exception inner)
+    // TODO: complete the definition of the constructor
     {
 
     }


### PR DESCRIPTION
1.  Please review _UserDefinedExceptions.cs_ as part of your initial review of this draft.
2. @ErikSchierboom I know you are averse to including language features in the test file that are not pre-requisites for the exercise.  We need lambdas in the test file but I don't really want to increase the dependency count.  I did half the Haskell track without really understanding how the test framework worked so I'm not so committed to this principle as you.  However, I am happy to fall into line if necessary.
3. I was in two minds about whether to include less boilerplate in the code provided for `CalculationException` but decided against it on the grounds that it could multiply the number of representations required.  I can't really judge