### PR TITLE
[Haskell] Docs: change case of `haskell` directory

### DIFF
--- a/languages/haskell/reference/implementing-a-concept-exercise.md
+++ b/languages/haskell/reference/implementing-a-concept-exercise.md
@@ -29,7 +29,7 @@ The directory structure of a single concept exercise looks like this:
 
 ```
 languages
-└── Haskell
+└── haskell
     └── exercises
         └── concept
             └── <SLUG>


### PR DESCRIPTION
Note: This is not for Hacktoberfest. I was just reading and saw this typo
(although I wouldn't mind it counting. I will probably hit the min with exercise anyways)