### PR TITLE
Ruby remove booleans from numbers

### DIFF
--- a/languages/ruby/config.json
+++ b/languages/ruby/config.json
@@ -32,7 +32,7 @@
         "slug": "numbers",
         "uuid": "d7108eb2-326c-446d-9140-228e0f220975",
         "concepts": ["numbers", "conditionals"],
-        "prerequisites": ["basics"]
+        "prerequisites": ["booleans"]
       },
       {
         "slug": "floating-point-numbers",

--- a/languages/ruby/exercises/concept/README.md
+++ b/languages/ruby/exercises/concept/README.md
@@ -10,7 +10,7 @@ These are the concept exercises that have currently been implemented, as well as
 | ------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------- |
 | [`strings`][concept-exercise-strings]                               | `strings`                            | -                                                       |
 | [`basics`][concept-exercise-basics]                                 | `basics`                             | -                                                       |
-| [`numbers`][concept-exercise-numbers]                               | `numbers`<br/>`conditionals`         | `basics`<br/>`booleans`                                                |
+| [`numbers`][concept-exercise-numbers]                               | `numbers`<br/>`conditionals`         | `booleans`                                              |
 | [`floating-point-numbers`][concept-exercise-floating-point-numbers] | `floating-point-numbers`<br/>`loops` | `numbers`<br/>`conditionals`                            |
 | [`arrays`][concept-exercise-arrays]                                 | `arrays`<br/>`each-loops`            | `classes`<br/>`chars`<br/>`booleans`<br/>`conditionals` |
 | [`booleans`][concept-exercise-booleans]                             | `booleans`                           | `instance-variables`                                    |

--- a/languages/ruby/exercises/concept/README.md
+++ b/languages/ruby/exercises/concept/README.md
@@ -10,7 +10,7 @@ These are the concept exercises that have currently been implemented, as well as
 | ------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------- |
 | [`strings`][concept-exercise-strings]                               | `strings`                            | -                                                       |
 | [`basics`][concept-exercise-basics]                                 | `basics`                             | -                                                       |
-| [`numbers`][concept-exercise-numbers]                               | `numbers`<br/>`conditionals`         | `basics`                                                |
+| [`numbers`][concept-exercise-numbers]                               | `numbers`<br/>`conditionals`         | `basics`<br/>`booleans`                                                |
 | [`floating-point-numbers`][concept-exercise-floating-point-numbers] | `floating-point-numbers`<br/>`loops` | `numbers`<br/>`conditionals`                            |
 | [`arrays`][concept-exercise-arrays]                                 | `arrays`<br/>`each-loops`            | `classes`<br/>`chars`<br/>`booleans`<br/>`conditionals` |
 | [`booleans`][concept-exercise-booleans]                             | `booleans`                           | `instance-variables`                                    |

--- a/languages/ruby/exercises/concept/numbers/.docs/after.md
+++ b/languages/ruby/exercises/concept/numbers/.docs/after.md
@@ -33,7 +33,7 @@ b.class
 #=> true
 ```
 
-An `if` statement can be used to conditionally execute code. The condition of an `if` statement does not have to be only `true` or `false`. It can be any value. But it's important to know that any value other than `nil` and `false` (_truthy_ values) will be treated as `true`, meaning that the code inside the `if` statement will be executed.
+An `if` statement can be used to conditionally execute code:
 
 ```ruby
 x = 5

--- a/languages/ruby/exercises/concept/numbers/.docs/introduction.md
+++ b/languages/ruby/exercises/concept/numbers/.docs/introduction.md
@@ -20,5 +20,3 @@ else
   # Execute logic in all other cases
 end
 ```
-
-The condition of an `if` statement does not have to be only `true` or `false`. It can be any value. But it's important to know that any value other than `nil` and `false` (_truthy_ values) will be treated as `true`, meaning that the code inside the `if` statement will be executed.

--- a/languages/ruby/exercises/concept/numbers/.meta/config.json
+++ b/languages/ruby/exercises/concept/numbers/.meta/config.json
@@ -5,5 +5,15 @@
       "exercism_username": "dvik1950"
     }
   ],
+  "contributors": [
+    {
+      "github_username": "kotp",
+      "exercism_username": "kotp"
+    },
+    {
+      "github_username": "iHiD",
+      "exercism_username": "iHiD"
+    }
+  ],
   "forked_from": ["csharp/numbers"]
 }

--- a/languages/ruby/exercises/concept/numbers/.meta/design.md
+++ b/languages/ruby/exercises/concept/numbers/.meta/design.md
@@ -26,8 +26,7 @@ The Concepts this exercise unlocks are:
 
 This exercise's prerequisite Concepts are:
 
-- `basics`: know how to define methods.
-- `booleans`: know about `true`/`false` and truthy/falsy values.
+- `booleans`: know about `true`/`false` and truthy/falsey values.
 
 ## Representer
 

--- a/languages/ruby/exercises/concept/numbers/.meta/design.md
+++ b/languages/ruby/exercises/concept/numbers/.meta/design.md
@@ -27,6 +27,7 @@ The Concepts this exercise unlocks are:
 This exercise's prerequisite Concepts are:
 
 - `basics`: know how to define methods.
+- `booleans`: know about `true`/`false` and truthy/falsy values.
 
 ## Representer
 


### PR DESCRIPTION
From https://github.com/exercism/v3/issues/2046:

- Make `booleans` a prerequisite of `numbers` -> Done
- Remove Boolean-content from `numbers`, ensure the content appears in `booleans` -> Done (at least I think so). The content I removed here is covered in the [introduction.md](https://github.com/exercism/v3/blob/master/languages/ruby/exercises/concept/booleans/.docs/introduction.md) of the booleans exercise.

Please let me know if I missed something, thanks.