### PR TITLE
[CI] Trigger labeler on pull_request_target event

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@5f867a63be70efff62b767459b009290364495eb # 2.2.0
-      continue-on-error: true
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true # Remove labels when matching files are reverted or no longer changed by the PR

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,13 +1,14 @@
 name: "Pull Request Labeler"
 
 on:
-- pull_request
+- pull_request_target
 
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@04aa5dbc72538e0b9194c658a9ad6026b865d039 # 2.1.0
+    - uses: actions/labeler@5f867a63be70efff62b767459b009290364495eb # 2.2.0
       continue-on-error: true
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true # Remove labels when matching files are reverted or no longer changed by the PR


### PR DESCRIPTION
This allows labeler to label PRs from forks.

`pull_request_target` runs workflows within the target repo of a PR rather than the source repo. Since labeler only acts on meta-info of the PR event rather than code included in the PR, this is safe to run.

See also the updated docs: https://github.com/actions/labeler#create-workflow