### PR TITLE
[CI] Allow skipping CI

### DIFF
--- a/.github/workflows/julia-exercise-ci.yml
+++ b/.github/workflows/julia-exercise-ci.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   test:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/valid-files.yml
+++ b/.github/workflows/valid-files.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   max-file-size:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
 
     steps:
@@ -29,6 +30,7 @@ jobs:
           done
 
   valid-filenames:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/valid-links.yml
+++ b/.github/workflows/valid-links.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   verify-links:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/verify-code-formatting.yml
+++ b/.github/workflows/verify-code-formatting.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   verify-code-formatting:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: [ubuntu-latest]
     steps:
       - name: 'Checkout code'

--- a/.github/workflows/verify-csharp-formatting.yml
+++ b/.github/workflows/verify-csharp-formatting.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   verify-csharp-formatting:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: [ubuntu-latest]
     steps:
       - name: 'Checkout code'


### PR DESCRIPTION
There's no point in wasting resources and getting spammed with failed build notifications if you know your PR won't pass them yet, e.g. when it's a very early draft PR like #1825.

This will check the commit message for `[skip ci]` and skip all builds.

---

Source for the command: https://github.community/t/github-actions-does-not-respect-skip-ci/17325/9

---

~Still need to test it on a fork.~ Seems to work, based on the builds in this PR.