### PR TITLE
[Docs] begin the Rust track's merging guidelines document

### DIFF
--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -4,7 +4,7 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 
 ## general principles
 
-- we strive to accept _all_ contributions even when **not** perfect.
+- we strive to accept _all_ contributions, bringing them to a high standard of quality through collaborative, iterative review
   - We adopt this principle of optimistic merging / Google engineering's code review handbook. See our [original discussion](https://github.com/exercism/v3/discussions/1725#discussion-7438) for appropriate sources.
 - One other maintainer should review a contributor's pull request
 - At least one other maintainer should approve a pull request before merging it into the development branch

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -22,12 +22,12 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 ### the workflow
 
 1. Contributors start by opening a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) with their changes
-   2. Our track follows broader exercism community here. Using the draft feature signals the work is ready for high-level review.
-2. One other maintainer shall review the contribution and provide feedback.
-3. The contributor shall address essential feedback as part of the pull request.
-4. The reviewer shall create a GitHub issue for tangential feedback not addressed in the original pull request.
-   6. The reviewer will lessen the contributor workload and preserve momentum by taking this step.
-5. The maintainer shall review the feedback and either:
-   8. approve
-   9. request additional changes. At this point, the process returns to step 3.
-6. Upon approval, the contributor shall merge their pull request.
+   1. Our track follows broader exercism community here. Using the draft feature signals the work is ready for high-level review.
+1. One other maintainer shall review the contribution and provide feedback.
+1. The contributor shall address essential feedback as part of the pull request.
+1. The reviewer shall create a GitHub issue for tangential feedback not addressed in the original pull request.
+   1. The reviewer will lessen the contributor workload and preserve momentum by taking this step.
+1. The maintainer shall review the feedback and either:
+   1. approve
+   1. request additional changes. At this point, the process returns to step 3.
+1. Upon approval, the contributor shall merge their pull request.

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -7,8 +7,8 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 - we strive to accept _all_ contributions
   - We'll bring contributions to a high standard of quality through collaborative, iterative review.
   - We adopt a pessimistic merging approach. Think of maintainer reviews like the Rust compiler's feedback. The amount of feedback can feel overwhelming and frustrating. But we'll work with you to get it over the finish line! So keep up the good work.
-- One other maintainer should review a contributor's pull request.
-- At least one other maintainer should approve a pull request before merging it into the development branch.
+- Every pull request must have at least 1 "Approve", and no "Request Changes", from a track maintainer before it can be merged.
+- No maintainer can approve their own PR.
 
 ## pull request workflow
 

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -16,7 +16,7 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 
 | Term               |                                                                                               Meaning |
 | ------------------ | ----------------------------------------------------------------------------------------------------: |
