### PR TITLE
[All] Add concepts section to config.json

### DIFF
--- a/languages/c/config.json
+++ b/languages/c/config.json
@@ -12,5 +12,6 @@
   "exercises": {
     "concept": [],
     "practice": []
-  }
+  },
+  "concepts": []
 }

--- a/languages/clojure/config.json
+++ b/languages/clojure/config.json
@@ -15,5 +15,13 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "33947666-6176-4ab6-825f-08b689c8040d",
+      "slug": "lists",
+      "name": "Lists",
+      "blurb": "TODO: add blurb for lists concept"
+    }
+  ]
 }

--- a/languages/common-lisp/config.json
+++ b/languages/common-lisp/config.json
@@ -230,5 +230,199 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "223d816f-c09e-4269-81fb-69db0c6fb1cd",
+      "slug": "anonymous-functions",
+      "name": "Anonymous Functions",
+      "blurb": "TODO: add blurb for anonymous-functions concept"
+    },
+    {
+      "uuid": "b2a3eef0-eb53-4b1b-bf32-167fd2f7d880",
+      "slug": "arithmetic",
+      "name": "Arithmetic",
+      "blurb": "TODO: add blurb for arithmetic concept"
+    },
+    {
+      "uuid": "9afaa6c5-5c25-4f44-a908-5e0f156f7fb3",
+      "slug": "arrays",
+      "name": "Arrays",
+      "blurb": "TODO: add blurb for arrays concept"
+    },
+    {
+      "uuid": "0dcab94c-b2c3-4c9c-b55e-2fbdff83d8cb",
+      "slug": "assignment",
+      "name": "Assignment",
+      "blurb": "TODO: add blurb for assignment concept"
+    },
+    {
+      "uuid": "3147bf8d-9050-4f1a-b267-25f297fc80d7",
+      "slug": "characters",
+      "name": "Characters",
+      "blurb": "TODO: add blurb for characters concept"
+    },
+    {
+      "uuid": "28e84e05-eafd-4774-abc2-2ea76fc5dced",
+      "slug": "code-as-data",
+      "name": "Code As Data",
+      "blurb": "TODO: add blurb for code-as-data concept"
+    },
+    {
+      "uuid": "477a4d8d-41d1-47a4-96f0-b39caeaee513",
+      "slug": "comments",
+      "name": "Comments",
+      "blurb": "TODO: add blurb for comments concept"
+    },
+    {
+      "uuid": "894a6bcc-5b4c-41d1-bfba-a0ca3b121257",
+      "slug": "conditionals",
+      "name": "Conditionals",
+      "blurb": "TODO: add blurb for conditionals concept"
+    },
+    {
+      "uuid": "9afa389a-17e2-4991-ab48-64be5fc955aa",
+      "slug": "cons",
+      "name": "Cons",
+      "blurb": "TODO: add blurb for cons concept"
+    },
+    {
+      "uuid": "b9f5a5fd-57e9-4003-880b-499206e1554f",
+      "slug": "constants",
+      "name": "Constants",
+      "blurb": "TODO: add blurb for constants concept"
+    },
+    {
+      "uuid": "92231d37-27e3-4692-96d4-ff9822a83132",
+      "slug": "destructuring-assignment",
+      "name": "Destructuring Assignment",
+      "blurb": "TODO: add blurb for destructuring-assignment concept"
+    },
+    {
+      "uuid": "16d4b9d8-0484-463a-9273-e0a89d1842e1",
+      "slug": "enumeration",
+      "name": "Enumeration",
+      "blurb": "TODO: add blurb for enumeration concept"
+    },
+    {
+      "uuid": "80ea7d53-76aa-4e89-9d70-45548181a6eb",
+      "slug": "expressions",
+      "name": "Expressions",
+      "blurb": "TODO: add blurb for expressions concept"
+    },
+    {
+      "uuid": "0d0ae380-7f1f-4ac7-8900-d501afd7a48a",
+      "slug": "floating-point-numbers",
+      "name": "Floating Point Numbers",
+      "blurb": "TODO: add blurb for floating-point-numbers concept"
+    },
+    {
+      "uuid": "a7b463d3-4d7f-4b4a-8a47-28307219541d",
+      "slug": "function-definition",
+      "name": "Function Definition",
+      "blurb": "TODO: add blurb for function-definition concept"
+    },
+    {
+      "uuid": "778561a9-c735-4c26-8d07-1baa71b8f94a",
+      "slug": "hash-tables",
+      "name": "Hash Tables",
+      "blurb": "TODO: add blurb for hash-tables concept"
+    },
+    {
+      "uuid": "0f570f2a-3b77-408e-9bd1-3712b12bcd4a",
+      "slug": "higher-order-functions",
+      "name": "Higher Order Functions",
+      "blurb": "TODO: add blurb for higher-order-functions concept"
+    },
+    {
+      "uuid": "e5fefeda-9e02-48c4-9591-fc8a518d99f2",
+      "slug": "integers",
+      "name": "Integers",
+      "blurb": "TODO: add blurb for integers concept"
+    },
+    {
+      "uuid": "65c600a7-7f6a-428f-9913-d6f127f35234",
+      "slug": "lists",
+      "name": "Lists",
+      "blurb": "TODO: add blurb for lists concept"
+    },
+    {
+      "uuid": "5a6598c3-8d92-4eca-b36e-42ba4b435237",
+      "slug": "loop.basic",
+      "name": "Loop Basic",
+      "blurb": "TODO: add blurb for loop.basic concept"
+    },
+    {
+      "uuid": "eb5772d1-756f-48b3-bbaa-7481e10c2bfe",
+      "slug": "multiple-values",
+      "name": "Multiple Values",
+      "blurb": "TODO: add blurb for multiple-values concept"
+    },
+    {
+      "uuid": "654667dc-547a-4ec9-8e83-d1b3df4bbeba",
+      "slug": "nested-functions",
+      "name": "Nested Functions",
+      "blurb": "TODO: add blurb for nested-functions concept"
+    },
+    {
+      "uuid": "58adfe20-f67b-40df-a68a-4c5e07ab5c21",
+      "slug": "packages",
+      "name": "Packages",
+      "blurb": "TODO: add blurb for packages concept"
+    },
+    {
+      "uuid": "c54d3099-ce89-4745-942a-ab8e1ec00ad3",
+      "slug": "printing",
+      "name": "Printing",
+      "blurb": "TODO: add blurb for printing concept"
+    },
+    {
+      "uuid": "9dc0a29a-6742-43ee-a03d-581dff2c1855",
+      "slug": "recursion",
+      "name": "Recursion",
+      "blurb": "TODO: add blurb for recursion concept"
+    },
+    {
+      "uuid": "c04de4d9-d69f-429f-916f-48ab461112ee",
+      "slug": "sameness",
+      "name": "Sameness",
+      "blurb": "TODO: add blurb for sameness concept"
+    },
+    {
+      "uuid": "5774aac1-e8c6-439f-97ee-27f4febc1b26",
+      "slug": "sets",
+      "name": "Sets",
+      "blurb": "TODO: add blurb for sets concept"
+    },
+    {
+      "uuid": "630eaa07-1239-4548-be46-e695c8a2c73f",
+      "slug": "strings",
+      "name": "Strings",
+      "blurb": "TODO: add blurb for strings concept"
+    },
+    {
+      "uuid": "3d57a337-1bea-4677-923d-39b4fb2c1e7b",
+      "slug": "structures",
+      "name": "Structures",
+      "blurb": "TODO: add blurb for structures concept"
+    },
+    {
+      "uuid": "c9ac82a1-19da-4aff-8184-8727efa67364",
+      "slug": "symbols",
+      "name": "Symbols",
+      "blurb": "TODO: add blurb for symbols concept"
+    },
+    {
+      "uuid": "59de6711-b247-4f06-8030-94633cf16a65",
+      "slug": "truthy-and-falsy",
+      "name": "Truthy And Falsy",
+      "blurb": "TODO: add blurb for truthy-and-falsy concept"
+    },
+    {
+      "uuid": "6e40e924-f9a1-4dce-9d23-44f922e3ba48",
+      "slug": "variables",
+      "name": "Variables",
+      "blurb": "TODO: add blurb for variables concept"
+    }
+  ]
 }

--- a/languages/cpp/config.json
+++ b/languages/cpp/config.json
@@ -18,5 +18,13 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "8d51e52a-95d3-45da-adb0-65bdfe96b875",
+      "slug": "strings",
+      "name": "Strings",
+      "blurb": "TODO: add blurb for strings concept"
+    }
+  ]
 }

