### PR TITLE
[CI] Exclude auto-generated Markdown files from file limit check

### DIFF
--- a/.github/workflows/valid-files.yml
+++ b/.github/workflows/valid-files.yml
@@ -23,8 +23,11 @@ jobs:
           git diff --diff-filter=d --name-only -z origin/master... | while read -r -d '' FILE; do
             # Skip files that are allowed to have larger size
             if [ "$FILE" == "languages/languages.json" ] ||
+               [ "$FILE" == "languages/README.md" ] ||
                [ "$FILE" == "reference/references.json" ] ||
-               [ "$FILE" == "reference/stories/stories.json" ]; then
+               [ "$FILE" == "reference/README.md" ] ||
+               [ "$FILE" == "reference/stories/stories.json" ] ||
+               [ "$FILE" == "reference/stories/README.md" ]; then
                 continue
             fi
 


### PR DESCRIPTION
See #2087 for an example for why this is needed.