### PR TITLE
Update to use the array name

### DIFF
--- a/languages/csharp/exercises/concept/arrays/.docs/after.md
+++ b/languages/csharp/exercises/concept/arrays/.docs/after.md
@@ -68,7 +68,7 @@ char[] vowels = new [] { 'a', 'e', 'i', 'o', 'u' };
 foreach (char vowel in vowels)
 {
     // This would result in a compiler error
-    // vowel = 'Y';
+    // vowels = 'Y';
 }
 ```
 


### PR DESCRIPTION
Hi, I am creating a Java version looking into your version :D 
I noted that we need to use the array name to generate the compilation error.