--- a/languages/csharp/config.json
+++ b/languages/csharp/config.json
@@ -374,5 +374,445 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "834bdd99-7b3a-48e4-af57-8184c3b2803c",
+      "slug": "accessibility",
+      "name": "Accessibility",
+      "blurb": "TODO: add blurb for accessibility concept"
+    },
+    {
+      "uuid": "78ab4dbd-da83-4082-825c-e463595b2ed6",
+      "slug": "arithmetic-overflow",
+      "name": "Arithmetic Overflow",
+      "blurb": "TODO: add blurb for arithmetic-overflow concept"
+    },
+    {
+      "uuid": "efc1a32a-ebea-45ab-8c0b-5b512717abc0",
+      "slug": "arrays",
+      "name": "Arrays",
+      "blurb": "TODO: add blurb for arrays concept"
+    },
+    {
+      "uuid": "06a39e16-780f-4d44-811e-53ebf2fdf6d5",
+      "slug": "attributes",
+      "name": "Attributes",
+      "blurb": "TODO: add blurb for attributes concept"
+    },
+    {
+      "uuid": "2eb4a463-355f-46ef-ac55-a75ec5afdf86",
+      "slug": "basics",
+      "name": "Basics",
+      "blurb": "TODO: add blurb for basics concept"
+    },
+    {
+      "uuid": "83226d8e-9d8b-4223-82ad-6d251f519a49",
+      "slug": "bit-manipulation",
+      "name": "Bit Manipulation",
+      "blurb": "TODO: add blurb for bit-manipulation concept"
+    },
+    {
+      "uuid": "64a2670d-f61a-419f-8623-7116bad8e8a7",
+      "slug": "booleans",
+      "name": "Booleans",
+      "blurb": "TODO: add blurb for booleans concept"
+    },
+    {
+      "uuid": "e3b507b0-d2c3-4791-9c6e-6a40bdb4ec1a",
+      "slug": "casting",
+      "name": "Casting",
+      "blurb": "TODO: add blurb for casting concept"
+    },
+    {
+      "uuid": "352db7e4-c47c-42cf-a290-74e42fadc6ff",
+      "slug": "chars",
+      "name": "Chars",
+      "blurb": "TODO: add blurb for chars concept"
+    },
+    {
+      "uuid": "5b2f9bbb-079c-47fd-9ba6-0c6469e547cb",
+      "slug": "classes",
+      "name": "Classes",
+      "blurb": "TODO: add blurb for classes concept"
+    },
+    {
+      "uuid": "2c1ac74e-cec8-4616-a1c4-a08ef9f3f926",
+      "slug": "compound-assignment",
+      "name": "Compound Assignment",
+      "blurb": "TODO: add blurb for compound-assignment concept"
+    },
+    {
+      "uuid": "43820de3-174a-41a3-9fc0-d7a6f0c393aa",
+      "slug": "conditionals-ternary",
+      "name": "Conditionals Ternary",
+      "blurb": "TODO: add blurb for conditionals-ternary concept"
+    },
+    {
+      "uuid": "b29bc90a-65ae-4984-b7de-17debee7fc5f",
+      "slug": "const-readonly",
+      "name": "Const Readonly",
+      "blurb": "TODO: add blurb for const-readonly concept"
+    },
+    {
+      "uuid": "0ae08bee-1252-4d21-ae47-4952a1ab03b5",
+      "slug": "constants",
+      "name": "Constants",
+      "blurb": "TODO: add blurb for constants concept"
+    },
+    {
+      "uuid": "250f7606-f01d-4713-8e3e-1b1056a6b790",
+      "slug": "constructors",
+      "name": "Constructors",
+      "blurb": "TODO: add blurb for constructors concept"
+    },
+    {
+      "uuid": "c040c1f0-4625-4725-a6f8-e272af0d41bb",
+      "slug": "datetime",
+      "name": "Datetime",
+      "blurb": "TODO: add blurb for datetime concept"
+    },
+    {
+      "uuid": "bed44bba-b5a5-43e7-a548-b17812a6f536",
+      "slug": "datetimes",
+      "name": "Datetimes",
+      "blurb": "TODO: add blurb for datetimes concept"
+    },
+    {
+      "uuid": "c710b7f8-226f-4cc0-8a8f-b125cebb13fc",
+      "slug": "defensive-copying",
+      "name": "Defensive Copying",
+      "blurb": "TODO: add blurb for defensive-copying concept"
+    },
+    {
+      "uuid": "3af88acb-1487-4554-8715-089d7dda1199",
+      "slug": "dictionaries",
+      "name": "Dictionaries",
+      "blurb": "TODO: add blurb for dictionaries concept"
+    },
+    {
+      "uuid": "5b04ddb3-54ff-479f-a525-fb4f117d5c34",
+      "slug": "do-while-loops",
+      "name": "Do While Loops",
+      "blurb": "TODO: add blurb for do-while-loops concept"
+    },
+    {
+      "uuid": "d5b628d9-ac64-4eeb-91c7-f2dcff798b31",
+      "slug": "enums",
+      "name": "Enums",
+      "blurb": "TODO: add blurb for enums concept"
+    },
+    {
+      "uuid": "08632727-cfae-4c5b-b53f-f04ba35ce4ed",
+      "slug": "equality",
+      "name": "Equality",
+      "blurb": "TODO: add blurb for equality concept"
+    },
+    {
+      "uuid": "d3f5d61c-6bed-46ef-be21-cf7fdc07d4f7",
+      "slug": "exception-filtering",
+      "name": "Exception Filtering",
+      "blurb": "TODO: add blurb for exception-filtering concept"
+    },
+    {
+      "uuid": "6a322f90-1428-4ced-ba8c-cdcadf8914bd",
+      "slug": "exceptions",
+      "name": "Exceptions",
+      "blurb": "TODO: add blurb for exceptions concept"
+    },
+    {
+      "uuid": "c82d74c8-fbe1-42ab-be71-b1f524f28bf6",
+      "slug": "explicit-casts",
+      "name": "Explicit Casts",
+      "blurb": "TODO: add blurb for explicit-casts concept"
+    },
+    {
+      "uuid": "8e69833b-9668-4ed1-bfdd-d3c90fe4d9a4",
+      "slug": "expression-bodied-members",
+      "name": "Expression Bodied Members",
+      "blurb": "TODO: add blurb for expression-bodied-members concept"
+    },
+    {
+      "uuid": "0d0ce715-a7f2-42f4-b97b-54ba99b4df73",
+      "slug": "flag-enums",
+      "name": "Flag Enums",
+      "blurb": "TODO: add blurb for flag-enums concept"
+    },
+    {
+      "uuid": "05cd97a1-fedb-40c1-9f73-3a47d3f8690d",
+      "slug": "floating-point-numbers",
+      "name": "Floating Point Numbers",
+      "blurb": "TODO: add blurb for floating-point-numbers concept"
+    },
+    {
+      "uuid": "bd406da5-7a16-4487-a820-ce7ef5f1066b",
+      "slug": "for-loops",
+      "name": "For Loops",
+      "blurb": "TODO: add blurb for for-loops concept"
+    },
+    {
+      "uuid": "a352e32f-2e90-43ba-94c3-f22dc985e10a",
+      "slug": "foreach-loops",
+      "name": "Foreach Loops",
+      "blurb": "TODO: add blurb for foreach-loops concept"
+    },
+    {
+      "uuid": "555dc4c4-b30e-4928-a52e-336b05c26fca",
+      "slug": "generic-types",
+      "name": "Generic Types",
+      "blurb": "TODO: add blurb for generic-types concept"
+    },
+    {
+      "uuid": "4466e33e-dcd2-4b1f-9d9d-2c4315bf5188",
+      "slug": "if-statements",
+      "name": "If Statements",
+      "blurb": "TODO: add blurb for if-statements concept"
+    },
+    {
+      "uuid": "760a9811-a77f-4022-bc62-2a84dfbddbfc",
+      "slug": "indexers",
+      "name": "Indexers",
+      "blurb": "TODO: add blurb for indexers concept"
+    },
+    {
+      "uuid": "4725bc7b-481a-4ba2-951d-e7fa42c5b0c3",
+      "slug": "inheritance",
+      "name": "Inheritance",
+      "blurb": "TODO: add blurb for inheritance concept"
+    },
+    {
+      "uuid": "0b793025-5434-4c3d-ab72-67578669529f",
+      "slug": "integral-numbers",
+      "name": "Integral Numbers",
+      "blurb": "TODO: add blurb for integral-numbers concept"
+    },
+    {
+      "uuid": "10b71949-a188-481a-8c24-04a9c20c1530",
+      "slug": "interfaces",
+      "name": "Interfaces",
+      "blurb": "TODO: add blurb for interfaces concept"
+    },
+    {
+      "uuid": "dd7bf404-59af-4ae6-895b-5d04cdc8ecaa",
+      "slug": "lists",
+      "name": "Lists",
+      "blurb": "TODO: add blurb for lists concept"
+    },
+    {
+      "uuid": "a93a154c-4706-4c01-8ece-b5504ba3378d",
+      "slug": "memory-allocation",
+      "name": "Memory Allocation",
+      "blurb": "TODO: add blurb for memory-allocation concept"
+    },
+    {
+      "uuid": "e4c0bba5-e08b-426a-bccf-0f0fb375c2ad",
+      "slug": "method-overloading",
+      "name": "Method Overloading",
+      "blurb": "TODO: add blurb for method-overloading concept"
+    },
+    {
+      "uuid": "3b67cb8b-bcd3-4d34-ad4c-8e2009c3e6b5",
+      "slug": "named-arguments",
+      "name": "Named Arguments",
+      "blurb": "TODO: add blurb for named-arguments concept"
+    },
+    {
+      "uuid": "944d243a-65bc-4a52-97e8-b692a8419d04",
+      "slug": "namespaces",
+      "name": "Namespaces",
+      "blurb": "TODO: add blurb for namespaces concept"
+    },
+    {
+      "uuid": "339dce38-c4b6-423d-9b66-88fed35408d4",
+      "slug": "nested-types",
+      "name": "Nested Types",
+      "blurb": "TODO: add blurb for nested-types concept"
+    },
+    {
+      "uuid": "f66d4f26-ebd8-41d0-b79e-05858491e035",
+      "slug": "nullability",
+      "name": "Nullability",
+      "blurb": "TODO: add blurb for nullability concept"
+    },
+    {
+      "uuid": "b9a421b2-c5ff-4213-bd6d-b886da31ea0d",
+      "slug": "numbers",
+      "name": "Numbers",
+      "blurb": "TODO: add blurb for numbers concept"
+    },
+    {
+      "uuid": "9b50d5ee-7b68-46e3-9c3b-893c3a83110f",
+      "slug": "object-initializers",
+      "name": "Object Initializers",
+      "blurb": "TODO: add blurb for object-initializers concept"
+    },
+    {
+      "uuid": "3b510fdc-2975-41e4-acc5-c6b3780acf50",
+      "slug": "operator-overloading",
+      "name": "Operator Overloading",
+      "blurb": "TODO: add blurb for operator-overloading concept"
+    },
+    {
+      "uuid": "cddf1b02-6dcd-4ef0-9847-a2cd35abdb80",
+      "slug": "optional-parameters",
+      "name": "Optional Parameters",
+      "blurb": "TODO: add blurb for optional-parameters concept"
+    },
+    {
+      "uuid": "9f993d9a-144c-45fe-ab09-e368b5be2e6c",
+      "slug": "ordering",
+      "name": "Ordering",
+      "blurb": "TODO: add blurb for ordering concept"
+    },
+    {
+      "uuid": "a9ea7864-bfc7-49ce-815b-32d018627fe9",
+      "slug": "overflow",
+      "name": "Overflow",
+      "blurb": "TODO: add blurb for overflow concept"
+    },
+    {
+      "uuid": "83414ea8-0335-485c-a826-95c88a532d65",
+      "slug": "parameters",
+      "name": "Parameters",
+      "blurb": "TODO: add blurb for parameters concept"
+    },
+    {
+      "uuid": "909a9208-55eb-4a9a-979e-a0cbb0137845",
+      "slug": "pattern-matching-constants",
+      "name": "Pattern Matching Constants",
+      "blurb": "TODO: add blurb for pattern-matching-constants concept"
+    },
+    {
+      "uuid": "7149c281-8b8c-42a2-a534-7bc5553cbbce",
+      "slug": "properties",
+      "name": "Properties",
+      "blurb": "TODO: add blurb for properties concept"
+    },
+    {
+      "uuid": "b71dc153-1cb0-4b82-ab5f-d896d6f1f7ed",
+      "slug": "randomness",
+      "name": "Randomness",
+      "blurb": "TODO: add blurb for randomness concept"
+    },
+    {
+      "uuid": "34e99b87-8862-47a7-87d3-621e1db47e5c",
+      "slug": "readonly-collections",
+      "name": "Readonly Collections",
+      "blurb": "TODO: add blurb for readonly-collections concept"
+    },
+    {
+      "uuid": "3c67b33f-e2a6-45e9-b4c4-456044e3c6ef",
+      "slug": "regular-expressions",
+      "name": "Regular Expressions",
+      "blurb": "TODO: add blurb for regular-expressions concept"
+    },
+    {
+      "uuid": "726f35e6-8af7-4279-b3bc-5299e1b7c182",
+      "slug": "resource-cleanup",
+      "name": "Resource Cleanup",
+      "blurb": "TODO: add blurb for resource-cleanup concept"
+    },
+    {
+      "uuid": "64ef0e6d-ca7a-4a3e-81a7-e66766615a9b",
+      "slug": "resource-lifetime",
+      "name": "Resource Lifetime",
+      "blurb": "TODO: add blurb for resource-lifetime concept"
+    },
+    {
+      "uuid": "d38a4651-09d2-47e5-8a18-9bcb6f3bfa0b",
+      "slug": "sets",
+      "name": "Sets",
+      "blurb": "TODO: add blurb for sets concept"
+    },
+    {
+      "uuid": "c1fcce17-0cbb-410e-8281-698606d73690",
+      "slug": "string-builder",
+      "name": "String Builder",
+      "blurb": "TODO: add blurb for string-builder concept"
+    },
+    {
+      "uuid": "7262549b-0bb3-4650-af34-e655c6ec59c2",
+      "slug": "string-formatting",
+      "name": "String Formatting",
+      "blurb": "TODO: add blurb for string-formatting concept"
+    },
+    {
+      "uuid": "df01147e-eac9-4df8-be9d-7bd81561a3c5",
+      "slug": "string-interpolation",
+      "name": "String Interpolation",
+      "blurb": "TODO: add blurb for string-interpolation concept"
+    },
+    {
+      "uuid": "fe39a4ab-e760-4e71-804e-2937ecc52b4d",
+      "slug": "strings",
+      "name": "Strings",
+      "blurb": "TODO: add blurb for strings concept"
+    },
+    {
+      "uuid": "b9a177bc-b815-4e85-9c0f-b84eb059500d",
+      "slug": "structs",
+      "name": "Structs",
+      "blurb": "TODO: add blurb for structs concept"
+    },
+    {
+      "uuid": "bc342654-6ebc-46fd-8148-eef2c8477a15",
+      "slug": "switch-expressions",
+      "name": "Switch Expressions",
+      "blurb": "TODO: add blurb for switch-expressions concept"
+    },
+    {
+      "uuid": "f57713c2-ddf3-4e71-802b-b24b552db609",
+      "slug": "switch-statements",
+      "name": "Switch Statements",
+      "blurb": "TODO: add blurb for switch-statements concept"
+    },
+    {
+      "uuid": "58d5caa7-1683-44e0-a62f-1564ac6959ab",
+      "slug": "throw-expressions",
+      "name": "Throw Expressions",
+      "blurb": "TODO: add blurb for throw-expressions concept"
+    },
+    {
+      "uuid": "050e789f-d318-41df-b2cc-f386ccf349dc",
+      "slug": "time",
+      "name": "Time",
+      "blurb": "TODO: add blurb for time concept"
+    },
+    {
+      "uuid": "3b83bdcc-de0b-43f7-b8f1-41fa9c656fb1",
+      "slug": "timezone",
+      "name": "Timezone",
+      "blurb": "TODO: add blurb for timezone concept"
+    },
+    {
+      "uuid": "86848fc2-c1ef-44ce-b099-86feabbbc7c9",
+      "slug": "tuples",
+      "name": "Tuples",
+      "blurb": "TODO: add blurb for tuples concept"
+    },
+    {
+      "uuid": "a625c3c3-7299-4426-99e5-f2c850479a29",
+      "slug": "user-defined-exceptions",
+      "name": "User Defined Exceptions",
+      "blurb": "TODO: add blurb for user-defined-exceptions concept"
+    },
+    {
+      "uuid": "1f78e26c-14d1-402e-a3cd-c786f8b1eec2",
+      "slug": "varargs",
+      "name": "Varargs",
+      "blurb": "TODO: add blurb for varargs concept"
+    },
+    {
+      "uuid": "6d85366c-7767-4d6a-af08-4cee5db801ca",
+      "slug": "verbatim-strings",
+      "name": "Verbatim Strings",
+      "blurb": "TODO: add blurb for verbatim-strings concept"
+    },
+    {
+      "uuid": "5442d5da-f74e-4793-97ee-97ddc09d4942",
+      "slug": "while-loops",
+      "name": "While Loops",
+      "blurb": "TODO: add blurb for while-loops concept"
+    }
+  ]
 }

