### PR TITLE
[Common Lisp] Add some template contents for .meta/config.json

### DIFF
--- a/languages/common-lisp/bin/generate-scaffolding/template/.meta/config.json
+++ b/languages/common-lisp/bin/generate-scaffolding/template/.meta/config.json
@@ -1,0 +1,10 @@
+{
+  "authors": [
+    {
+      "github_username": "your-user-name",
+      "exercism_username": "your-user-name"
+    }
+  ],
+  "contributors": [],
+  "forked_from": []
+}


### PR DESCRIPTION
The template file for `.meta/config.json` was empty. This PR adds some default contents.