### PR TITLE
[All] Readiness cleanup in README.md

### DIFF
--- a/languages/bash/README.md
+++ b/languages/bash/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json file document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/bash/README.md
+++ b/languages/bash/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/bash/README.md
+++ b/languages/bash/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/bash/README.md
+++ b/languages/bash/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/c/README.md
+++ b/languages/c/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/c/README.md
+++ b/languages/c/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/c/README.md
+++ b/languages/c/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/c/README.md
+++ b/languages/c/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/clojure/README.md
+++ b/languages/clojure/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/clojure/README.md
+++ b/languages/clojure/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/clojure/README.md
+++ b/languages/clojure/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/clojure/README.md
+++ b/languages/clojure/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/coffeescript/README.md
+++ b/languages/coffeescript/README.md
@@ -27,7 +27,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/coffeescript/README.md
+++ b/languages/coffeescript/README.md
@@ -24,15 +24,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/coffeescript/README.md
+++ b/languages/coffeescript/README.md
@@ -33,7 +33,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/coffeescript/README.md
+++ b/languages/coffeescript/README.md
@@ -27,7 +27,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/common-lisp/README.md
+++ b/languages/common-lisp/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/common-lisp/README.md
+++ b/languages/common-lisp/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/common-lisp/README.md
+++ b/languages/common-lisp/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/common-lisp/README.md
+++ b/languages/common-lisp/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/cpp/README.md
+++ b/languages/cpp/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/cpp/README.md
+++ b/languages/cpp/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/cpp/README.md
+++ b/languages/cpp/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/cpp/README.md
+++ b/languages/cpp/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/csharp/README.md
+++ b/languages/csharp/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/csharp/README.md
+++ b/languages/csharp/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/csharp/README.md
+++ b/languages/csharp/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/csharp/README.md
+++ b/languages/csharp/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/dart/README.md
+++ b/languages/dart/README.md
@@ -27,7 +27,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/dart/README.md
+++ b/languages/dart/README.md
@@ -24,15 +24,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/dart/README.md
+++ b/languages/dart/README.md
@@ -33,7 +33,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/dart/README.md
+++ b/languages/dart/README.md
@@ -27,7 +27,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/delphi/README.md
+++ b/languages/delphi/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/delphi/README.md
+++ b/languages/delphi/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/delphi/README.md
+++ b/languages/delphi/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/delphi/README.md
+++ b/languages/delphi/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/elixir/README.md
+++ b/languages/elixir/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/elixir/README.md
+++ b/languages/elixir/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/elixir/README.md
+++ b/languages/elixir/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/elixir/README.md
+++ b/languages/elixir/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [x] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/elm/README.md
+++ b/languages/elm/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/elm/README.md
+++ b/languages/elm/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/elm/README.md
+++ b/languages/elm/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/elm/README.md
+++ b/languages/elm/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/emacs-lisp/README.md
+++ b/languages/emacs-lisp/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/emacs-lisp/README.md
+++ b/languages/emacs-lisp/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/emacs-lisp/README.md
+++ b/languages/emacs-lisp/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/emacs-lisp/README.md
+++ b/languages/emacs-lisp/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/erlang/README.md
+++ b/languages/erlang/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/erlang/README.md
+++ b/languages/erlang/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/erlang/README.md
+++ b/languages/erlang/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/erlang/README.md
+++ b/languages/erlang/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/factor/README.md
+++ b/languages/factor/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/factor/README.md
+++ b/languages/factor/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/factor/README.md
+++ b/languages/factor/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/factor/README.md
+++ b/languages/factor/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/fsharp/README.md
+++ b/languages/fsharp/README.md
@@ -27,7 +27,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [x] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/fsharp/README.md
+++ b/languages/fsharp/README.md
@@ -33,7 +33,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/fsharp/README.md
+++ b/languages/fsharp/README.md
@@ -24,15 +24,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/fsharp/README.md
+++ b/languages/fsharp/README.md
@@ -27,7 +27,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/go/README.md
+++ b/languages/go/README.md
@@ -46,7 +46,6 @@ Before launch, we need all the following parts to be completed:
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
     - see [exercise issue](https://github.com/exercism/v3/issues/212) for status on the individual concept exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### [Representer](https://github.com/exercism/automated-analysis/blob/master/docs/representers/introduction.md)
 

--- a/languages/go/README.md
+++ b/languages/go/README.md
@@ -39,7 +39,7 @@ Before launch, we need all the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/go/README.md
+++ b/languages/go/README.md
@@ -36,16 +36,21 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
-    - see [exercise issue](https://github.com/exercism/v3/issues/212) for status on the individual concept exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
+  - see [exercise issue](https://github.com/exercism/v3/issues/212) for status on the individual concept exercises
 
 ### [Representer](https://github.com/exercism/automated-analysis/blob/master/docs/representers/introduction.md)
 

--- a/languages/go/README.md
+++ b/languages/go/README.md
@@ -39,7 +39,7 @@ Before launch, we need all the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/haskell/README.md
+++ b/languages/haskell/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/haskell/README.md
+++ b/languages/haskell/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/haskell/README.md
+++ b/languages/haskell/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/haskell/README.md
+++ b/languages/haskell/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/j/README.md
+++ b/languages/j/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/j/README.md
+++ b/languages/j/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/j/README.md
+++ b/languages/j/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/j/README.md
+++ b/languages/j/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/java/README.md
+++ b/languages/java/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/java/README.md
+++ b/languages/java/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/java/README.md
+++ b/languages/java/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/java/README.md
+++ b/languages/java/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/javascript/README.md
+++ b/languages/javascript/README.md
@@ -38,7 +38,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/javascript/README.md
+++ b/languages/javascript/README.md
@@ -35,15 +35,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/javascript/README.md
+++ b/languages/javascript/README.md
@@ -38,7 +38,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/javascript/README.md
+++ b/languages/javascript/README.md
@@ -44,7 +44,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/julia/README.md
+++ b/languages/julia/README.md
@@ -29,7 +29,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/julia/README.md
+++ b/languages/julia/README.md
@@ -26,15 +26,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/julia/README.md
+++ b/languages/julia/README.md
@@ -29,7 +29,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/julia/README.md
+++ b/languages/julia/README.md
@@ -35,7 +35,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/kotlin/README.md
+++ b/languages/kotlin/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/kotlin/README.md
+++ b/languages/kotlin/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/kotlin/README.md
+++ b/languages/kotlin/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/kotlin/README.md
+++ b/languages/kotlin/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/nim/README.md
+++ b/languages/nim/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/nim/README.md
+++ b/languages/nim/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/nim/README.md
+++ b/languages/nim/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/nim/README.md
+++ b/languages/nim/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/ocaml/README.md
+++ b/languages/ocaml/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/ocaml/README.md
+++ b/languages/ocaml/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/ocaml/README.md
+++ b/languages/ocaml/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/ocaml/README.md
+++ b/languages/ocaml/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/perl5/README.md
+++ b/languages/perl5/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/perl5/README.md
+++ b/languages/perl5/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/perl5/README.md
+++ b/languages/perl5/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/perl5/README.md
+++ b/languages/perl5/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/purescript/README.md
+++ b/languages/purescript/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/purescript/README.md
+++ b/languages/purescript/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/purescript/README.md
+++ b/languages/purescript/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/purescript/README.md
+++ b/languages/purescript/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/python/README.md
+++ b/languages/python/README.md
@@ -27,7 +27,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/python/README.md
+++ b/languages/python/README.md
@@ -33,7 +33,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/python/README.md
+++ b/languages/python/README.md
@@ -24,15 +24,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/python/README.md
+++ b/languages/python/README.md
@@ -27,7 +27,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/r/README.md
+++ b/languages/r/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/r/README.md
+++ b/languages/r/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/r/README.md
+++ b/languages/r/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/r/README.md
+++ b/languages/r/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/racket/README.md
+++ b/languages/racket/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/racket/README.md
+++ b/languages/racket/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/racket/README.md
+++ b/languages/racket/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/racket/README.md
+++ b/languages/racket/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/raku/README.md
+++ b/languages/raku/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/raku/README.md
+++ b/languages/raku/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/raku/README.md
+++ b/languages/raku/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/raku/README.md
+++ b/languages/raku/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/reasonml/README.md
+++ b/languages/reasonml/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/reasonml/README.md
+++ b/languages/reasonml/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/reasonml/README.md
+++ b/languages/reasonml/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/reasonml/README.md
+++ b/languages/reasonml/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/ruby/README.md
+++ b/languages/ruby/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/ruby/README.md
+++ b/languages/ruby/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/ruby/README.md
+++ b/languages/ruby/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/ruby/README.md
+++ b/languages/ruby/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/rust/README.md
+++ b/languages/rust/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/rust/README.md
+++ b/languages/rust/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/rust/README.md
+++ b/languages/rust/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/rust/README.md
+++ b/languages/rust/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [x] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/scala/README.md
+++ b/languages/scala/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/scala/README.md
+++ b/languages/scala/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/scala/README.md
+++ b/languages/scala/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/scala/README.md
+++ b/languages/scala/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/scheme/README.md
+++ b/languages/scheme/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/scheme/README.md
+++ b/languages/scheme/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/scheme/README.md
+++ b/languages/scheme/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/scheme/README.md
+++ b/languages/scheme/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/swift/README.md
+++ b/languages/swift/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/swift/README.md
+++ b/languages/swift/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [x] Added `version` key
-  - [x] Added online editor settings
-    - [x] Added `indent_style`
-    - [x] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [x] Added `version` key
+- [x] Added online editor settings
+  - [x] Added `indent_style`
+  - [x] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/swift/README.md
+++ b/languages/swift/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [x] Added `version` key
   - [x] Added online editor settings
     - [x] Added `indent_style`

--- a/languages/swift/README.md
+++ b/languages/swift/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [x] Added `indent_style`
     - [x] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/typescript/README.md
+++ b/languages/typescript/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/typescript/README.md
+++ b/languages/typescript/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/typescript/README.md
+++ b/languages/typescript/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/typescript/README.md
+++ b/languages/typescript/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/x86-64-assembly/README.md
+++ b/languages/x86-64-assembly/README.md
@@ -23,15 +23,20 @@ Before we publicize requesting contribution for this language, the following ste
 
 Before launch, we need all of the following parts to be completed:
 
-### Track Structure
+### config.json
 
-- [ ] Implemented 20+ Concept Exercises
-- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
-  - [ ] Added `version` key
-  - [ ] Added online editor settings
-    - [ ] Added `indent_style`
-    - [ ] Added `indent_size`
-  - [ ] Added Concept Exercises
+- [ ] Added `version` key
+- [ ] Added online editor settings
+  - [ ] Added `indent_style`
+  - [ ] Added `indent_size`
+- [ ] Convert the `exercises` array to an object
+- [ ] Remove the `foregone` property
+
+See the [migrating your config.json files document](../../docs/maintainers/migrating-your-config-json-files.md) for more information.
+
+### Concept Exercises
+
+- [ ] Added 20+ Concept Exercises
 
 ### Representer
 

--- a/languages/x86-64-assembly/README.md
+++ b/languages/x86-64-assembly/README.md
@@ -32,7 +32,6 @@ Before launch, we need all of the following parts to be completed:
     - [ ] Added `indent_style`
     - [ ] Added `indent_size`
   - [ ] Added Concept Exercises
-  - [ ] Added Concepts for all Practice Exercises
 
 ### Representer
 

--- a/languages/x86-64-assembly/README.md
+++ b/languages/x86-64-assembly/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Migrated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`

--- a/languages/x86-64-assembly/README.md
+++ b/languages/x86-64-assembly/README.md
@@ -26,7 +26,7 @@ Before launch, we need all of the following parts to be completed:
 ### Track Structure
 
 - [ ] Implemented 20+ Concept Exercises
-- [ ] [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
+- [Updated `config.json`](../../docs/maintainers/migrating-your-config-json-files.md)
   - [ ] Added `version` key
   - [ ] Added online editor settings
     - [ ] Added `indent_style`


### PR DESCRIPTION
As discussed in #1573, there are some minor issues with the readiness list in the `README.md` files. This PR aims to fix those:

- Move the Concept Exercises related checkbox into a separate section
- Not have the migrate config.json entry be checkable
- Add the missing steps from the migration
- Remove the Practice Exercises checkbox as we haven't finalized what needs to be done there

Closes #1573