--- a/languages/dart/config.json
+++ b/languages/dart/config.json
@@ -31,5 +31,55 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "ba21e341-5393-4484-b5b1-a82e56a87d06",
+      "slug": "callbacks",
+      "name": "Callbacks",
+      "blurb": "TODO: add blurb for callbacks concept"
+    },
+    {
+      "uuid": "66ae5bf8-222c-46b7-b343-ecc58e56d943",
+      "slug": "errors-basic",
+      "name": "Errors Basic",
+      "blurb": "TODO: add blurb for errors-basic concept"
+    },
+    {
+      "uuid": "b90f1363-7501-480f-bd85-e64a420325d1",
+      "slug": "futures",
+      "name": "Futures",
+      "blurb": "TODO: add blurb for futures concept"
+    },
+    {
+      "uuid": "2727c1e4-8634-4229-82b1-004cb19d01c5",
+      "slug": "iterables-basic",
+      "name": "Iterables Basic",
+      "blurb": "TODO: add blurb for iterables-basic concept"
+    },
+    {
+      "uuid": "df1cc116-f806-4f8b-b97a-440f1425c9c7",
+      "slug": "numbers-basic",
+      "name": "Numbers Basic",
+      "blurb": "TODO: add blurb for numbers-basic concept"
+    },
+    {
+      "uuid": "d2a40784-15fa-4ea3-8e71-581aea4f3398",
+      "slug": "recursion",
+      "name": "Recursion",
+      "blurb": "TODO: add blurb for recursion concept"
+    },
+    {
+      "uuid": "4f20c5b4-7d32-4cff-8bab-6c544d776f78",
+      "slug": "strings-basic",
+      "name": "Strings Basic",
+      "blurb": "TODO: add blurb for strings-basic concept"
+    },
+    {
+      "uuid": "692ca96a-ed31-4bf7-a981-f7f51211b24d",
+      "slug": "type-conversion",
+      "name": "Type Conversion",
+      "blurb": "TODO: add blurb for type-conversion concept"
+    }
+  ]
 }

