### PR TITLE
[Clojure] config.json: add lists, and minor update in doc

### DIFF
--- a/languages/clojure/config.json
+++ b/languages/clojure/config.json
@@ -8,7 +8,7 @@
     "concept": [
       {
         "slug": "lists",
-        "uuid": "where to get this?",
+        "uuid": "0d05620f-3ef9-43aa-8e89-660187e090f3",
         "concepts": ["lists"],
         "prerequisites": []
       }

--- a/languages/clojure/config.json
+++ b/languages/clojure/config.json
@@ -3,18 +3,16 @@
   "active": true,
   "blurb": "a JVM hosted functional programming language.",
   "version": 3,
-  "online_editor": {
-    "indent_style": "space",
-    "indent_size": 2
-  },
+  "online_editor": { "indent_style": "space", "indent_size": 2 },
   "exercises": {
     "concept": [
-        {
-            "slug": "lists",
-            "uuid": "where to get this?",
-            "concepts": ["lists"],
-            "prerequisites": [""]
-        }],
+      {
+        "slug": "lists",
+        "uuid": "where to get this?",
+        "concepts": ["lists"],
+        "prerequisites": []
+      }
+    ],
     "practice": []
   }
 }

--- a/languages/clojure/config.json
+++ b/languages/clojure/config.json
@@ -8,7 +8,13 @@
     "indent_size": 2
   },
   "exercises": {
-    "concept": [],
+    "concept": [
+        {
+            "slug": "lists",
+            "uuid": "where to get this?",
+            "concepts": ["lists"],
+            "prerequisites": [""]
+        }],
     "practice": []
   }
 }

--- a/languages/clojure/exercises/concept/README.md
+++ b/languages/clojure/exercises/concept/README.md
@@ -4,7 +4,7 @@ The concept exercises are based on this [list of concepts][reference-shared].
 
 ## Implemented exercises
 
-- [List][concept-exercise-list]
+- [Lists][concept-exercise-lists]
 
 ## TODO
 
@@ -15,6 +15,6 @@ To contribute, please find and work on one of the [new exercise issues][issues-n
 [reference-shared]: ../../reference/README.md
 [reference]: ./reference.md
 [concept-exercises]: ./concept/README.md
-[concept-exercise-list]: ./lists/.meta/design.md
+[concept-exercise-lists]: ./lists/.meta/design.md
 [issues-new-exercise]: https://github.com/exercism/v3/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Atrack%2Fclojure+label%3Atype%2Fnew-exercise+label%3Astatus%2Fhelp-wanted
 [issues-improve-exercise]: https://github.com/exercism/v3/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Atrack%2Fclojure+label%3Atype%2Fimprove-exercise+label%3Astatus%2Fhelp-wanted


### PR DESCRIPTION
Added concept lists as per [[Clojure] Missing exercise entries in config.json · Issue #1701 · exercism/v3](https://github.com/exercism/v3/issues/1701)