### PR TITLE
[Ruby] Normalize naming for method references

### DIFF
--- a/languages/ruby/exercises/concept/basics/lasagna.rb
+++ b/languages/ruby/exercises/concept/basics/lasagna.rb
@@ -1,13 +1,13 @@
 class Lasagna
   def remaining_minutes_in_oven(actual_minutes_in_oven)
-    raise NotImplementedError, 'Please implement the remaining_minutes_in_oven method'
+    raise NotImplementedError, 'Please implement the Lasagna#remaining_minutes_in_oven method'
   end
 
   def preparation_time_in_minutes(layers)
-    raise NotImplementedError, 'Please implement the preparation_time_in_minutes method'
+    raise NotImplementedError, 'Please implement the Lasagna#preparation_time_in_minutes method'
   end
 
   def total_time_in_minutes(number_of_layers:, actual_minutes_in_oven:)
-    raise NotImplementedError, 'Please implement the total_time_in_minutes method'
+    raise NotImplementedError, 'Please implement the Lasagna#total_time_in_minutes method'
   end
 end

--- a/languages/ruby/exercises/concept/booleans/.docs/instructions.md
+++ b/languages/ruby/exercises/concept/booleans/.docs/instructions.md
@@ -2,7 +2,7 @@ Continuing your work with the amusement park, you are tasked with writing some u
 
 ## 1. Check if an attendee has a ride pass
 
-Implement the `pass?` method to return a boolean (`true`/`false`) value based on the presence of a ride pass.
+Implement the `Attendee#pass?` method to return a boolean (`true`/`false`) value based on the presence of a ride pass.
 
 ```ruby
 Attendee.new(100).has_pass?
@@ -11,7 +11,7 @@ Attendee.new(100).has_pass?
 
 ## 2. Check if an attendee fits a ride
 
-Implement the `fits_ride?` method to see if an attendee fits a ride based on their height and the minimum height of required by the ride.
+Implement the `Attendee#fits_ride?` method to see if an attendee fits a ride based on their height and the minimum height of required by the ride.
 
 ```ruby
 Attendee.new(140).fits_ride?(100)
@@ -20,7 +20,7 @@ Attendee.new(140).fits_ride?(100)
 
 ## 3. Check if an attendee is allowed to ride
 
-Implement the `allowed_to_ride?` method to see if an attendee is allowed to go on a ride. The ride's required minimum height is provided as an argument. An attendee must have a ride pass and be able to fit the ride.
+Implement the `Attendee#allowed_to_ride?` method to see if an attendee is allowed to go on a ride. The ride's required minimum height is provided as an argument. An attendee must have a ride pass and be able to fit the ride.
 
 ```ruby
 attendee = Attendee.new(100)

--- a/languages/ruby/exercises/concept/booleans/attendee.rb
+++ b/languages/ruby/exercises/concept/booleans/attendee.rb
@@ -16,14 +16,14 @@ class Attendee
   # Do not edit above methods, add your own methods below.
 
   def pass?
-    raise NotImplementedError, 'Please implement the pass? method'
+    raise NotImplementedError, 'Please implement the Attendee#pass? method'
   end
 
   def fits_ride?(ride_minimum_height)
-    raise NotImplementedError, 'Please implement the fits_ride? method'
+    raise NotImplementedError, 'Please implement the Attendee#fits_ride? method'
   end
 
   def allowed_to_ride?(ride_minimum_height)
-    raise NotImplementedError, 'Please implement the allowed_to_ride? method'
+    raise NotImplementedError, 'Please implement the Attendee#allowed_to_ride? method'
   end
 end

--- a/languages/ruby/exercises/concept/instance-variables/.docs/hints.md
+++ b/languages/ruby/exercises/concept/instance-variables/.docs/hints.md
@@ -26,11 +26,11 @@ About instance variables:
 
 ## 4. Allow people to buy a pass
 
-- Using the `issue_pass!` method, set the instance's state to the argument.
+- Using the `Attendee#issue_pass!` method, set the instance's state to the argument.
 
 ## 4. Revoke the pass
 