--- a/languages/elixir/config.json
+++ b/languages/elixir/config.json
@@ -206,5 +206,277 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "e95023cf-6928-4ccc-ae09-d3cb93d96d0e",
+      "slug": "access-behaviour",
+      "name": "Access Behaviour",
+      "blurb": "TODO: add blurb for access-behaviour concept"
+    },
+    {
+      "uuid": "a5a3b2bb-fe4d-4a0b-97a3-c56ddfa9b650",
+      "slug": "agent",
+      "name": "Agent",
+      "blurb": "TODO: add blurb for agent concept"
+    },
+    {
+      "uuid": "a5b7f41f-9f07-4996-8032-05225f0ef639",
+      "slug": "anonymous-functions",
+      "name": "Anonymous Functions",
+      "blurb": "TODO: add blurb for anonymous-functions concept"
+    },
+    {
+      "uuid": "0bc1ad03-5ec7-4269-ad33-df6decbb5ee2",
+      "slug": "atoms",
+      "name": "Atoms",
+      "blurb": "TODO: add blurb for atoms concept"
+    },
+    {
+      "uuid": "5bd736ed-290d-4d1b-9668-36a704cbe236",
+      "slug": "basics",
+      "name": "Basics",
+      "blurb": "TODO: add blurb for basics concept"
+    },
+    {
+      "uuid": "d291ca4b-7163-43e4-ab02-383904f19c34",
+      "slug": "binaries",
+      "name": "Binaries",
+      "blurb": "TODO: add blurb for binaries concept"
+    },
+    {
+      "uuid": "ffd52ca2-8d45-4bce-a048-5d6c99dc8571",
+      "slug": "bit-manipulation",
+      "name": "Bit Manipulation",
+      "blurb": "TODO: add blurb for bit-manipulation concept"
+    },
+    {
+      "uuid": "71d2383f-fa4e-4309-a0ce-7b05312f3259",
+      "slug": "bitstrings",
+      "name": "Bitstrings",
+      "blurb": "TODO: add blurb for bitstrings concept"
+    },
+    {
+      "uuid": "e1c4540a-12ae-4986-a604-07f38d46b498",
+      "slug": "booleans",
+      "name": "Booleans",
+      "blurb": "TODO: add blurb for booleans concept"
+    },
+    {
+      "uuid": "cc1d6b46-976a-481f-96e2-7d3eadea7603",
+      "slug": "case",
+      "name": "Case",
+      "blurb": "TODO: add blurb for case concept"
+    },
+    {
+      "uuid": "7fe6a6a2-34f7-4786-a2af-1d3e2a977bc7",
+      "slug": "charlists",
+      "name": "Charlists",
+      "blurb": "TODO: add blurb for charlists concept"
+    },
+    {
+      "uuid": "bc688f4f-e8a1-44d8-a5aa-eceb8e725ce2",
+      "slug": "closures",
+      "name": "Closures",
+      "blurb": "TODO: add blurb for closures concept"
+    },
+    {
+      "uuid": "1e7bb8a6-9620-4474-b01e-a232408e9b65",
+      "slug": "cond",
+      "name": "Cond",
+      "blurb": "TODO: add blurb for cond concept"
+    },
+    {
+      "uuid": "337ea0be-2978-48a1-ba10-0c29d7018a99",
+      "slug": "default-arguments",
+      "name": "Default Arguments",
+      "blurb": "TODO: add blurb for default-arguments concept"
+    },
+    {
+      "uuid": "34f0a21f-1ec5-4042-9efe-0c3ae7e35fbb",
+      "slug": "enum",
+      "name": "Enum",
+      "blurb": "TODO: add blurb for enum concept"
+    },
+    {
+      "uuid": "3f8ca849-0546-4fd0-b55d-a617a9e119ee",
+      "slug": "errors",
+      "name": "Errors",
+      "blurb": "TODO: add blurb for errors concept"
+    },
+    {
+      "uuid": "586001b3-974f-468e-9f7c-45a8c74e6f39",
+      "slug": "exceptions",
+      "name": "Exceptions",
+      "blurb": "TODO: add blurb for exceptions concept"
+    },
+    {
+      "uuid": "a0a894e1-c54d-4c7a-89bf-653e6efb0039",
+      "slug": "floating-point-numbers",
+      "name": "Floating Point Numbers",
+      "blurb": "TODO: add blurb for floating-point-numbers concept"
+    },
+    {
+      "uuid": "5dd6841b-3875-499c-9de7-4cf4d033e68f",
+      "slug": "guards",
+      "name": "Guards",
+      "blurb": "TODO: add blurb for guards concept"
+    },
+    {
+      "uuid": "6bafcc9f-7e2b-4240-a487-be15030cf4a3",
+      "slug": "if",
+      "name": "If",
+      "blurb": "TODO: add blurb for if concept"
+    },
+    {
+      "uuid": "bab00476-4570-41c3-b74a-ba6c1a567c49",
+      "slug": "integers",
+      "name": "Integers",
+      "blurb": "TODO: add blurb for integers concept"
+    },
+    {
+      "uuid": "776919ef-6e4a-40d6-8977-9da237d8cc14",
+      "slug": "io",
+      "name": "Io",
+      "blurb": "TODO: add blurb for io concept"
+    },
+    {
+      "uuid": "a07081f3-c517-46ea-b68f-27f7e048cb5e",
+      "slug": "keyword-lists",
+      "name": "Keyword Lists",
+      "blurb": "TODO: add blurb for keyword-lists concept"
+    },
+    {
+      "uuid": "9db9d827-ea45-46ca-bc0c-ef81363f9492",
+      "slug": "list-comprehensions",
+      "name": "List Comprehensions",
+      "blurb": "TODO: add blurb for list-comprehensions concept"
+    },
+    {
+      "uuid": "68417562-6ef3-4a1d-9983-96b4182d444f",
+      "slug": "lists",
+      "name": "Lists",
+      "blurb": "TODO: add blurb for lists concept"
+    },
+    {
+      "uuid": "c1dca378-b124-4b9b-8822-ddfa23643047",
+      "slug": "maps",
+      "name": "Maps",
+      "blurb": "TODO: add blurb for maps concept"
+    },
+    {
+      "uuid": "0b4e7214-657f-40db-a30b-ee0a0b0552c3",
+      "slug": "module-attributes-as-constants",
+      "name": "Module Attributes As Constants",
+      "blurb": "TODO: add blurb for module-attributes-as-constants concept"
+    },
+    {
+      "uuid": "01211dc2-c8e1-4621-99a2-6aa66080839a",
+      "slug": "multiple-clause-functions",
+      "name": "Multiple Clause Functions",
+      "blurb": "TODO: add blurb for multiple-clause-functions concept"
+    },
+    {
+      "uuid": "e2868bb9-b384-45b6-8bdf-08e9a1ba4eea",
+      "slug": "nil",
+      "name": "Nil",
+      "blurb": "TODO: add blurb for nil concept"
+    },
+    {
+      "uuid": "bf0232ea-f5e7-465e-a942-b126f118f05a",
+      "slug": "pattern-matching",
+      "name": "Pattern Matching",
+      "blurb": "TODO: add blurb for pattern-matching concept"
+    },
+    {
+      "uuid": "fe428299-37fd-4c7f-a498-fad1977390fb",
+      "slug": "pids",
+      "name": "Pids",
+      "blurb": "TODO: add blurb for pids concept"
+    },
+    {
+      "uuid": "36c21dce-62d5-4865-bf67-96ca6037a4a4",
+      "slug": "pipe-operator",
+      "name": "Pipe Operator",
+      "blurb": "TODO: add blurb for pipe-operator concept"
+    },
+    {
+      "uuid": "410a2c9b-de5f-4501-a01a-ca65a1f22ef2",
+      "slug": "processes",
+      "name": "Processes",
+      "blurb": "TODO: add blurb for processes concept"
+    },
+    {
+      "uuid": "b2165ae4-a742-4230-8297-11e65882ce2c",
+      "slug": "ranges",
+      "name": "Ranges",
+      "blurb": "TODO: add blurb for ranges concept"
+    },
+    {
+      "uuid": "fc21f957-faac-41f3-ad94-fd643a4a0787",
+      "slug": "recursion",
+      "name": "Recursion",
+      "blurb": "TODO: add blurb for recursion concept"
+    },
+    {
+      "uuid": "ddd88935-a304-4a9e-8b28-a2a877c22e3b",
+      "slug": "regular-expressions",
+      "name": "Regular Expressions",
+      "blurb": "TODO: add blurb for regular-expressions concept"
+    },
+    {
+      "uuid": "0c96a65b-8b7d-4fa8-b64c-aea86286ca35",
+      "slug": "static-access-operator",
+      "name": "Static Access Operator",
+      "blurb": "TODO: add blurb for static-access-operator concept"
+    },
+    {
+      "uuid": "442e8992-9eed-4b11-bd97-edf23ab0dc7b",
+      "slug": "streams",
+      "name": "Streams",
+      "blurb": "TODO: add blurb for streams concept"
+    },
+    {
+      "uuid": "df703456-1c56-4692-bd76-bee569e41e84",
+      "slug": "string-literals",
+      "name": "String Literals",
+      "blurb": "TODO: add blurb for string-literals concept"
+    },
+    {
+      "uuid": "c7ad7fb0-0efc-4d5f-a501-2abe5e048ac7",
+      "slug": "strings",
+      "name": "Strings",
+      "blurb": "TODO: add blurb for strings concept"
+    },
+    {
+      "uuid": "de1ee106-da36-44ed-8eeb-988f079641d6",
+      "slug": "structs",
+      "name": "Structs",
+      "blurb": "TODO: add blurb for structs concept"
+    },
+    {
+      "uuid": "2b2632d6-84a5-45d8-a686-d4b995300beb",
+      "slug": "tail-call-recursion",
+      "name": "Tail Call Recursion",
+      "blurb": "TODO: add blurb for tail-call-recursion concept"
+    },
+    {
+      "uuid": "eef1727c-e5d3-41de-801b-a57b85051363",
+      "slug": "try-rescue",
+      "name": "Try Rescue",
+      "blurb": "TODO: add blurb for try-rescue concept"
+    },
+    {
+      "uuid": "3beba34b-0675-48bf-9fe5-0e7e36eb6eea",
+      "slug": "try-rescue-else-after",
+      "name": "Try Rescue Else After",
+      "blurb": "TODO: add blurb for try-rescue-else-after concept"
+    },
+    {
+      "uuid": "41100681-1d36-4cb6-8968-e9e815ca161d",
+      "slug": "tuples",
+      "name": "Tuples",
+      "blurb": "TODO: add blurb for tuples concept"
+    }
+  ]
 }

--- a/languages/elm/config.json
+++ b/languages/elm/config.json
@@ -11,5 +11,6 @@
   "exercises": {
     "concept": [],
     "practice": []
-  }
+  },
+  "concepts": []
 }

--- a/languages/emacs-lisp/config.json
+++ b/languages/emacs-lisp/config.json
@@ -11,5 +11,6 @@
   "exercises": {
     "concept": [],
     "practice": []
-  }
+  },
+  "concepts": []
 }

--- a/languages/erlang/config.json
+++ b/languages/erlang/config.json
@@ -11,5 +11,6 @@
   "exercises": {
     "concept": [],
     "practice": []
-  }
+  },
+  "concepts": []
 }

--- a/languages/fsharp/config.json
+++ b/languages/fsharp/config.json
@@ -86,5 +86,97 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "ecdd0d87-8d03-43b8-85e1-ea0fe9f0dbf7",
+      "slug": "arrays",
+      "name": "Arrays",
+      "blurb": "TODO: add blurb for arrays concept"
+    },
+    {
+      "uuid": "f91b9627-803e-47fd-8bba-1a8f113b5215",
+      "slug": "basics",
+      "name": "Basics",
+      "blurb": "TODO: add blurb for basics concept"
+    },
+    {
+      "uuid": "b1d78394-24f0-4956-82c2-e3d33dfecc95",
+      "slug": "booleans",
+      "name": "Booleans",
+      "blurb": "TODO: add blurb for booleans concept"
+    },
+    {
+      "uuid": "1d7fe262-134c-43eb-a3ff-418ddff9f84a",
+      "slug": "classes",
+      "name": "Classes",
+      "blurb": "TODO: add blurb for classes concept"
+    },
+    {
+      "uuid": "2d2c2485-7655-40f0-9bd2-476fc322e67f",
+      "slug": "conditionals",
+      "name": "Conditionals",
+      "blurb": "TODO: add blurb for conditionals concept"
+    },
+    {
+      "uuid": "2076158a-be99-4b7b-9321-fd8e864a6556",
+      "slug": "datetimes",
+      "name": "Datetimes",
+      "blurb": "TODO: add blurb for datetimes concept"
+    },
+    {
+      "uuid": "0deda8b3-98f2-4025-9c15-836b3bb35ad1",
+      "slug": "discriminated-unions",
+      "name": "Discriminated Unions",
+      "blurb": "TODO: add blurb for discriminated-unions concept"
+    },
+    {
+      "uuid": "1327d780-3263-4a22-b363-684d775241b8",
+      "slug": "floating-point-numbers",
+      "name": "Floating Point Numbers",
+      "blurb": "TODO: add blurb for floating-point-numbers concept"
+    },
+    {
+      "uuid": "0a662a9c-68fe-435e-97b1-ca93a8af6d8c",
+      "slug": "higher-order-functions",
+      "name": "Higher Order Functions",
+      "blurb": "TODO: add blurb for higher-order-functions concept"
+    },
+    {
+      "uuid": "b84e3e3a-d34f-44fb-b096-4e92bc2cca9d",
+      "slug": "lists",
+      "name": "Lists",
+      "blurb": "TODO: add blurb for lists concept"
+    },
+    {
+      "uuid": "d0fe01c7-d94b-4d6b-92a7-a0055c5704a3",
+      "slug": "numbers",
+      "name": "Numbers",
+      "blurb": "TODO: add blurb for numbers concept"
+    },
+    {
+      "uuid": "3439b5d6-6e1b-486b-989d-9f7e8f9eb732",
+      "slug": "pattern-matching",
+      "name": "Pattern Matching",
+      "blurb": "TODO: add blurb for pattern-matching concept"
+    },
+    {
+      "uuid": "7c481331-8c4f-440e-ab2b-362bce355ebc",
+      "slug": "records",
+      "name": "Records",
+      "blurb": "TODO: add blurb for records concept"
+    },
+    {
+      "uuid": "b949a78d-99ed-46a5-be85-f17ea6d1aa4b",
+      "slug": "recursion",
+      "name": "Recursion",
+      "blurb": "TODO: add blurb for recursion concept"
+    },
+    {
+      "uuid": "8a3e23fd-aa42-42c3-9dbd-c26159fd6774",
+      "slug": "strings",
+      "name": "Strings",
+      "blurb": "TODO: add blurb for strings concept"
+    }
+  ]
 }

