### PR TITLE
[docs] connect Rust documentation to website

### DIFF
--- a/languages/rust/_sidebar.md
+++ b/languages/rust/_sidebar.md
@@ -1,0 +1,11 @@
+- [Start here](/)
+- Docs
+- [Languages](/languages/README.md)
+  - [Rust](/languages/rust/README.md)
+    - [Exercises](/languages/rust/exercises/README.md)
+    - [Reference](/languages/rust/reference/README.md)
+- Reference
+  - [Concepts](/reference/concepts/README.md)
+  - [Paradigms](/reference/paradigms/README.md)
+  - [Tooling](/reference/tooling/README.md)
+  - [Types](/reference/types/README.md)

--- a/languages/rust/exercises/README.md
+++ b/languages/rust/exercises/README.md
@@ -1,0 +1,9 @@
+# Rust exercises
+
+There are two types of exercises:
+
+- [Concept exercises][concept-exercises] (WIP)
+- [Practice exercises][practice-exercises] (on hold)
+
+[concept-exercises]: ./concept/README.md
+[practice-exercises]: ./practice/README.md

--- a/languages/rust/exercises/practice/README.md
+++ b/languages/rust/exercises/practice/README.md
@@ -1,0 +1,9 @@
+# Rust practice exercises
+
+Practice Exercises are exercises that help one dig a bit deeper into concepts that one has learnt through Concept Exercises.
+
+## To do
+
+Currently, we're not actively working on building practice exercises. This will change once the [concept exercises][exercises-concept] have been built.
+
+[exercises-concept]: ../concept/README.md


### PR DESCRIPTION
You need to add `_sidebar.md` files to relevant directories for them to appear in the [documentation website](https://exercism.github.io/v3/#/). Thanks to @SleeplessByte for pointing that out to me.