### PR TITLE
[Go] change output formatting in examples comments #2010

### DIFF
--- a/languages/go/exercises/concept/basics/.docs/instructions.md
+++ b/languages/go/exercises/concept/basics/.docs/instructions.md
@@ -8,7 +8,7 @@ Define the `OvenTime()` function that does not take any parameters and returns h
 
 ```go
 OvenTime()
-// => 40
+// Output: 40
 ```
 
 ## 2. Calculate the remaining oven time in minutes
@@ -17,7 +17,7 @@ Define the `RemainingOvenTime()` function that takes the actual minutes the lasa
 
 ```go
 RemainingOvenTime(30)
-// => 10
+// Output: 10
 ```
 
 ## 3. Calculate the preparation time in minutes
@@ -26,7 +26,7 @@ Define the `PreparationTime()` function that takes the number of layers you adde
 
 ```go
 PreparationTime(2)
-// => 4
+// Output: 4
 ```
 
 ## 4. Calculate the elapsed working time in minutes
@@ -35,5 +35,5 @@ Define the `ElapsedTime()` function that takes two parameters: the first paramet
 
 ```go
 ElapsedTime(3, 20)
-// => 26
+// Output: 26
 ```

--- a/languages/go/exercises/concept/booleans/.docs/after.md
+++ b/languages/go/exercises/concept/booleans/.docs/after.md
@@ -3,16 +3,16 @@ Booleans in Go are represented by the `bool` type, which values can be either `t
 Go supports three [boolean operators][logical operators]: `!` (NOT), `&&` (AND), and `||` (OR).
 
 ```go
-true || false // => true
-true && false // => false
-!true // => false
+true || false // Output: true
+true && false // Output: false
+!true // Output: false
 ```
 
 The three boolean operators each have a different [_operator precedence_][operators]. As a consequence, they are evaluated in this order: `!` first, `&&` second, and finally `||`. If you want to 'escape' these rules, you can enclose a boolean expression in parentheses (`()`), as the parentheses have an even higher operator precedence.
 
 ```go
-!true && false   // => false
-!(true && false) // => true
+!true && false   // Output: false
+!(true && false) // Output: true
 ```
 
 [operators]: https://golang.org/ref/spec#Operators

--- a/languages/go/exercises/concept/methods/.docs/instructions.md
+++ b/languages/go/exercises/concept/methods/.docs/instructions.md
@@ -22,7 +22,7 @@ speed := 5
 batteryDrain := 2
 car := NewCar(speed, batteryDrain)
 car.Drive()
-// => Car{speed: 5, batteryDrain: 2, battery: 98, distance: 5}
+// Output: Car{speed: 5, batteryDrain: 2, battery: 98, distance: 5}
 ```
 
 Note: If a car's battery is below its battery drain percentage, you can't drive the car anymore.
@@ -40,7 +40,7 @@ distance := 100
 raceTrack := NewTrack(distance)
 
 car.CanFinish(raceTrack)
-// => true
+// Output: true
 ```
 
 ## 2. Display the distance driven
@@ -53,7 +53,7 @@ batteryDrain := 2
 car := NewCar(speed, batteryDrain)
 
 car.DisplayDistance()
-// => "Driven 0 meters"
+// Output: "Driven 0 meters"
 ```
 
 ## 3. Display the battery percentage
@@ -66,5 +66,5 @@ batteryDrain := 2
 car := NewCar(speed, batteryDrain)
 
 car.DisplayBattery()
-// => "Battery at 100%"
+// Output: "Battery at 100%"
 ```

--- a/languages/go/exercises/concept/slices/.docs/instructions.md
+++ b/languages/go/exercises/concept/slices/.docs/instructions.md
@@ -8,7 +8,7 @@ Return the card at position `index` from the given stack.
 
 ```go
 GetItem([]uint8{1, 2, 4, 1}, 2)
-// Returns: 4
+// Output: 4
 ```
 
 ## 2. Exchange a card in the stack
@@ -20,7 +20,7 @@ Note that this will also change the input slice which is ok.
 index := 2
 new_card := 6
 SetItem([]uint8{1, 2, 4, 1}, index, new_card)
-// Returns: []uint8{1, 2, 6, 1}
+// Output: []uint8{1, 2, 6, 1}
 ```
 
 ## 3. Create a stack of cards
@@ -29,7 +29,7 @@ Create a stack of given `length` and fill it with cards of the given `value`.
 
 ```go
 PrefilledSlice(8, 3)
-// Returns: []int{8, 8, 8}
+// Output: []int{8, 8, 8}
 ```
 
 ## 4. Remove a card from the stack
@@ -38,5 +38,5 @@ Remove the card at position `index` from the stack and return the stack.
 
 ```go
 RemoveItem([]int{3, 2, 6, 4, 8}, 2)
-// Returns: []int{3, 2, 4, 8}
+// Output: []int{3, 2, 4, 8}
 ```