--- a/languages/go/config.json
+++ b/languages/go/config.json
@@ -242,5 +242,265 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "2149c74b-b05f-45b1-8e64-8ff66110c402",
+      "slug": "anonymous-functions",
+      "name": "Anonymous Functions",
+      "blurb": "TODO: add blurb for anonymous-functions concept"
+    },
+    {
+      "uuid": "ab3da6c2-9cc8-4019-90d7-b592787787e7",
+      "slug": "application-timing",
+      "name": "Application Timing",
+      "blurb": "TODO: add blurb for application-timing concept"
+    },
+    {
+      "uuid": "142cf89f-c109-4a05-8108-60b5051294de",
+      "slug": "booleans",
+      "name": "Booleans",
+      "blurb": "TODO: add blurb for booleans concept"
+    },
+    {
+      "uuid": "16c5d4d5-05a0-4e89-8846-6d8f50e09520",
+      "slug": "bytes",
+      "name": "Bytes",
+      "blurb": "TODO: add blurb for bytes concept"
+    },
+    {
+      "uuid": "092a3fad-e75a-44bd-8d66-4f48cde0e0b5",
+      "slug": "channels",
+      "name": "Channels",
+      "blurb": "TODO: add blurb for channels concept"
+    },
+    {
+      "uuid": "159f921c-f379-45c5-871b-da7cc8f3a8cc",
+      "slug": "comments",
+      "name": "Comments",
+      "blurb": "TODO: add blurb for comments concept"
+    },
+    {
+      "uuid": "d74a04ba-0eb8-481d-9e2f-2e6a4694d482",
+      "slug": "conditionals",
+      "name": "Conditionals",
+      "blurb": "TODO: add blurb for conditionals concept"
+    },
+    {
+      "uuid": "c0bb612b-2571-40a1-9fbe-81819e49d267",
+      "slug": "conditionals-if",
+      "name": "Conditionals If",
+      "blurb": "TODO: add blurb for conditionals-if concept"
+    },
+    {
+      "uuid": "c24b971e-e344-490e-aacc-2ea29bd60822",
+      "slug": "conditionals-switch",
+      "name": "Conditionals Switch",
+      "blurb": "TODO: add blurb for conditionals-switch concept"
+    },
+    {
+      "uuid": "288e3276-8ef4-4719-99a1-94882345d8aa",
+      "slug": "constants",
+      "name": "Constants",
+      "blurb": "TODO: add blurb for constants concept"
+    },
+    {
+      "uuid": "4007b59c-0860-4535-adbd-9c035e8eb8e0",
+      "slug": "context",
+      "name": "Context",
+      "blurb": "TODO: add blurb for context concept"
+    },
+    {
+      "uuid": "ee2a475f-461a-4931-b35b-6ab43ec446f1",
+      "slug": "defer",
+      "name": "Defer",
+      "blurb": "TODO: add blurb for defer concept"
+    },
+    {
+      "uuid": "dcd62cda-450f-48b6-bf1c-01bbb3eea13b",
+      "slug": "duration",
+      "name": "Duration",
+      "blurb": "TODO: add blurb for duration concept"
+    },
+    {
+      "uuid": "b9686994-4978-4588-9734-1d2137fadd6d",
+      "slug": "empty-interface",
+      "name": "Empty Interface",
+      "blurb": "TODO: add blurb for empty-interface concept"
+    },
+    {
+      "uuid": "95f9c430-dc4a-4eff-b2cc-5c6ea93a6960",
+      "slug": "errors",
+      "name": "Errors",
+      "blurb": "TODO: add blurb for errors concept"
+    },
+    {
+      "uuid": "ecb157d1-9e1e-4dd1-9a51-2074e598937d",
+      "slug": "errors-handling",
+      "name": "Errors Handling",
+      "blurb": "TODO: add blurb for errors-handling concept"
+    },
+    {
+      "uuid": "08c88d5c-a74c-451f-ab51-5c2c252a0988",
+      "slug": "floating-point",
+      "name": "Floating Point",
+      "blurb": "TODO: add blurb for floating-point concept"
+    },
+    {
+      "uuid": "28c60820-b6cc-49e3-8e23-e3321aa5c210",
+      "slug": "functions",
+      "name": "Functions",
+      "blurb": "TODO: add blurb for functions concept"
+    },
+    {
+      "uuid": "bcdf181d-b245-40b5-b5a6-09c1b1cfe466",
+      "slug": "goroutines",
+      "name": "Goroutines",
+      "blurb": "TODO: add blurb for goroutines concept"
+    },
+    {
+      "uuid": "05d17798-a93b-4b1e-a9e0-b287fffe9c8b",
+      "slug": "interfaces",
+      "name": "Interfaces",
+      "blurb": "TODO: add blurb for interfaces concept"
+    },
+    {
+      "uuid": "65728435-33ae-446a-8a08-77ed51b3d69c",
+      "slug": "iteration",
+      "name": "Iteration",
+      "blurb": "TODO: add blurb for iteration concept"
+    },
+    {
+      "uuid": "e02ef56e-6ede-481f-8098-ecd2ae984d2c",
+      "slug": "maps",
+      "name": "Maps",
+      "blurb": "TODO: add blurb for maps concept"
+    },
+    {
+      "uuid": "8918289f-5383-42c5-be15-290065d821ed",
+      "slug": "methods",
+      "name": "Methods",
+      "blurb": "TODO: add blurb for methods concept"
+    },
+    {
+      "uuid": "21628cd6-e215-47be-923d-91de47665c46",
+      "slug": "mutex",
+      "name": "Mutex",
+      "blurb": "TODO: add blurb for mutex concept"
+    },
+    {
+      "uuid": "8d34e7cf-2621-4985-b10e-1995201cf870",
+      "slug": "nil",
+      "name": "Nil",
+      "blurb": "TODO: add blurb for nil concept"
+    },
+    {
+      "uuid": "a7d2277b-a3be-4ffd-914c-75e8ca2de01e",
+      "slug": "numbers",
+      "name": "Numbers",
+      "blurb": "TODO: add blurb for numbers concept"
+    },
+    {
+      "uuid": "f4ab745a-a02e-48f5-b104-faa060f41fcf",
+      "slug": "packages",
+      "name": "Packages",
+      "blurb": "TODO: add blurb for packages concept"
+    },
+    {
+      "uuid": "48938b85-9bd8-40e4-9226-836020811e45",
+      "slug": "panic",
+      "name": "Panic",
+      "blurb": "TODO: add blurb for panic concept"
+    },
+    {
+      "uuid": "034d13fd-88d4-450e-968e-e124478ff39c",
+      "slug": "pointers",
+      "name": "Pointers",
+      "blurb": "TODO: add blurb for pointers concept"
+    },
+    {
+      "uuid": "99310096-1130-4a06-96a5-af94906bcc83",
+      "slug": "range-iteration",
+      "name": "Range Iteration",
+      "blurb": "TODO: add blurb for range-iteration concept"
+    },
+    {
+      "uuid": "c4a36ddb-e594-4ae1-91de-d25e274465d9",
+      "slug": "recover",
+      "name": "Recover",
+      "blurb": "TODO: add blurb for recover concept"
+    },
+    {
+      "uuid": "47eef38f-8f1b-4b3f-a3c6-b0011da61436",
+      "slug": "reflection",
+      "name": "Reflection",
+      "blurb": "TODO: add blurb for reflection concept"
+    },
+    {
+      "uuid": "0844c19c-97a7-4efb-a5ef-2cbac1f19684",
+      "slug": "runes",
+      "name": "Runes",
+      "blurb": "TODO: add blurb for runes concept"
+    },
+    {
+      "uuid": "4bb55d2f-628c-4ddc-9bde-ebf54277e01a",
+      "slug": "select",
+      "name": "Select",
+      "blurb": "TODO: add blurb for select concept"
+    },
+    {
+      "uuid": "d76c163c-2fc2-4af9-b1e1-33813ada91b7",
+      "slug": "slices",
+      "name": "Slices",
+      "blurb": "TODO: add blurb for slices concept"
+    },
+    {
+      "uuid": "c4d03633-94e3-4fc9-b230-816c56153189",
+      "slug": "strings",
+      "name": "Strings",
+      "blurb": "TODO: add blurb for strings concept"
+    },
+    {
+      "uuid": "bab4029c-d016-44d6-b51a-31a8384bd580",
+      "slug": "strings-package",
+      "name": "Strings Package",
+      "blurb": "TODO: add blurb for strings-package concept"
+    },
+    {
+      "uuid": "156ea093-0a5d-4207-b54d-119c9808928f",
+      "slug": "structs",
+      "name": "Structs",
+      "blurb": "TODO: add blurb for structs concept"
+    },
+    {
+      "uuid": "673104d9-bc95-45e7-88e8-73990438ada5",
+      "slug": "time",
+      "name": "Time",
+      "blurb": "TODO: add blurb for time concept"
+    },
+    {
+      "uuid": "f27dc295-c02a-4dc5-80c1-0301592ef961",
+      "slug": "type-assertion",
+      "name": "Type Assertion",
+      "blurb": "TODO: add blurb for type-assertion concept"
+    },
+    {
+      "uuid": "0789fe42-8af2-43c8-9922-d845017a08a6",
+      "slug": "type-conversion",
+      "name": "Type Conversion",
+      "blurb": "TODO: add blurb for type-conversion concept"
+    },
+    {
+      "uuid": "9bfb0484-6307-4c98-bf90-da1c0851e403",
+      "slug": "variables",
+      "name": "Variables",
+      "blurb": "TODO: add blurb for variables concept"
+    },
+    {
+      "uuid": "b38e16a2-2645-4d46-a7e7-a11efd15bcf8",
+      "slug": "zero-value",
+      "name": "Zero Value",
+      "blurb": "TODO: add blurb for zero-value concept"
+    }
+  ]
 }

--- a/languages/haskell/config.json
+++ b/languages/haskell/config.json
@@ -13,5 +13,6 @@
   "exercises": {
     "concept": [],
     "practice": []
-  }
+  },
+  "concepts": []
 }

--- a/languages/j/config.json
+++ b/languages/j/config.json
@@ -13,5 +13,6 @@
   "exercises": {
     "concept": [],
     "practice": []
-  }
+  },
+  "concepts": []
 }

