### PR TITLE
[C#][F#] Remove duplicate datetime format from the appointment scheduler story

### DIFF
--- a/languages/csharp/exercises/concept/datetimes/.docs/instructions.md
+++ b/languages/csharp/exercises/concept/datetimes/.docs/instructions.md
@@ -1,11 +1,10 @@
 In this exercise you'll be working on an appointment scheduler for a beauty salon in New York that opened on September 15th in 2012.
 
-You have four tasks, which will all involve appointment dates. The dates and times will use one of the following four formats:
+You have four tasks, which will all involve appointment dates. The dates and times will use one of the following three formats:
 
 - `"7/25/2019 13:45:00"`
 - `"July 25, 2019 13:45:00"`
 - `"Thursday, July 25, 2019 13:45:00:00"`
-- `"July 25, 2019 13:45:00"`
 
 The tests will automatically set the culture to `en-US` - you don't have to set or specify the culture yourselves.
 

--- a/languages/fsharp/exercises/concept/datetimes/.docs/instructions.md
+++ b/languages/fsharp/exercises/concept/datetimes/.docs/instructions.md
@@ -1,11 +1,10 @@
 In this exercise you'll be working on an appointment scheduler for a beauty salon in New York that opened on September 15th in 2012.
 
-You have four tasks, which will all involve appointment dates. The dates and times will use one of the following four formats:
+You have four tasks, which will all involve appointment dates. The dates and times will use one of the following three formats:
 
 - `"7/25/2019 13:45:00"`
 - `"July 25, 2019 13:45:00"`
 - `"Thursday, July 25, 2019 13:45:00:00"`
-- `"July 25, 2019 13:45:00"`
 
 The tests will automatically set the culture to `en-US` - you don't have to set or specify the culture yourselves.
 

--- a/reference/stories/datetimes.appointment-scheduler.md
+++ b/reference/stories/datetimes.appointment-scheduler.md
@@ -4,12 +4,11 @@
 
 In this exercise you'll be working on an appointment scheduler for a beauty salon in New York that opened on September 15th in 2012.
 
-You have four tasks, which will all involve appointment dates. The dates and times will use one of the following four formats:
+You have four tasks, which will all involve appointment dates. The dates and times will use one of the following three formats:
 
 - `"7/25/2019 13:45:00"`
 - `"July 25, 2019 13:45:00"`
 - `"Thursday, July 25, 2019 13:45:00:00"`
-- `"July 25, 2019 13:45:00"`
 
 The exercise will ensure that the code is executed under the `en-US` culture.
 


### PR DESCRIPTION
As I was reading the story, I noticed it says to handle 4 different formats, but one of them was repeated. In the unit tests in both interpretations, there are only 3 different formats tested.