### PR TITLE
[CI] Use SSH to push summary branches

### DIFF
--- a/.github/workflows/stories-summary.yml
+++ b/.github/workflows/stories-summary.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: 'Checkout code'
         uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: 'Install .NET core'
         uses: actions/setup-dotnet@v1


### PR DESCRIPTION
**I haven't tested this but a PR was quicker than writing an issue**

---

The summary PRs don't trigger required CI runs. Pushing via SSH using the deploy key should trigger them, as it does with `/format`. Since this only runs on master, we don't have to worry about forks.

See also https://github.com/actions/checkout#usage