--- a/languages/java/config.json
+++ b/languages/java/config.json
@@ -90,5 +90,109 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "e16a7735-0b61-46bf-b453-8fb088ae6590",
+      "slug": "abstract",
+      "name": "Abstract",
+      "blurb": "TODO: add blurb for abstract concept"
+    },
+    {
+      "uuid": "b36a466d-4154-44ce-a88c-d40c53de933a",
+      "slug": "arrays",
+      "name": "Arrays",
+      "blurb": "TODO: add blurb for arrays concept"
+    },
+    {
+      "uuid": "18bd44ca-9af7-4116-81d8-791b5eac8183",
+      "slug": "basics",
+      "name": "Basics",
+      "blurb": "TODO: add blurb for basics concept"
+    },
+    {
+      "uuid": "36887046-6df3-411a-ae79-8c478b67709b",
+      "slug": "boolean",
+      "name": "Boolean",
+      "blurb": "TODO: add blurb for boolean concept"
+    },
+    {
+      "uuid": "ea12527d-7a9d-461e-93b1-bf639652430e",
+      "slug": "booleans",
+      "name": "Booleans",
+      "blurb": "TODO: add blurb for booleans concept"
+    },
+    {
+      "uuid": "9a9a6ece-fa18-44c9-aba3-3ecaf4a71796",
+      "slug": "chars",
+      "name": "Chars",
+      "blurb": "TODO: add blurb for chars concept"
+    },
+    {
+      "uuid": "d8bf400a-951b-418a-90d6-2fe7d0fa1dcd",
+      "slug": "classes",
+      "name": "Classes",
+      "blurb": "TODO: add blurb for classes concept"
+    },
+    {
+      "uuid": "5be4c3d7-fc14-45c9-9677-a0ebddbcf570",
+      "slug": "conditionals",
+      "name": "Conditionals",
+      "blurb": "TODO: add blurb for conditionals concept"
+    },
+    {
+      "uuid": "4ce7cdbb-4ff3-4988-89db-8fbcef380500",
+      "slug": "conditionals-if",
+      "name": "Conditionals If",
+      "blurb": "TODO: add blurb for conditionals-if concept"
+    },
+    {
+      "uuid": "e552c05c-6360-4b2f-a438-7ec7e855c0f5",
+      "slug": "constructors",
+      "name": "Constructors",
+      "blurb": "TODO: add blurb for constructors concept"
+    },
+    {
+      "uuid": "6c6c8973-d4c5-483b-b529-7dda14a98c6d",
+      "slug": "functions",
+      "name": "Functions",
+      "blurb": "TODO: add blurb for functions concept"
+    },
+    {
+      "uuid": "90776fcc-c6a7-4665-b5fe-5a8a0618358b",
+      "slug": "inheritance",
+      "name": "Inheritance",
+      "blurb": "TODO: add blurb for inheritance concept"
+    },
+    {
+      "uuid": "27255c34-f9c3-4bca-a0b3-cb72714a6f19",
+      "slug": "interfaces",
+      "name": "Interfaces",
+      "blurb": "TODO: add blurb for interfaces concept"
+    },
+    {
+      "uuid": "87d25b56-8075-4c12-9d46-3f8173c3ff18",
+      "slug": "lists",
+      "name": "Lists",
+      "blurb": "TODO: add blurb for lists concept"
+    },
+    {
+      "uuid": "58529dab-0ef2-4943-ac12-a98ca79b922b",
+      "slug": "numbers",
+      "name": "Numbers",
+      "blurb": "TODO: add blurb for numbers concept"
+    },
+    {
+      "uuid": "8a468b14-724a-4036-8edb-d19a02809840",
+      "slug": "strings",
+      "name": "Strings",
+      "blurb": "TODO: add blurb for strings concept"
+    },
+    {
+      "uuid": "78f3c7b2-cb9c-4d21-8cb4-7106a188f713",
+      "slug": "ternary-operators",
+      "name": "Ternary Operators",
+      "blurb": "TODO: add blurb for ternary-operators concept"
+    }
+  ]
 }

--- a/languages/javascript/config.json
+++ b/languages/javascript/config.json
@@ -79,5 +79,109 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "e1b15569-387c-4833-8c3b-9a94e0ee1583",
+      "slug": "array-analysis",
+      "name": "Array Analysis",
+      "blurb": "TODO: add blurb for array-analysis concept"
+    },
+    {
+      "uuid": "9f8f96bb-db13-485a-bfe4-6ae3fe2fbf46",
+      "slug": "array-destructuring",
+      "name": "Array Destructuring",
+      "blurb": "TODO: add blurb for array-destructuring concept"
+    },
+    {
+      "uuid": "5b0ab681-f44f-4910-b2cf-0b1fcd19ba55",
+      "slug": "array-loops",
+      "name": "Array Loops",
+      "blurb": "TODO: add blurb for array-loops concept"
+    },
+    {
+      "uuid": "c7c56d2a-636f-4976-9e08-931258a47923",
+      "slug": "arrays",
+      "name": "Arrays",
+      "blurb": "TODO: add blurb for arrays concept"
+    },
+    {
+      "uuid": "611d6b3d-1241-4432-90f6-8fcffb36917c",
+      "slug": "basics",
+      "name": "Basics",
+      "blurb": "TODO: add blurb for basics concept"
+    },
+    {
+      "uuid": "791d215c-6813-479a-a126-d9ad9cdc49a9",
+      "slug": "booleans",
+      "name": "Booleans",
+      "blurb": "TODO: add blurb for booleans concept"
+    },
+    {
+      "uuid": "fba5ca5c-849c-44ee-91be-3d6c81a3cf4e",
+      "slug": "callbacks",
+      "name": "Callbacks",
+      "blurb": "TODO: add blurb for callbacks concept"
+    },
+    {
+      "uuid": "bffd6d06-c10a-469c-812b-9b75010c8416",
+      "slug": "closures",
+      "name": "Closures",
+      "blurb": "TODO: add blurb for closures concept"
+    },
+    {
+      "uuid": "2d0b9f1f-c135-4014-b87c-25b081387002",
+      "slug": "conditionals",
+      "name": "Conditionals",
+      "blurb": "TODO: add blurb for conditionals concept"
+    },
+    {
+      "uuid": "95ba7bed-c370-4f20-9173-79cbd5c2416e",
+      "slug": "errors",
+      "name": "Errors",
+      "blurb": "TODO: add blurb for errors concept"
+    },
+    {
+      "uuid": "008f1c88-7c14-48b2-a88d-49ecb5e3b122",
+      "slug": "nullability",
+      "name": "Nullability",
+      "blurb": "TODO: add blurb for nullability concept"
+    },
+    {
+      "uuid": "8da586c3-9327-46e2-ad32-c8423061912d",
+      "slug": "numbers",
+      "name": "Numbers",
+      "blurb": "TODO: add blurb for numbers concept"
+    },
+    {
+      "uuid": "b3aa57d9-74b2-4d04-a673-ae2402630d8b",
+      "slug": "promises",
+      "name": "Promises",
+      "blurb": "TODO: add blurb for promises concept"
+    },
+    {
+      "uuid": "cfbc96fa-717e-4f29-a91d-760ebea88822",
+      "slug": "recursion",
+      "name": "Recursion",
+      "blurb": "TODO: add blurb for recursion concept"
+    },
+    {
+      "uuid": "19085ad2-038a-4e08-ad34-47ff2a78fec6",
+      "slug": "string-formatting",
+      "name": "String Formatting",
+      "blurb": "TODO: add blurb for string-formatting concept"
+    },
+    {
+      "uuid": "7d5c1533-c7cf-418e-b0f2-080da1e5bdc5",
+      "slug": "strings",
+      "name": "Strings",
+      "blurb": "TODO: add blurb for strings concept"
+    },
+    {
+      "uuid": "a8cdc468-c950-43d7-a1b8-99a5e0de651a",
+      "slug": "variable-parameters",
+      "name": "Variable Parameters",
+      "blurb": "TODO: add blurb for variable-parameters concept"
+    }
+  ]
 }

--- a/languages/julia/config.json
+++ b/languages/julia/config.json
@@ -57,5 +57,103 @@
             }
         ],
         "practice": []
-    }
+    },
+    "concepts": [
+        {
+            "uuid": "7d7cef41-5cef-4896-9aa3-cd7baf15339c",
+            "slug": "abstract-types",
+            "name": "Abstract Types",
+            "blurb": "TODO: add blurb for abstract-types concept"
+        },
+        {
+            "uuid": "839e5029-3bde-4823-8177-7b04a43cbf62",
+            "slug": "boolean-logic",
+            "name": "Boolean Logic",
+            "blurb": "TODO: add blurb for boolean-logic concept"
+        },
+        {
+            "uuid": "9470279c-9960-420b-b266-53e329bb205c",
+            "slug": "booleans",
+            "name": "Booleans",
+            "blurb": "TODO: add blurb for booleans concept"
+        },
+        {
+            "uuid": "aad9773b-9032-4d8d-a9e9-4b8152f35b68",
+            "slug": "composite-types",
+            "name": "Composite Types",
+            "blurb": "TODO: add blurb for composite-types concept"
+        },
+        {
+            "uuid": "3584666e-faaa-4a30-b5af-b80c4ee980c7",
+            "slug": "constants",
+            "name": "Constants",
+            "blurb": "TODO: add blurb for constants concept"
+        },
+        {
+            "uuid": "daef8574-4fed-4385-919b-82a16e3b9701",
+            "slug": "emoji-symbols",
+            "name": "Emoji Symbols",
+            "blurb": "TODO: add blurb for emoji-symbols concept"
+        },
+        {
+            "uuid": "32384ed4-ef26-4118-8ea3-4d44c331e828",
+            "slug": "functions-introduction",
+            "name": "Functions Introduction",
+            "blurb": "TODO: add blurb for functions-introduction concept"
+        },
+        {
+            "uuid": "0ac24090-fa7b-4b36-a78c-4c2fe3686223",
+            "slug": "matrices-concatenation",
+            "name": "Matrices Concatenation",
+            "blurb": "TODO: add blurb for matrices-concatenation concept"
+        },
+        {
+            "uuid": "63b504c0-a6b4-410b-8ebd-9e6745ad99f0",
+            "slug": "matrices-indices",
+            "name": "Matrices Indices",
+            "blurb": "TODO: add blurb for matrices-indices concept"
+        },
+        {
+            "uuid": "6d1448b6-847a-4c18-9a9b-3ad37a66d31e",
+            "slug": "matrices-introduction",
+            "name": "Matrices Introduction",
+            "blurb": "TODO: add blurb for matrices-introduction concept"
+        },
+        {
+            "uuid": "de3002c3-9234-4516-923f-2ffb33024ea5",
+            "slug": "matrices-iteration",
+            "name": "Matrices Iteration",
+            "blurb": "TODO: add blurb for matrices-iteration concept"
+        },
+        {
+            "uuid": "1ba6abf2-646a-444d-a820-e94560e6f685",
+            "slug": "matrices-mutation",
+            "name": "Matrices Mutation",
+            "blurb": "TODO: add blurb for matrices-mutation concept"
+        },
+        {
+            "uuid": "8ca3e0f2-30ef-4a27-b30e-c196fcc6104f",
+            "slug": "methods",
+            "name": "Methods",
+            "blurb": "TODO: add blurb for methods concept"
+        },
+        {
+            "uuid": "84567594-5ec1-48f4-bfaf-f6480a75c47e",
+            "slug": "multiple-dispatch",
+            "name": "Multiple Dispatch",
+            "blurb": "TODO: add blurb for multiple-dispatch concept"
+        },
+        {
+            "uuid": "ac862fcd-90a1-404c-8f6d-ba42f2c813a4",
+            "slug": "symbols",
+            "name": "Symbols",
+            "blurb": "TODO: add blurb for symbols concept"
+        },
+        {
+            "uuid": "7ebfefea-f725-4b3e-9f2d-b5820b73dd9a",
+            "slug": "unicode-identifiers",
+            "name": "Unicode Identifiers",
+            "blurb": "TODO: add blurb for unicode-identifiers concept"
+        }
+    ]
 }