-- Using the `revoke_pass!` setter method set the instance's state so that no pass exists.
+- Using the `Attendee#revoke_pass!` setter method set the instance's state so that no pass exists.
 
 [rfb-instance-variables]: http://ruby-for-beginners.rubymonstas.org/writing_classes/instance_variables.html
 [rg-initialize-method]: https://www.rubyguides.com/2019/01/ruby-initialize-method/

--- a/languages/ruby/exercises/concept/instance-variables/.docs/instructions.md
+++ b/languages/ruby/exercises/concept/instance-variables/.docs/instructions.md
@@ -2,7 +2,7 @@ Working with an amusement park, you've been handed a specification to design a s
 
 ## 1. Make new attendees
 
-Implement the `initialize` method of the `Attendee` class, it should take a height (in centimeters) and store it as an instance variable
+Implement the `Attendee#initialize` method of the `Attendee` class, it should take a height (in centimeters) and store it as an instance variable
 
 ```ruby
 Attendee.new(106)
@@ -11,7 +11,7 @@ Attendee.new(106)
 
 ## 2. How tall is the attendee
 
-Implement the `height` getter of the `Attendee` class, it should return the instances height
+Implement the `Attendee#height` getter of the `Attendee` class, it should return the instances height
 
 ```ruby
 Attendee.new(106).height
@@ -20,7 +20,7 @@ Attendee.new(106).height
 
 ## 3. What is the ride pass' id
 
-Not all attendees have bought a ride pass, but we need to know if they have a pass or not. Implement the `pass_id` getter for the `Attendee` class, it should return the instance's pass_id or `nil` if the Attendee doesn't have one.
+Not all attendees have bought a ride pass, but we need to know if they have a pass or not. Implement the `Attendee#pass_id` getter for the `Attendee` class, it should return the instance's pass_id or `nil` if the Attendee doesn't have one.
 
 ```ruby
 Attendee.new(106).pass_id
@@ -29,7 +29,7 @@ Attendee.new(106).pass_id
 
 ## 4. Allow people to buy a pass
 
-Implement `issue_pass!` to mutate the state of the instance, and set the pass id instance varaiable to the argument. It should return the pass id.
+Implement `Attendee#issue_pass!` to mutate the state of the instance, and set the pass id instance varaiable to the argument. It should return the pass id.
 
 ```ruby
 attendee = Attendee.new(106)
@@ -40,7 +40,7 @@ attendee.pass_id
 
 ## 4. Revoke the pass
 
-Some guests break the rules with unsafe behavior, so the park wants to be able to revoke passes. Implement `revoke_pass` to mutate the state of the instance, and set the pass id to `nil`
+Some guests break the rules with unsafe behavior, so the park wants to be able to revoke passes. Implement `Attendee#revoke_pass` to mutate the state of the instance, and set the pass id to `nil`
 
 ```ruby
 attendee = Attendee.new(106)

--- a/languages/ruby/exercises/concept/instance-variables/attendee.rb
+++ b/languages/ruby/exercises/concept/instance-variables/attendee.rb
@@ -1,21 +1,21 @@
 class Attendee
   def initialize(height)
-    raise NotImplementedError, 'Implement the initialize method'
+    raise NotImplementedError, 'Implement the Attendee#initialize method'
   end
 
   def height
-    raise NotImplementedError, 'Implement the height method'
+    raise NotImplementedError, 'Implement the Attendee#height method'
   end
 
   def pass_id
-    raise NotImplementedError, 'Implement the pass_id method'
+    raise NotImplementedError, 'Implement the Attendee#pass_id method'
   end
 
   def issue_pass!(pass_id)
-    raise NotImplementedError, 'Implement the issue_pass! method'
+    raise NotImplementedError, 'Implement the Attendee#issue_pass! method'
   end
 
   def revoke_pass!
-    raise NotImplementedError, 'Implement the revoke_pass! method'
+    raise NotImplementedError, 'Implement the Attendee#revoke_pass! method'
   end
 end


### PR DESCRIPTION
**Issue**: https://github.com/exercism/v3/issues/2055

**Description**
As per the issue description, this PR normalizes the naming for method references to `<CLASS>.<METHOD>` for class methods and `<CLASS>#<METHOD>` for instance methods.