### PR TITLE
[C#] Fix invalid exercise name

### DIFF
--- a/languages/csharp/config.json
+++ b/languages/csharp/config.json
@@ -43,7 +43,7 @@
         "prerequisites": ["classes", "conditionals", "numbers", "while-loops"]
       },
       {
-        "slug": "dates",
+        "slug": "datetimes",
         "uuid": "7762d9ec-ca95-4e10-b93c-afd2521787a2",
         "concepts": ["datetimes"],
         "prerequisites": ["classes", "numbers", "strings"]


### PR DESCRIPTION
The slug was out of sync with the directory name (which was the correct name)