--- a/languages/kotlin/config.json
+++ b/languages/kotlin/config.json
@@ -14,6 +14,14 @@
     ],
     "practice": []
   },
+  "concepts": [
+    {
+      "uuid": "72e47dcb-dccf-44a5-ab91-8773c2aec5bd",
+      "slug": "basics",
+      "name": "Basics",
+      "blurb": "TODO: add blurb for basics concept"
+    }
+  ],
   "online_editor": {
     "indent_style": "space",
     "indent_size": 4

--- a/languages/nim/config.json
+++ b/languages/nim/config.json
@@ -11,5 +11,6 @@
   "exercises": {
     "concept": [],
     "practice": []
-  }
+  },
+  "concepts": []
 }

--- a/languages/perl5/config.json
+++ b/languages/perl5/config.json
@@ -11,5 +11,6 @@
   "exercises": {
     "concept": [],
     "practice": []
-  }
+  },
+  "concepts": []
 }

--- a/languages/purescript/config.json
+++ b/languages/purescript/config.json
@@ -18,5 +18,13 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "aa02ae57-c40b-448f-a2cb-7abc2fab0031",
+      "slug": "booleans",
+      "name": "Booleans",
+      "blurb": "TODO: add blurb for booleans concept"
+    }
+  ]
 }

--- a/languages/python/config.json
+++ b/languages/python/config.json
@@ -44,5 +44,67 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "d1aee0de-68ca-468b-a808-289bd905e837",
+      "slug": "basics",
+      "name": "Basics",
+      "blurb": "TODO: add blurb for basics concept"
+    },
+    {
+      "uuid": "ae8ba59d-5be3-45cd-869d-1a654249c60a",
+      "slug": "bools",
+      "name": "Bools",
+      "blurb": "TODO: add blurb for bools concept"
+    },
+    {
+      "uuid": "4e6fcb5c-23db-4788-b043-9817cbfa1b9a",
+      "slug": "for-loops",
+      "name": "For Loops",
+      "blurb": "TODO: add blurb for for-loops concept"
+    },
+    {
+      "uuid": "f82fd15e-d7ad-4478-b7cb-d94705557827",
+      "slug": "functions",
+      "name": "Functions",
+      "blurb": "TODO: add blurb for functions concept"
+    },
+    {
+      "uuid": "cb6d5297-5752-4f4b-a6e9-899410efc13e",
+      "slug": "if-keyword",
+      "name": "If Keyword",
+      "blurb": "TODO: add blurb for if-keyword concept"
+    },
+    {
+      "uuid": "90751178-4bcd-491b-a3f6-03bb5964dcfe",
+      "slug": "in-keyword",
+      "name": "In Keyword",
+      "blurb": "TODO: add blurb for in-keyword concept"
+    },
+    {
+      "uuid": "e0656e6f-25c7-4653-a700-a2c1f27a1cd9",
+      "slug": "integers",
+      "name": "Integers",
+      "blurb": "TODO: add blurb for integers concept"
+    },
+    {
+      "uuid": "50cc2099-4eb2-40b9-8f7a-e5cd56b8ef88",
+      "slug": "return-keyword",
+      "name": "Return Keyword",
+      "blurb": "TODO: add blurb for return-keyword concept"
+    },
+    {
+      "uuid": "1eec0dde-4599-450f-909d-2b20ea40e73d",
+      "slug": "strings",
+      "name": "Strings",
+      "blurb": "TODO: add blurb for strings concept"
+    },
+    {
+      "uuid": "5894fb84-c313-464c-86f0-cd5e3eceeab1",
+      "slug": "tuples",
+      "name": "Tuples",
+      "blurb": "TODO: add blurb for tuples concept"
+    }
+  ]
 }

--- a/languages/ruby/config.json
+++ b/languages/ruby/config.json
@@ -55,5 +55,79 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "7f2bf3a7-9771-48e8-bb6a-3022ca073a41",
+      "slug": "arrays",
+      "name": "Arrays",
+      "blurb": "TODO: add blurb for arrays concept"
+    },
+    {
+      "uuid": "fe345fe6-229b-4b4b-a489-4ed3b77a1d7e",
+      "slug": "basics",
+      "name": "Basics",
+      "blurb": "TODO: add blurb for basics concept"
+    },
+    {
+      "uuid": "bf57350d-9e18-4ec6-9341-e4d2c289724d",
+      "slug": "blocks",
+      "name": "Blocks",
+      "blurb": "TODO: add blurb for blocks concept"
+    },
+    {
+      "uuid": "831b4db4-6b75-4a8d-a835-4c2555aacb61",
+      "slug": "booleans",
+      "name": "Booleans",
+      "blurb": "TODO: add blurb for booleans concept"
+    },
+    {
+      "uuid": "acec3b2a-c1cc-4583-bd4b-9f7ae41acfb3",
+      "slug": "classes",
+      "name": "Classes",
+      "blurb": "TODO: add blurb for classes concept"
+    },
+    {
+      "uuid": "dedd9182-66b7-4fbc-bf4b-ba6603edbfca",
+      "slug": "conditionals",
+      "name": "Conditionals",
+      "blurb": "TODO: add blurb for conditionals concept"
+    },
+    {
+      "uuid": "01d61b5c-8f50-4b12-9fe0-0723e6f00999",
+      "slug": "floating-point-numbers",
+      "name": "Floating Point Numbers",
+      "blurb": "TODO: add blurb for floating-point-numbers concept"
+    },
+    {
+      "uuid": "35001ed1-a7b9-4a80-a766-26725a29dc50",
+      "slug": "instance-variables",
+      "name": "Instance Variables",
+      "blurb": "TODO: add blurb for instance-variables concept"
+    },
+    {
+      "uuid": "152d3976-dbcb-4a16-9f89-c61e0cdda4e5",
+      "slug": "loops",
+      "name": "Loops",
+      "blurb": "TODO: add blurb for loops concept"
+    },
+    {
+      "uuid": "aa31cd95-54b2-4728-8fe3-2fdc244b3f53",
+      "slug": "nil",
+      "name": "Nil",
+      "blurb": "TODO: add blurb for nil concept"
+    },
+    {
+      "uuid": "162721bd-3d64-43ff-889e-6fb2eac75709",
+      "slug": "numbers",
+      "name": "Numbers",
+      "blurb": "TODO: add blurb for numbers concept"
+    },
+    {
+      "uuid": "3b1da281-7099-4c93-a109-178fc9436d68",
+      "slug": "strings",
+      "name": "Strings",
+      "blurb": "TODO: add blurb for strings concept"
+    }
+  ]
 }

--- a/languages/rust/config.json
+++ b/languages/rust/config.json
@@ -42,5 +42,103 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "a2e79ee4-8534-45ac-ad36-5dcde91a6bf4",
+      "slug": "entry-api",
+      "name": "Entry Api",
+      "blurb": "TODO: add blurb for entry-api concept"
+    },
+    {
+      "uuid": "40d727f1-d011-4305-b1c2-1b4380246d9b",
+      "slug": "enums-basic",
+      "name": "Enums Basic",
+      "blurb": "TODO: add blurb for enums-basic concept"
+    },
+    {
+      "uuid": "cebb248b-b9d5-4189-a764-87b14e8dd603",
+      "slug": "floating-point-numbers",
+      "name": "Floating Point Numbers",
+      "blurb": "TODO: add blurb for floating-point-numbers concept"
+    },
+    {
+      "uuid": "49f19bcc-4d61-4b12-9241-12ffbea8c1b7",
+      "slug": "floats",
+      "name": "Floats",
+      "blurb": "TODO: add blurb for floats concept"
+    },
+    {
+      "uuid": "11d39059-0949-4bfe-a89c-0fd522c3baee",
+      "slug": "hashmaps",
+      "name": "Hashmaps",
+      "blurb": "TODO: add blurb for hashmaps concept"
+    },
+    {
+      "uuid": "8e399de6-f143-45fb-bb8e-1ce1f15dcf01",
+      "slug": "integers",
+      "name": "Integers",
+      "blurb": "TODO: add blurb for integers concept"
+    },
+    {
+      "uuid": "4cd3ad94-0a2a-4f44-a0dc-0c7402225499",
+      "slug": "intro-fn",
+      "name": "Intro Fn",
+      "blurb": "TODO: add blurb for intro-fn concept"
+    },
+    {
+      "uuid": "257cc7b3-7b69-488d-8789-644a412a1668",
+      "slug": "intro-option",
+      "name": "Intro Option",
+      "blurb": "TODO: add blurb for intro-option concept"
+    },
+    {
+      "uuid": "9eb55d59-7953-46ab-a8cc-8525daddf1a9",
+      "slug": "intro-types",
+      "name": "Intro Types",
+      "blurb": "TODO: add blurb for intro-types concept"
+    },
+    {
+      "uuid": "b1d55ba6-2b4a-4f85-bbdf-9cef4f9a7e2b",
+      "slug": "match.pattern-matching",
+      "name": "Match.Pattern Matching",
+      "blurb": "TODO: add blurb for match.pattern-matching concept"
+    },
+    {
+      "uuid": "d552644c-ba59-4441-9a73-f0df4291549c",
+      "slug": "numbers",
+      "name": "Numbers",
+      "blurb": "TODO: add blurb for numbers concept"
+    },
+    {
+      "uuid": "36bc26cf-dd54-4706-9abf-7a89e6a168e3",
+      "slug": "option",
+      "name": "Option",
+      "blurb": "TODO: add blurb for option concept"
+    },
+    {
+      "uuid": "950c39f1-9647-41d5-8ec7-33b02863178f",
+      "slug": "signedness",
+      "name": "Signedness",
+      "blurb": "TODO: add blurb for signedness concept"
+    },
+    {
+      "uuid": "8dc3c89e-afd4-4155-a79a-9699852ea21e",
+      "slug": "string-use",
+      "name": "String Use",
+      "blurb": "TODO: add blurb for string-use concept"
+    },
+    {
+      "uuid": "46a207e8-560b-421d-871e-0b743f8eaeb8",
+      "slug": "strings-basic",
+      "name": "Strings Basic",
+      "blurb": "TODO: add blurb for strings-basic concept"
+    },
+    {
+      "uuid": "febd2cf9-e058-48ef-bdc7-7583fb67e053",
+      "slug": "structs",
+      "name": "Structs",
+      "blurb": "TODO: add blurb for structs concept"
+    }
+  ]
 }