--- a/languages/go/exercises/concept/strings-package/.docs/instructions.md
+++ b/languages/go/exercises/concept/strings-package/.docs/instructions.md
@@ -16,14 +16,14 @@ Implement the `Message` function to return a log line's message:
 
 ```go
 Message("[ERROR]: Invalid operation")
-// Returns: "Invalid operation"
+// Output: "Invalid operation"
 ```
 
 Any leading or trailing white space should be removed:
 
 ```go
 Message("[WARNING]:  Disk almost full\r\n")
-// Returns: "Disk almost full"
+// Output: "Disk almost full"
 ```
 
 ## 2. Get the message length in characters
@@ -32,7 +32,7 @@ Implement the `LogLevel` function to return a log line's message length:
 
 ```go
 Strings.LogLevel("[ERROR]: Invalid operation \n")
-// Returns: 17
+// Output: 17
 ```
 
 ## 3. Get log level from a log line
@@ -41,7 +41,7 @@ Implement the `LogLevel` function to return a log line's log level, which should
 
 ```go
 Strings.LogLevel("[ERROR]: Invalid operation")
-// Returns: "error"
+// Output: "error"
 ```
 
 ## 4. Reformat a log line
@@ -50,5 +50,5 @@ Implement the `Reformat` function that reformats the log line, putting the messa
 
 ```go
 Strings.Reformat("[INFO]: Operation completed")
-// Returns: "Operation completed (info)"
+// Output: "Operation completed (info)"
 ```

--- a/languages/go/exercises/concept/strings/.docs/instructions.md
+++ b/languages/go/exercises/concept/strings/.docs/instructions.md
@@ -10,7 +10,7 @@ Implement the `Welcome` function to return a welcome message using the given nam
 
 ```go
 Welcome("Christiane")
-// Returns:
+// Output:
 // Welcome to my party, Christiane!
 ```
 
@@ -22,7 +22,7 @@ knowledge of every guest's birthday.
 
 ```go
 HappyBirthday("Frank", 58)
-// Returns:
+// Output:
 // Happy birthday Frank! You are now 58 years old!
 ```
 
@@ -34,7 +34,7 @@ was limited to 1 digit.
 
 ```go
 AssignTable("Christiane", 27, "Frank", "on the left", 23.7834298)
-// Returns:
+// Output:
 // Welcome to my party, Christiane!
 // You have been assigned to table 1B. Your table is on the left, exactly 23.8 meters from here.
 // You will be sitting next to Frank.

--- a/languages/go/exercises/concept/structs/.docs/instructions.md
+++ b/languages/go/exercises/concept/structs/.docs/instructions.md
@@ -35,7 +35,7 @@ speed := 5
 batteryDrain := 2
 car := NewCar(speed, batteryDrain)
 car = Drive(car)
-// => Car{speed: 5, batteryDrain: 2, battery: 98, distance: 5}
+// Output: Car{speed: 5, batteryDrain: 2, battery: 98, distance: 5}
 ```
 
 ## 4. Check if a remote control car can finish a race
@@ -51,5 +51,5 @@ distance := 100
 raceTrack := NewTrack(distance)
 
 CanFinish(car, raceTrack)
-// => true
+// Output: true
 ```

--- a/languages/go/exercises/concept/time/.docs/instructions.md
+++ b/languages/go/exercises/concept/time/.docs/instructions.md
@@ -8,7 +8,7 @@ Implement the `Schedule` function to parse a textual representation of an appoin
 
 ```go
 Schedule("7/25/2019 13:45:00")
-// => 2019-07-25 13:45:00 +0000 UTC
+// Output: 2019-07-25 13:45:00 +0000 UTC
 ```
 
 ## 2. Check if an appointment has already passed
@@ -17,7 +17,7 @@ Implement the `HasPassed` function that takes an appointment date and checks if 
 
 ```go
 HasPassed("July 25, 2019 13:45:00")
-// => true
+// Output: true
 ```
 
 ## 3. Check if appointment is in the afternoon
@@ -26,7 +26,7 @@ Implement the `IsAfternoonAppointment` function that takes an appointment date a
 
 ```go
 IsAfternoonAppointment("Thursday, July 25, 2019 13:45:00:00")
-// => true
+// Output: true
 ```
 
 ## 4. Describe the time and date of the appointment
@@ -35,7 +35,7 @@ Implement the `Description` function that takes an appointment date and returns 
 
 ```go
 Description("7/25/2019 13:45:00")
-// => "You have an appointment on Thursday, July 25, 2019, at 13:45."
+// Output: "You have an appointment on Thursday, July 25, 2019, at 13:45."
 ```
 
 ## 5. Return the anniversary date
@@ -44,5 +44,5 @@ Implement the `AnniversaryDate` function that returns this year's anniversary da
 
 ```go
 AnniversaryDate()
-// => 2020-09-15
+// Output: 2020-09-15
 ```


### PR DESCRIPTION
I chose to use `Output:` as formatting. Please let me know if this is alright.