### PR TITLE
[Common Lisp] Remove some angle-brackets left behind in a template file

### DIFF
--- a/languages/common-lisp/bin/generate-scaffolding/template/.meta/example.lisp
+++ b/languages/common-lisp/bin/generate-scaffolding/template/.meta/example.lisp
@@ -1,6 +1,6 @@
-(defpackage <SLUG>
+(defpackage SLUG
   (:use :cl))
 
-(in-package :<SLUG>)
+(in-package :SLUG)
 
 ;;; Use this space to write an example that passes all of the tests


### PR DESCRIPTION
This is a new PR so we can just get it merged quickly