--- a/languages/scala/config.json
+++ b/languages/scala/config.json
@@ -11,5 +11,6 @@
   "exercises": {
     "concept": [],
     "practice": []
-  }
+  },
+  "concepts": []
 }

--- a/languages/swift/config.json
+++ b/languages/swift/config.json
@@ -111,5 +111,217 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "ca0161f2-1915-4911-8595-3854c391a502",
+      "slug": "arrays",
+      "name": "Arrays",
+      "blurb": "TODO: add blurb for arrays concept"
+    },
+    {
+      "uuid": "e59edeed-a13b-427b-9677-c36f276f440a",
+      "slug": "basics",
+      "name": "Basics",
+      "blurb": "TODO: add blurb for basics concept"
+    },
+    {
+      "uuid": "1c887c26-d5a1-415b-87d3-b627013a33da",
+      "slug": "booleans",
+      "name": "Booleans",
+      "blurb": "TODO: add blurb for booleans concept"
+    },
+    {
+      "uuid": "ce6ccbb9-352c-4795-8187-7f28e59cfe0b",
+      "slug": "characters",
+      "name": "Characters",
+      "blurb": "TODO: add blurb for characters concept"
+    },
+    {
+      "uuid": "70702be6-4678-44c0-b5d2-6e93ff0b5eb2",
+      "slug": "classes",
+      "name": "Classes",
+      "blurb": "TODO: add blurb for classes concept"
+    },
+    {
+      "uuid": "a8919ee9-23d1-4c74-a30f-d860295c3502",
+      "slug": "conditionals",
+      "name": "Conditionals",
+      "blurb": "TODO: add blurb for conditionals concept"
+    },
+    {
+      "uuid": "d9ab700f-01ca-4d7e-991f-efcc2d19548b",
+      "slug": "conditionals-guard",
+      "name": "Conditionals Guard",
+      "blurb": "TODO: add blurb for conditionals-guard concept"
+    },
+    {
+      "uuid": "0ce7e6f2-ae63-4e0f-8eeb-8bc9831f4578",
+      "slug": "conditionals-if",
+      "name": "Conditionals If",
+      "blurb": "TODO: add blurb for conditionals-if concept"
+    },
+    {
+      "uuid": "e8fec07d-7a44-4ae4-8ad7-bc788c3ff827",
+      "slug": "conditionals-switch",
+      "name": "Conditionals Switch",
+      "blurb": "TODO: add blurb for conditionals-switch concept"
+    },
+    {
+      "uuid": "b8fc890f-aa62-44e9-acd3-9e90f6706000",
+      "slug": "constants",
+      "name": "Constants",
+      "blurb": "TODO: add blurb for constants concept"
+    },
+    {
+      "uuid": "290d9abd-355f-48fe-baf0-c5dd6b3b1801",
+      "slug": "default-parameters",
+      "name": "Default Parameters",
+      "blurb": "TODO: add blurb for default-parameters concept"
+    },
+    {
+      "uuid": "9a6357cc-1635-4ba6-80be-e5c525fabfb9",
+      "slug": "enumerations",
+      "name": "Enumerations",
+      "blurb": "TODO: add blurb for enumerations concept"
+    },
+    {
+      "uuid": "971b030e-4401-431a-a947-c5a34f519b7e",
+      "slug": "function-overloading",
+      "name": "Function Overloading",
+      "blurb": "TODO: add blurb for function-overloading concept"
+    },
+    {
+      "uuid": "8fe54be1-48e6-49c7-8137-efdd25973716",
+      "slug": "functions",
+      "name": "Functions",
+      "blurb": "TODO: add blurb for functions concept"
+    },
+    {
+      "uuid": "71b8a728-e8c9-466c-a53c-a7d436a732d1",
+      "slug": "higher-order-functions",
+      "name": "Higher Order Functions",
+      "blurb": "TODO: add blurb for higher-order-functions concept"
+    },
+    {
+      "uuid": "f7b413b4-9316-4b93-92a5-84b7b90f9169",
+      "slug": "importing",
+      "name": "Importing",
+      "blurb": "TODO: add blurb for importing concept"
+    },
+    {
+      "uuid": "4105e13e-cc28-4081-9556-8d6057571dae",
+      "slug": "initializers",
+      "name": "Initializers",
+      "blurb": "TODO: add blurb for initializers concept"
+    },
+    {
+      "uuid": "7dddb6c1-9737-4c95-997b-6d22f958e4f1",
+      "slug": "inout-parameters",
+      "name": "Inout Parameters",
+      "blurb": "TODO: add blurb for inout-parameters concept"
+    },
+    {
+      "uuid": "35974d7f-b6e3-4e14-942d-e7624a8f5a1f",
+      "slug": "methods",
+      "name": "Methods",
+      "blurb": "TODO: add blurb for methods concept"
+    },
+    {
+      "uuid": "0c12d60a-cab0-49a6-bf92-5866b8bc92b2",
+      "slug": "multiple-return-values",
+      "name": "Multiple Return Values",
+      "blurb": "TODO: add blurb for multiple-return-values concept"
+    },
+    {
+      "uuid": "ce01b3ca-6b8e-407b-a9f5-3e4da78d0719",
+      "slug": "nested-functions",
+      "name": "Nested Functions",
+      "blurb": "TODO: add blurb for nested-functions concept"
+    },
+    {
+      "uuid": "67a32afb-6010-494a-8343-d76bd9cccc38",
+      "slug": "numbers",
+      "name": "Numbers",
+      "blurb": "TODO: add blurb for numbers concept"
+    },
+    {
+      "uuid": "b734ebd0-83d5-4e33-94f2-d5a8f1bbd1b4",
+      "slug": "opaque-indices",
+      "name": "Opaque Indices",
+      "blurb": "TODO: add blurb for opaque-indices concept"
+    },
+    {
+      "uuid": "5a144b97-b15d-4b51-9818-a94619f5eef3",
+      "slug": "optionals",
+      "name": "Optionals",
+      "blurb": "TODO: add blurb for optionals concept"
+    },
+    {
+      "uuid": "a4b7ebd1-28f4-4270-910f-cf511ec4b45a",
+      "slug": "self",
+      "name": "Self",
+      "blurb": "TODO: add blurb for self concept"
+    },
+    {
+      "uuid": "32dbc50c-beb2-4162-910f-ecdae0e48109",
+      "slug": "stored-properties",
+      "name": "Stored Properties",
+      "blurb": "TODO: add blurb for stored-properties concept"
+    },
+    {
+      "uuid": "343255a9-9931-4887-941e-e768448bf6a4",
+      "slug": "string-components",
+      "name": "String Components",
+      "blurb": "TODO: add blurb for string-components concept"
+    },
+    {
+      "uuid": "6b721b54-e85e-4156-af34-04f36ec37af0",
+      "slug": "string-indexing",
+      "name": "String Indexing",
+      "blurb": "TODO: add blurb for string-indexing concept"
+    },
+    {
+      "uuid": "2174427d-86c6-4e89-bf1d-3722933b8d04",
+      "slug": "strings",
+      "name": "Strings",
+      "blurb": "TODO: add blurb for strings concept"
+    },
+    {
+      "uuid": "293ea717-4f2c-4c7f-bf1b-823696635146",
+      "slug": "structs",
+      "name": "Structs",
+      "blurb": "TODO: add blurb for structs concept"
+    },
+    {
+      "uuid": "0a8fd1c6-3d73-4f77-921f-8cdd2b4ae32f",
+      "slug": "structs-and-classes",
+      "name": "Structs And Classes",
+      "blurb": "TODO: add blurb for structs-and-classes concept"
+    },
+    {
+      "uuid": "4b52314c-c3a0-458c-a463-d051c146df95",
+      "slug": "tuples",
+      "name": "Tuples",
+      "blurb": "TODO: add blurb for tuples concept"
+    },
+    {
+      "uuid": "85147cec-238c-4cc9-a3b3-fc7792f53508",
+      "slug": "type-annotations",
+      "name": "Type Annotations",
+      "blurb": "TODO: add blurb for type-annotations concept"
+    },
+    {
+      "uuid": "5da5a2b3-5d51-44e9-810b-a5379abe41f0",
+      "slug": "variables",
+      "name": "Variables",
+      "blurb": "TODO: add blurb for variables concept"
+    },
+    {
+      "uuid": "f6bb1433-96ae-4efe-b1f6-abbe0f48cd9c",
+      "slug": "variadic-parameters",
+      "name": "Variadic Parameters",
+      "blurb": "TODO: add blurb for variadic-parameters concept"
+    }
+  ]
 }

--- a/languages/x86-64-assembly/config.json
+++ b/languages/x86-64-assembly/config.json
@@ -15,5 +15,13 @@
       }
     ],
     "practice": []
-  }
+  },
+  "concepts": [
+    {
+      "uuid": "96a9995c-c428-4759-b995-05da80f14f02",
+      "slug": "basics",
+      "name": "Basics",
+      "blurb": "TODO: add blurb for basics concept"
+    }
+  ]
 }


### PR DESCRIPTION
As per the [updated specification](https://github.com/exercism/v3/issues/2293), this PR adds a top-level "concepts" section to each track's `config.json` file. The `name` property is inferred from the slug, but could use some tweaking here and there. Individual tracks can do this themselves once this merged. The same goes for the `blurb` property, which has just some placeholder TODO text.

I'll update the documentation in a separate PR.