-| Contributor        |                                                                 Anyone adding a new concept exercise. |
+| Contributor        |                                                                 Anyone submitting a pull request. |
 | Maintainer         |         Anyone who belongs to the [@exercism/rust team](https://github.com/orgs/exercism/teams/rust). |
 | development branch | The [v3](https://github.com/exercism/v3) repository's default development branch. Currently `master`. |
 

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -16,7 +16,7 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 
 | Term               |                                                                                               Meaning |
 | ------------------ | ----------------------------------------------------------------------------------------------------: |
-| Contributor        |                                                                 Anyone submitting a pull request. |
+| Contributor        |                                                                     Anyone submitting a pull request. |
 | Maintainer         |         Anyone who belongs to the [@exercism/rust team](https://github.com/orgs/exercism/teams/rust). |
 | development branch | The [v3](https://github.com/exercism/v3) repository's default development branch. Currently `master`. |
 

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -22,8 +22,9 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 
 ### the workflow
 
-1. Contributors start by opening a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) with their changes
-   1. Our track follows broader exercism community here. Using the draft feature signals the work is ready for high-level review.
+1. Contributors start by opening a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) or a complete pull request with their changes
+   1. Using the draft feature signals the work is ready for high-level review, but that details may currently be unimplemented, incomplete, or wrong.
+   1. After an unspecified number of iterations of steps 2-3, the contributor marks the PR as ready for review.
 1. One other maintainer shall review the contribution and provide feedback.
 1. The contributor shall address _all_ maintainer feedback as part of the pull request.
    1. Maintainers shall consider using GitHub's suggestion feature for nitpick or cut-and-dry changes.

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -16,8 +16,8 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 
 | Term               |                                                                                               Meaning |
 | ------------------ | ----------------------------------------------------------------------------------------------------: |
-| Contributor        |                                                                  Anyone adding a new concept exercise. |
-| Maintainer         |          Anyone who belongs to the [@exercism/rust team](https://github.com/orgs/exercism/teams/rust). |
+| Contributor        |                                                                 Anyone adding a new concept exercise. |
+| Maintainer         |         Anyone who belongs to the [@exercism/rust team](https://github.com/orgs/exercism/teams/rust). |
 | development branch | The [v3](https://github.com/exercism/v3) repository's default development branch. Currently `master`. |
 
 ### the workflow
@@ -25,7 +25,7 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 1. Contributors start by opening a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) with their changes
    1. Our track follows broader exercism community here. Using the draft feature signals the work is ready for high-level review.
 1. One other maintainer shall review the contribution and provide feedback.
-1. The contributor shall address *all* maintainer feedback as part of the pull request.
+1. The contributor shall address _all_ maintainer feedback as part of the pull request.
    1. Maintainers shall consider using GitHub's suggestion feature for nitpick or cut-and-dry changes.
 1. The maintainer shall review the feedback and either:
    1. approve

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -27,6 +27,7 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 1. One other maintainer shall review the contribution and provide feedback.
 1. The contributor shall address _all_ maintainer feedback as part of the pull request.
    1. Maintainers shall consider using GitHub's suggestion feature for nitpick or cut-and-dry changes.
+   1. Pushback is encouraged when a contributor believes that they are right and a maintainer is wrong about a feedback item. "Addressing" a piece of feedback is not synonymous with slavishly implementing it.
 1. The maintainer shall review the feedback and either:
    1. approve
    1. request additional changes. At this point, the process returns to step 3.

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -7,7 +7,7 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 - we strive to accept _all_ contributions
   - We'll bring contributions to a high standard of quality through collaborative, iterative review.
   - We adopt a pessimistic merging approach. Think of maintainer reviews like the Rust compiler's feedback. The amount of feedback can feel overwhelming and frustrating. But we'll work with you to get it over the finish line! So keep up the good work.
-- Every pull request must have at least 1 "Approve", and no "Request Changes", from a track maintainer before it can be merged.
+- Every pull request must have at least one "Approval", and no "Request Changes", from a track maintainer before it can be merged.
 - No maintainer can approve their own PR.
 
 ## pull request workflow

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -3,28 +3,31 @@
 The Rust track maintainers [have decided](https://github.com/exercism/v3/discussions/1725#discussion-7438) to write down our merging strategy to communicate expectations and encourage quality contributions.
 
 ## general principles
-- we strive to accept *all* contributions even when **not** perfect.
-    - We adopt this principle of optimistic merging / Google engineering's code review handbook. See our [original discussion](https://github.com/exercism/v3/discussions/1725#discussion-7438) for appropriate sources.
+
+- we strive to accept _all_ contributions even when **not** perfect.
+  - We adopt this principle of optimistic merging / Google engineering's code review handbook. See our [original discussion](https://github.com/exercism/v3/discussions/1725#discussion-7438) for appropriate sources.
 - One other maintainer should review a contributor's pull request
 - At least one other maintainer should approve a pull request before merging it into the development branch
 
 ## pull request workflow
+
 ### definitions
-| Term        |                                       Meaning |
-|-------------|----------------------------------------------:|
-| Contributor |          anyone adding a new concept exercise |
-| Maintainer  | Anyone who belongs to the [@exercism/rust team](https://github.com/orgs/exercism/teams/rust) |
-| development branch |          the [v3](https://github.com/exercism/v3) repository's default development branch. Currently `master`. |
+
+| Term               |                                                                                               Meaning |
+| ------------------ | ----------------------------------------------------------------------------------------------------: |
+| Contributor        |                                                                  anyone adding a new concept exercise |
+| Maintainer         |          Anyone who belongs to the [@exercism/rust team](https://github.com/orgs/exercism/teams/rust) |
+| development branch | the [v3](https://github.com/exercism/v3) repository's default development branch. Currently `master`. |
 
 ### the workflow
-1. Contributors start by opening a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) with their changes
-    2. Our track follows broader exercism community here. Using the draft feature signals the work is ready for high-level review.
-3.  One other maintainer shall review the contribution and provide feedback.
-4.  The contributor shall address essential feedback as part of the pull request.
-5.  The reviewer shall create a GitHub issue for tangential feedback not addressed in the original pull request.
-    6.  The reviewer will lessen the contributor workload and preserve momentum by taking this step.
-7. The maintainer shall review the feedback and either:
-    8. approve
-    9. request additional changes. At this point, the process returns to step 3.
-10. Upon approval, the contributor shall merge their pull request.
 
+1. Contributors start by opening a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) with their changes
+   2. Our track follows broader exercism community here. Using the draft feature signals the work is ready for high-level review.
+2. One other maintainer shall review the contribution and provide feedback.
+3. The contributor shall address essential feedback as part of the pull request.
+4. The reviewer shall create a GitHub issue for tangential feedback not addressed in the original pull request.
+   6. The reviewer will lessen the contributor workload and preserve momentum by taking this step.
+5. The maintainer shall review the feedback and either:
+   8. approve
+   9. request additional changes. At this point, the process returns to step 3.
+6. Upon approval, the contributor shall merge their pull request.

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -4,10 +4,10 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 
 ## general principles
 
-- we strive to accept _all_ contributions, bringing them to a high standard of quality through collaborative, iterative review
-  - We adopt this principle of optimistic merging / Google engineering's code review handbook. See our [original discussion](https://github.com/exercism/v3/discussions/1725#discussion-7438) for appropriate sources.
-- One other maintainer should review a contributor's pull request
-- At least one other maintainer should approve a pull request before merging it into the development branch
+- we strive to accept _all_ contributions, bringing them to a high standard of quality through collaborative, iterative review.
+  - We adopt a pessimistic merging approach. Think of maintainer reviews like the Rust compiler's feedback. The amount of feedback can feel overwhelming and frustrating. But we'll work with you to get it over the finish line! So keep up the good work.
+- One other maintainer should review a contributor's pull request.
+- At least one other maintainer should approve a pull request before merging it into the development branch.
 
 ## pull request workflow
 
@@ -24,9 +24,8 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 1. Contributors start by opening a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) with their changes
    1. Our track follows broader exercism community here. Using the draft feature signals the work is ready for high-level review.
 1. One other maintainer shall review the contribution and provide feedback.
-1. The contributor shall address essential feedback as part of the pull request.
-1. The reviewer shall create a GitHub issue for tangential feedback not addressed in the original pull request.
-   1. The reviewer will lessen the contributor workload and preserve momentum by taking this step.
+1. The contributor shall address *all* maintainer feedback as part of the pull request.
+   1. Maintainers shall consider using GitHub's suggestion feature for nitpick or cut-and-dry changes.
 1. The maintainer shall review the feedback and either:
    1. approve
    1. request additional changes. At this point, the process returns to step 3.

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -1,0 +1,30 @@
+# merging strategy
+
+The Rust track maintainers [have decided](https://github.com/exercism/v3/discussions/1725#discussion-7438) to write down our merging strategy to communicate expectations and encourage quality contributions.
+
+## general principles
+- we strive to accept *all* contributions even when **not** perfect.
+    - We adopt this principle of optimistic merging / Google engineering's code review handbook. See our [original discussion](https://github.com/exercism/v3/discussions/1725#discussion-7438) for appropriate sources.
+- One other maintainer should review a contributor's pull request
+- At least one other maintainer should approve a pull request before merging it into the development branch
+
+## pull request workflow
+### definitions
+| Term        |                                       Meaning |
+|-------------|----------------------------------------------:|
+| Contributor |          anyone adding a new concept exercise |
+| Maintainer  | Anyone who belongs to the [@exercism/rust team](https://github.com/orgs/exercism/teams/rust) |
+| development branch |          the [v3](https://github.com/exercism/v3) repository's default development branch. Currently `master`. |
+
+### the workflow
+1. Contributors start by opening a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) with their changes
+    2. Our track follows broader exercism community here. Using the draft feature signals the work is ready for high-level review.
+3.  One other maintainer shall review the contribution and provide feedback.
+4.  The contributor shall address essential feedback as part of the pull request.
+5.  The reviewer shall create a GitHub issue for tangential feedback not addressed in the original pull request.
+    6.  The reviewer will lessen the contributor workload and preserve momentum by taking this step.
+7. The maintainer shall review the feedback and either:
+    8. approve
+    9. request additional changes. At this point, the process returns to step 3.
+10. Upon approval, the contributor shall merge their pull request.
+

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -4,7 +4,8 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 
 ## general principles
 
-- we strive to accept _all_ contributions, bringing them to a high standard of quality through collaborative, iterative review.
+- we strive to accept _all_ contributions
+  - We'll bring contributions to a high standard of quality through collaborative, iterative review.
   - We adopt a pessimistic merging approach. Think of maintainer reviews like the Rust compiler's feedback. The amount of feedback can feel overwhelming and frustrating. But we'll work with you to get it over the finish line! So keep up the good work.
 - One other maintainer should review a contributor's pull request.
 - At least one other maintainer should approve a pull request before merging it into the development branch.

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -15,9 +15,9 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 
 | Term               |                                                                                               Meaning |
 | ------------------ | ----------------------------------------------------------------------------------------------------: |
-| Contributor        |                                                                  anyone adding a new concept exercise |
-| Maintainer         |          Anyone who belongs to the [@exercism/rust team](https://github.com/orgs/exercism/teams/rust) |
-| development branch | the [v3](https://github.com/exercism/v3) repository's default development branch. Currently `master`. |
+| Contributor        |                                                                  Anyone adding a new concept exercise. |
+| Maintainer         |          Anyone who belongs to the [@exercism/rust team](https://github.com/orgs/exercism/teams/rust). |
+| development branch | The [v3](https://github.com/exercism/v3) repository's default development branch. Currently `master`. |
 
 ### the workflow
 
@@ -30,4 +30,5 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 1. The maintainer shall review the feedback and either:
    1. approve
    1. request additional changes. At this point, the process returns to step 3.
-1. Upon approval, the contributor shall merge their pull request.
+1. Upon approval, a maintainer shall merge their pull request.
+   1. Maintainers shall merge their own pull requests. Since contributors are not necessarily maintainers, a maintainer must preform this step.

--- a/languages/rust/reference/merge-strategy.md
+++ b/languages/rust/reference/merge-strategy.md
@@ -8,7 +8,7 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
   - We'll bring contributions to a high standard of quality through collaborative, iterative review.
   - We adopt a pessimistic merging approach. Think of maintainer reviews like the Rust compiler's feedback. The amount of feedback can feel overwhelming and frustrating. But we'll work with you to get it over the finish line! So keep up the good work.
 - Every pull request must have at least one "Approval", and no "Request Changes", from a track maintainer before it can be merged.
-- No maintainer can approve their own PR.
+- No maintainer can approve their own pull request.
 
 ## pull request workflow
 
@@ -24,7 +24,7 @@ The Rust track maintainers [have decided](https://github.com/exercism/v3/discuss
 
 1. Contributors start by opening a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) or a complete pull request with their changes
    1. Using the draft feature signals the work is ready for high-level review, but that details may currently be unimplemented, incomplete, or wrong.
-   1. After an unspecified number of iterations of steps 2-3, the contributor marks the PR as ready for review.
+   1. After an unspecified number of iterations of steps 2-3, the contributor marks the pull request as ready for review.
 1. One other maintainer shall review the contribution and provide feedback.
 1. The contributor shall address _all_ maintainer feedback as part of the pull request.
    1. Maintainers shall consider using GitHub's suggestion feature for nitpick or cut-and-dry changes.


### PR DESCRIPTION
~~See #1725 for the backstory.~~

@coriolinus and I met 2 weeks ago to clarify our approach to a merge policy.
We decided to proceed as follows:
1. write down our current Pessimistic Merging policy
2. propose an Optimistic Merging approach with a bounded duration to increase contribution efficiency before the v3 launch
3. return to a Pessimistic Merging policy upon V3 launch.

I have revised this PR to solve the first step. I'll author a subsequent PR with the OM proposals so we can come to consensus on what that looks like before rushing ahead.