### PR TITLE
Add practice exercises

### DIFF
--- a/languages/c/config.json
+++ b/languages/c/config.json
@@ -13,5 +13,655 @@
     "concept": [],
     "practice": []
   },
-  "concepts": []
+  "concepts": [],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "ee307061-5bc2-439c-8815-abd730aedc2d",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "a4658ee9-b71c-4764-9652-7ed83d46516b",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "logic",
+        "math"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "darts",
+      "uuid": "a579e471-86f3-4f29-82ca-e984a2cc8891",
+      "prerequisites": [],
+      "topics": ["control_flow_if_else_statements", "logic", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color",
+      "uuid": "75653d83-1a64-472c-ac43-49e87833c7f7",
+      "prerequisites": [],
+      "topics": ["arrays", "enums", "pointers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color-duo",
+      "uuid": "93271b2e-8ad9-4e7d-8732-5988140e8c00",
+      "prerequisites": [],
+      "topics": ["arrays", "enums"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color-trio",
+      "uuid": "6cd7bb9c-2817-4c44-8bef-5f2916b2db2d",
+      "prerequisites": [],
+      "topics": ["arrays", "enums", "structs"],
+      "difficulty": 1
+    },
+    {
+      "slug": "isogram",
+      "uuid": "b3c9d339-60bc-48fe-84ba-77cbc0017a89",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "strings"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "acronym",
+      "uuid": "1a8ba121-d2c4-4994-8c6b-610d8987346d",
+      "prerequisites": [],
+      "topics": ["control_flow_loops", "memory_management", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "word-count",
+      "uuid": "1e4f4fcf-c32d-459f-8920-15ac56008666",
+      "prerequisites": [],
+      "topics": ["filtering", "memory_management", "strings", "structs"],
+      "difficulty": 3
+    },
+    {
+      "slug": "pangram",
+      "uuid": "6311b9f8-b438-4186-88b2-1e4f55275ccb",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "strings"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "000340f6-e30d-4d49-a255-016237d6fe60",
+      "prerequisites": [],
+      "topics": ["dates"],
+      "difficulty": 1
+    },
+    {
+      "slug": "space-age",
+      "uuid": "fc03c7de-b0c6-4806-90bb-e9dda846e660",
+      "prerequisites": [],
+      "topics": ["functions"],
+      "difficulty": 1
+    },
+    {
+      "slug": "meetup",
+      "uuid": "a7baa53f-e828-457e-a456-ba3471494d80",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_statements",
+        "preprocessor_x_macros_in_test",
+        "strings",
+        "structs",
+        "time_functions"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "hamming",
+      "uuid": "fa5e6bbb-2eaf-484f-a5c5-de5cb2a9175b",
+      "prerequisites": [],
+      "topics": ["arrays", "control_flow_loops", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "d12fea98-bf4e-476d-a91c-799fc98a1690",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_case_statements",
+        "control_flow_loops",
+        "strings"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "38669990-e1e6-4486-a603-575a135d1f5c",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_loops_switch_if_statements",
+        "memory_management",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "grains",
+      "uuid": "53959d50-efad-4911-84de-b67efe1bee5f",
+      "prerequisites": [],
+      "topics": [
+        "bitwise_operations",
+        "control_flow_loops",
+        "performance_optimizations"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "9b047dda-b85e-4378-9487-9f9cce086e4f",
+      "prerequisites": [],
+      "topics": ["control_flow_if_else_statements", "logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "c06789cb-cdd6-44a7-bee5-16e0d85e913a",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "strings"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "93acdd0d-9bd1-4dec-a572-fd12d0c66187",
+      "prerequisites": [],
+      "topics": ["control_flow_if_else_statements", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "bob",
+      "uuid": "b0feb5e2-eb94-4393-b60d-cf8a275d1860",
+      "prerequisites": [],
+      "topics": ["control_flow_if_else_statements", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "9802cbc0-eb70-4840-b8ee-a228f1fc29ea",
+      "prerequisites": [],
+      "topics": ["control_flow_loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "06a3660f-16b0-4391-939e-a9786887b0b2",
+      "prerequisites": [],
+      "topics": ["control_flow_case_statements", "control_flow_loops", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "square-root",
+      "uuid": "0400f52d-48ae-4300-a72e-32e8a08514d0",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "control_flow_loops", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "68b1de28-7c3d-4e8c-ab51-7abe6779e187",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "pointers",
+        "sorting",
+        "strings",
+        "structs"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "db1771d2-afd8-4e01-9b6a-6be75029ef1d",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "searching"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "anagram",
+      "uuid": "0b64079a-7fec-42b4-bd2e-1b04dd4b7e6e",
+      "prerequisites": [],
+      "topics": ["filtering", "strings", "structs"],
+      "difficulty": 5
+    },
+    {
+      "slug": "rational-numbers",
+      "uuid": "c3325db9-8067-4c2f-94b3-b5190b056d38",
+      "prerequisites": [],
+      "topics": ["math", "structs"],
+      "difficulty": 5
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "6cde608f-9819-46cd-884b-dbda39a4fa16",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "control_flow_loops",
+        "memory_management",
+        "strings",
+        "structs"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "c54a33a3-8c6f-4964-b770-b602d207fa20",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "buffers",
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "flexible_array_members",
+        "memory_management",
+        "pointers",
+        "structs"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "27a56356-d3ad-41d2-923c-2a58fbb36454",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "flexible_array_members",
+        "function_pointers",
+        "memory_management",
+        "pointers",
+        "structs"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "7b7c61f4-2849-46b7-9057-900bb6b95052",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "flexible_array_members",
+        "memory_management",
+        "structs"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "448f9137-4e58-4c26-9853-abe07f01c908",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "flexible_array_members",
+        "memory_management",
+        "structs"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "allergies",
+      "uuid": "871f1c41-debd-4807-8ee5-bde54c3918f8",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_statements",
+        "control_flow_loops",
+        "memory_management",
+        "structs"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "180f59f3-78ab-4368-9fa7-e3d98a9dca78",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "strings"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "series",
+      "uuid": "40bcec79-7235-4ac6-b69f-8e3a6374188d",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_statements",
+        "memory_management",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "react",
+      "uuid": "929b651e-2017-4f98-b2cb-1dc46c609703",
+      "prerequisites": [],
+      "topics": ["functions", "memory_management"],
+      "difficulty": 10
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "660d1586-c4e0-4537-94b5-455a983820f8",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "memory_management",
+        "strings"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "clock",
+      "uuid": "b868eeff-400c-4e46-8675-10d85c14b503",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_statements",
+        "preprocessor_x_macros_in_test",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "sieve",
+      "uuid": "fb2530a3-cbbf-4ba9-88d0-203faac03e96",
+      "prerequisites": [],
+      "topics": ["control_flow_if_statements", "math", "memory_management"],
+      "difficulty": 2
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "a0a703b2-244b-4739-b318-b837618b1047",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "math",
+        "performance_optimizations"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "e665da31-fda2-4bce-94e9-7d79dffdef14",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_statements",
+        "pointers",
+        "strings",
+        "structs",
+        "variable_argument_lists"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "be19352f-1b63-4673-9a2d-e763ee807741",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_else_statements",
+        "math",
+        "memory_management"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "triangle",
+      "uuid": "5c6bc8d2-2509-471a-993c-a5bf9d030ca7",
+      "prerequisites": [],
+      "topics": ["booleans", "control_flow_if_else_statements", "structs"],
+      "difficulty": 1
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "a1168a15-d46f-4541-8b58-68bca0c54733",
+      "prerequisites": [],
+      "topics": ["control_flow_if_else_statements", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "5a47f8a5-36a1-4479-bb77-ef5fbab4bae0",
+      "prerequisites": [],
+      "topics": ["functions", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "binary",
+      "uuid": "8621177c-1068-4610-bf5b-26cf23340ae6",
+      "prerequisites": [],
+      "topics": ["control_flow_if_statements", "control_flow_loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "e3574f75-89cb-4dda-8fce-14ce3141b595",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "control_flow_if_else_statements",
+        "control_flow_loops",
+        "math"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "8dd43f6c-37ba-42b1-bb85-9ad693e4ce03",
+      "prerequisites": [],
+      "topics": ["functions", "math", "pointers", "strings", "structs"],
+      "difficulty": 2
+    },
+    {
+      "slug": "sublist",
+      "uuid": "a19acc6f-2530-434d-9c98-2d8d4ca635d3",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "control_flow_if_statements",
+        "control_flow_loops",
+        "pointers",
+        "searching"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "4b5974fe-dcff-4542-ad3e-2782201cba1e",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_loops",
+        "math",
+        "performance_optimizations",
+        "strings"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "8c631290-13b7-4d25-9ee7-ced2e534deb4",
+      "prerequisites": [],
+      "topics": ["pointers", "searching", "strings", "structs"],
+      "difficulty": 4
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "b0a152e9-5a45-41f9-bda0-427111d9a56c",
+      "prerequisites": [],
+      "topics": ["control_flow_if_statements", "enums", "functions", "structs"],
+      "difficulty": 1
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "58107e5f-8091-4429-9130-13f2c7dac9a9",
+      "prerequisites": [],
+      "topics": ["functions", "lists", "pointers", "structs"],
+      "difficulty": 4
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "472b1a6b-2b7a-4609-a97d-4c2b6c941a1f",
+      "prerequisites": [],
+      "topics": ["math", "performance_optimizations", "structs"],
+      "difficulty": 2
+    },
+    {
+      "slug": "etl",
+      "uuid": "9b6faac9-10dd-46ff-9d29-7242e74f5c06",
+      "prerequisites": [],
+      "topics": ["pointers", "structs"],
+      "difficulty": 2
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "f34db12c-7acc-4287-92a6-c077938512d7",
+      "prerequisites": [],
+      "topics": ["algorithms", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "luhn",
+      "uuid": "8c0762e6-702e-4733-a0a1-65099e2a46f7",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "cd573670-54da-4291-ab78-afd5d77fbeac",
+      "prerequisites": [],
+      "topics": ["control_flow_if_statements", "recursion", "stacks"],
+      "difficulty": 5
+    },
+    {
+      "slug": "say",
+      "uuid": "523fa391-08d4-4c4e-95e6-20335cd157a0",
+      "prerequisites": [],
+      "topics": ["algorithms", "control_flow_if_statements", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "23c2a169-eea2-4636-af62-4a77a4dc3d7b",
+      "prerequisites": [],
+      "topics": ["algorithms", "control_flow_if_statements", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "119c20a6-849f-412e-b0a6-113a2cedc72d",
+      "prerequisites": [],
+      "topics": ["algorithms", "control_flow_if_statements", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "62f539e7-f682-412d-bf86-38503e7cebca",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "control_flow_if_statements",
+        "functions",
+        "strings"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "2e97072f-9e77-4ddd-9d75-6162a927bab1",
+      "prerequisites": [],
+      "topics": ["arrays", "control_flow_if_statements", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "b22152b9-99d1-411c-8cf2-f89e8f5f8141",
+      "prerequisites": [],
+      "topics": ["algorithms", "control_flow_if_statements", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "15653c72-5468-415f-9425-6c58d552d346",
+      "prerequisites": [],
+      "topics": ["control_flow_if_statements", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "wordy",
+      "uuid": "c1392944-08fd-45c3-b508-41d682f832d3",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "control_flow_if_statements",
+        "functions",
+        "strings"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "1b33f528-8f29-4582-a268-07be2d1a4516",
+      "prerequisites": [],
+      "topics": ["arrays", "control_flow_loops", "recursion", "structs"],
+      "difficulty": 6
+    },
+    {
+      "slug": "diamond",
+      "uuid": "8605a296-1c67-4723-84ac-3a25d77ed015",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "control_flow_if_statements",
+        "functions",
+        "strings"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "314dcf23-9cd9-4488-b53e-6dee1b303980",
+      "prerequisites": [],
+      "topics": ["arrays", "control_flow_if_statements", "strings"],
+      "difficulty": 4
+    }
+  ]
 }

--- a/languages/clojure/config.json
+++ b/languages/clojure/config.json
@@ -4,7 +4,10 @@
   "active": true,
   "blurb": "a JVM hosted functional programming language.",
   "version": 3,
-  "online_editor": { "indent_style": "space", "indent_size": 2 },
+  "online_editor": {
+    "indent_style": "space",
+    "indent_size": 2
+  },
   "exercises": {
     "concept": [
       {
@@ -22,6 +25,482 @@
       "slug": "lists",
       "name": "Lists",
       "blurb": "TODO: add blurb for lists concept"
+    }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "1378910d-9bec-4217-bd40-07a8967fa3ad",
+      "prerequisites": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "91a1f32c-0dac-4c65-8a13-49da90d21520",
+      "prerequisites": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "a8957cc5-d99e-4a31-9d49-4653226fd50b",
+      "prerequisites": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "bob",
+      "uuid": "d3bcad28-db03-4f6c-a85d-9f2d01331e88",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "a4bdbdfd-1db1-425c-a243-dd032dc7b93a",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "c2100dff-4d18-4fcb-9035-6c57eddd6d37",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "04a6c1d6-6cce-4c87-a34b-23fdd9baf70d",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "e6411d18-d9b9-48fa-8ee6-0df8c13d3dee",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "word-count",
+      "uuid": "3ab74232-11f5-4efd-82ac-e7c4129c7ff4",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "anagram",
+      "uuid": "04ac2bd0-504c-4faa-912e-d2111b46123c",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "say",
+      "uuid": "31aa2618-b971-44ff-9799-761fdec53b87",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "c14ef548-c5f6-43a9-84e2-c7238705fc8e",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "c14ef548-c5f6-43a9-84e2-c7248705fc8e",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "series",
+      "uuid": "c34af548-c5f6-43a9-84e2-c4166605fc8e",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "66d97ae9-36ac-47c6-8b9f-e77ce498fc70",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "hamming",
+      "uuid": "60004bf0-e551-4bfc-bda9-49c5611811c4",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "84ce66e5-6091-4078-9921-c0b8ccabc86f",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "clock",
+      "uuid": "8e722baf-bbf9-445f-9adb-b21db88b5132",
+      "prerequisites": [],
+      "difficulty": 5
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "f4cf3676-4399-4d1c-b21f-8e735c7af8cc",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "95580d10-92db-4809-b5e7-4085319d19e9",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "3ce7ad7d-61ef-4a71-b87a-8c1b45c758b6",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "leap",
+      "uuid": "0cde8a62-412a-45cc-b16e-4b31057cab74",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "etl",
+      "uuid": "c51658c1-7cdb-4a45-8d4d-2a370b655362",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "11450b65-628d-4890-a668-7031de985f5c",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "sublist",
+      "uuid": "dabe93c3-038c-4c6f-8a2e-f50acf130b8f",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "36f47cc4-0c5e-4edc-b109-c9e007b7b1f8",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "097edd69-91b5-4a71-b197-a9c14b61c4ce",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "meetup",
+      "uuid": "1657cd1a-f3d8-475f-824f-31ba4d8e229a",
+      "prerequisites": [],
+      "difficulty": 4
+    },
+    {
+      "slug": "space-age",
+      "uuid": "735e991b-f736-4ca2-80db-f94e20aa2319",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "grains",
+      "uuid": "27b44b76-5e4f-4711-bce0-869e372636dd",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "23498ff3-310e-41b0-b15e-52fec2f2bfcb",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "triangle",
+      "uuid": "74f7eacd-d3de-4467-85b2-8590ba1f28ce",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "01afac67-ff81-432e-b2a0-63f4540f2eb5",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "04d0369f-b0e5-4c00-a0f7-1b86eefba484",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "binary",
+      "uuid": "4c59731d-165a-43e1-9917-16131dadbbac",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "trinary",
+      "uuid": "d32f41d4-e1b1-4daf-8ddc-a2ab9ee07c98",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "d42g42d7-21b1-4daf-8ddc-a2ab9ee07c98",
+      "prerequisites": [],
+      "topics": ["recursivity"],
+      "difficulty": 4
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "068a0997-d333-48cb-a82a-c5082e85115d",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "c1113f92-df4d-4d04-865f-20b8b2c56205",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "allergies",
+      "uuid": "810803c7-4480-4e11-b848-d56477ba9d08",
+      "prerequisites": [],
+      "difficulty": 4
+    },
+    {
+      "slug": "octal",
+      "uuid": "db1a86fb-2f04-4afe-9e45-00b539c86b63",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "strain",
+      "uuid": "ad08dcef-14f7-406d-b3a5-4b5aad37ebf1",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "47266422-622e-4e20-b597-e85ab7bd3046",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "bank-account",
+      "uuid": "e6848f52-a6b5-4669-9b50-beedfd3ebe2f",
+      "prerequisites": [],
+      "difficulty": 7
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "8b90d4c5-0d53-4664-afba-c4ed1c865e77",
+      "prerequisites": [],
+      "difficulty": 4
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "9c8c4689-4990-4266-a02e-2dcb9fa32402",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "a7e1d0a1-feb5-4a55-93c7-e7f81a39238c",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "sieve",
+      "uuid": "910adfb9-be3e-45ef-af4c-facba7825cfd",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "luhn",
+      "uuid": "5f62a862-f65e-4af0-a15d-5aa1fdb4f970",
+      "prerequisites": [],
+      "difficulty": 5
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "5288c0fb-a90d-4f71-b525-e9a7b687aaf2",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "e4f94fe1-7258-4e55-94c8-756a8080f898",
+      "prerequisites": [],
+      "difficulty": 6
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "0bc807ef-60b8-49d9-9428-0060bc5517a9",
+      "prerequisites": [],
+      "difficulty": 7
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "73cdbbd8-04a6-42ba-aeea-1f1c8d53af70",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "62f3cbcb-2503-472f-9544-50e05e368949",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "254199d8-8add-470f-a8fc-8ec9ffc54dd1",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "8ede90b5-d1ad-41c3-8474-2ffaea39e7e4",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "b55eefa5-dce6-46fb-8c0e-4c476cc871ce",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "eec9ea9a-fa32-4ea2-831e-0caccbca208b",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pov",
+      "uuid": "ee9b837b-ea2f-4c77-9a3d-3d0007b9ae88",
+      "prerequisites": [],
+      "difficulty": 10
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "c8ebc25b-17b9-44a9-8cbe-df2c2eb6e2d6",
+      "prerequisites": [],
+      "difficulty": 7
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "2d35d9b3-5cff-4e68-a861-1461b32e22ba",
+      "prerequisites": [],
+      "difficulty": 7
+    },
+    {
+      "slug": "change",
+      "uuid": "6fd886e5-94b0-4938-9f48-f4c6850027a0",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "pangram",
+      "uuid": "398f65f2-2324-4b08-945d-a9fbd62d1a41",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "wordy",
+      "uuid": "4a2033a7-5579-49ac-94d7-8693cee45381",
+      "prerequisites": [],
+      "difficulty": 6
+    },
+    {
+      "slug": "isogram",
+      "uuid": "1fc5c2e9-2851-4735-8fde-612a8c054a5a",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "acronym",
+      "uuid": "e14a4261-c84f-417e-841e-29ff6f1f533d",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "d380de85-4d35-4342-9b88-7402deea2869",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "6768b55e-bab3-4e55-ac71-ddda0bd16298",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "2cc37c2a-7e6c-49ba-8b30-2ff8c9d818c2",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "622823dc-ee47-42a0-acc6-190de4541625",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "diamond",
+      "uuid": "f3971f71-08c9-4e36-a69e-5bd7fe070b07",
+      "prerequisites": [],
+      "difficulty": 5
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "c4b7120c-a7c5-4a39-a08e-8d4fb9861a27",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "proverb",
+      "uuid": "c8ba6ce5-9a7e-4c1c-8044-bb18a0d6ad39",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "poker",
+      "uuid": "7df7ff1c-74ab-4f4e-aaf0-257b6e1cbc18",
+      "prerequisites": [],
+      "difficulty": 7
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "db6162c0-adff-401e-9dd6-a0322ca10dcf",
+      "prerequisites": [],
+      "difficulty": 4
+    },
+    {
+      "slug": "go-counting",
+      "uuid": "987438e8-1db3-447a-a243-e67c7591709d",
+      "prerequisites": [],
+      "difficulty": 9
     }
   ]
 }

--- a/languages/common-lisp/config.json
+++ b/languages/common-lisp/config.json
@@ -424,5 +424,338 @@
       "name": "Variables",
       "blurb": "TODO: add blurb for variables concept"
     }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "d4af6cfa-d468-15b5-dcdf-7d717ddf6556",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "b80ab7d9-6152-4351-b405-07c2fb071962",
+      "prerequisites": [],
+      "topics": ["optional_values", "strings", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "hamming",
+      "uuid": "c029678b-9b9f-4fb2-958f-3a118efa16a9",
+      "prerequisites": [],
+      "topics": ["conditionals", "equality", "filtering", "loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "5c215cbf-a575-42ad-9b3f-892410a63077",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "8bfa54a8-4ee6-4e6e-b286-7fc8c70b9e9f",
+      "prerequisites": [],
+      "topics": ["conditionals", "equality", "integers", "logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "anagram",
+      "uuid": "b9fd0f13-966c-4085-ac9d-ed49a96ac0bf",
+      "prerequisites": [],
+      "topics": ["equality", "filtering", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "5c6f22e7-109c-4d9e-b8bf-4ea63b2823ca",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers", "loops", "text_formatting"],
+      "difficulty": 2
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "150d3608-d234-4c9e-ab6d-2d91f8a2c855",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "integers",
+        "loops",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "word-count",
+      "uuid": "424ed7aa-24f3-4aec-9620-3cc9dc224166",
+      "prerequisites": [],
+      "topics": ["conditionals", "filtering", "loops", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "bob",
+      "uuid": "1e6c8365-775d-4a4f-8fc7-e376912d7912",
+      "prerequisites": [],
+      "topics": ["conditionals", "parsing", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "luhn",
+      "uuid": "7cc9d827-b08e-437d-826e-244f220feca0",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "9b01a3bd-68fe-4171-8e5e-ff3351865aaf",
+      "prerequisites": [],
+      "topics": ["integers", "math", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "acronym",
+      "uuid": "a999c375-f2e2-4d47-a9e2-5af923cd46d1",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "40ce6656-b8f5-4156-94b6-d634876215b2",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "sublist",
+      "uuid": "428e5b28-31b6-4c84-8eae-d7753d45efc1",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 1
+    },
+    {
+      "slug": "grains",
+      "uuid": "eb3a92bf-0748-4406-ba67-9e27e367ae45",
+      "prerequisites": [],
+      "topics": ["integers", "variables"],
+      "difficulty": 1
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "25506c31-7274-402a-95e1-8475fcdb34e1",
+      "prerequisites": [],
+      "topics": ["dates", "integers", "time", "transforming", "variables"],
+      "difficulty": 1
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "79a4a35c-40d6-4e2d-92a1-005c40b4f4c5",
+      "prerequisites": [],
+      "topics": ["randomness", "strings", "variables"],
+      "difficulty": 2
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "b5345fcb-d4cc-4ea0-b1b9-f1b0cb92f05c",
+      "prerequisites": [],
+      "topics": ["conditionals", "filtering", "integers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "841641f2-16ba-4dc5-af1b-ffae5052853a",
+      "prerequisites": [],
+      "topics": ["interfaces", "lists", "maps", "sorting", "variables"],
+      "difficulty": 2
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "d1d86b51-a3f4-4276-a18c-6db54bc8dfcc",
+      "prerequisites": [],
+      "topics": ["interfaces", "parsing", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "etl",
+      "uuid": "52ac3dd0-8803-445f-93cf-e984b59d6702",
+      "prerequisites": [],
+      "topics": ["loops", "maps", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "space-age",
+      "uuid": "d24cf0ea-876f-4775-969b-99970425e413",
+      "prerequisites": [],
+      "topics": ["floating_point_numbers", "interfaces", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "b2ad38c2-2962-4a47-9b14-20ca262ebff6",
+      "prerequisites": [],
+      "topics": ["loops", "maps", "sorting", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "b3ad38c2-2962-4b47-9b14-20ca262ebff6",
+      "prerequisites": [],
+      "topics": ["integers", "math", "recursion"],
+      "difficulty": 1
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "b3ad38c2-2962-4b47-9b15-15ca262ebff6",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "isogram",
+      "uuid": "89ea51d0-3f7e-4e07-8e2b-4dde4c76608b",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "meetup",
+      "uuid": "6c702aa9-70f3-41d0-bc76-4323a08f8fbf",
+      "prerequisites": [],
+      "topics": ["conditionals", "dates", "filtering"],
+      "difficulty": 3
+    },
+    {
+      "slug": "triangle",
+      "uuid": "bd2a55e3-9874-4d2e-ad6f-4b2f8c5e2e0a",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "filtering",
+        "floating_point_numbers",
+        "integers"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "71804ace-6ca1-46b9-bf06-ff57faef7afa",
+      "prerequisites": [],
+      "topics": ["floating_point_numbers", "integers", "loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "f350f23d-72f8-4f47-a0f5-fe3c00f3f5f1",
+      "prerequisites": [],
+      "topics": ["games", "loops", "maps", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "binary",
+      "uuid": "005ff8b4-9df8-4b82-b919-a0c67356d654",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "conditionals", "integers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "allergies",
+      "uuid": "d2fd481e-7156-452d-976d-ea6df220fa18",
+      "prerequisites": [],
+      "topics": [
+        "bitwise_operations",
+        "conditionals",
+        "integers",
+        "text_formatting"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "sieve",
+      "uuid": "40f3b911-0739-4fec-95cc-cfab99788c19",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "filtering",
+        "integers",
+        "loops",
+        "maps",
+        "math"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "strain",
+      "uuid": "1a81aac9-9128-48ab-aa6a-4d981d6eb602",
+      "prerequisites": [],
+      "topics": ["conditionals", "filtering", "loops", "sequences"],
+      "difficulty": 1
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "71a1fdb6-414e-452c-8d24-03f2a5621e62",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "sequences", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "cc138097-7c0f-44b4-b07e-2a24f6475986",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "filtering",
+        "integers",
+        "loops",
+        "maps",
+        "math"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "fcfc6b44-597d-4a03-bf02-6be5c8f7ae4e",
+      "prerequisites": [],
+      "topics": ["arrays", "conditionals", "loops", "strings", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "trinary",
+      "uuid": "ff3eb2c5-c7ce-4352-805c-e01d4fb85aa6",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "34bc4fbe-f148-4519-a699-91efed432703",
+      "prerequisites": [],
+      "topics": ["integers", "loops", "math", "sequences"],
+      "difficulty": 1
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "9319d1a6-276f-4b3b-8305-fc022cc48ef2",
+      "prerequisites": [],
+      "topics": ["integers", "lists", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "d218cf9e-3b35-4357-9734-87142c22d551",
+      "prerequisites": [],
+      "topics": ["loops", "sequences", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "b327bd9a-b12e-490b-91cb-d3c21a23b4eb",
+      "prerequisites": [],
+      "topics": ["loops", "sequences", "strings"],
+      "difficulty": 1
+    }
   ]
 }

--- a/languages/cpp/config.json
+++ b/languages/cpp/config.json
@@ -26,5 +26,399 @@
       "name": "Strings",
       "blurb": "TODO: add blurb for strings concept"
     }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "3eeadff6-82b6-43be-8834-d9ef258e454d",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "isogram",
+      "uuid": "fcd69b30-63e4-485d-a3b5-71f5039a9180",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "leap",
+      "uuid": "76a840c7-24f1-455d-b62e-da42b13f8dd5",
+      "prerequisites": [],
+      "topics": ["conditionals", "logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "c6946af0-3c2f-4f76-8b30-a1643cd5be63",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "4dbe1bb3-0419-4749-8c2a-ec91539a8640",
+      "prerequisites": [],
+      "topics": ["dates", "interfaces"],
+      "difficulty": 2
+    },
+    {
+      "slug": "hamming",
+      "uuid": "a9716747-8cc6-4529-b5d2-dc24bd8641a8",
+      "prerequisites": [],
+      "topics": ["loops", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "bob",
+      "uuid": "d80210b8-45e8-4e5c-8b07-9e87c33c5959",
+      "prerequisites": [],
+      "topics": ["conditionals", "parsing", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "anagram",
+      "uuid": "a34d1c83-fb96-4b7a-aeca-fdb17cf91a75",
+      "prerequisites": [],
+      "topics": ["arrays", "filtering", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "etl",
+      "uuid": "0dd45f6a-c6cd-4549-a56b-7babe0a71add",
+      "prerequisites": [],
+      "topics": ["arrays", "loops", "maps"],
+      "difficulty": 3
+    },
+    {
+      "slug": "word-count",
+      "uuid": "d531e2b1-28bc-4025-b3a7-119d314b5a80",
+      "prerequisites": [],
+      "topics": ["arrays", "maps", "parsing", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "46cb230c-8ce9-431d-9dea-a195a3abd117",
+      "prerequisites": [],
+      "topics": ["loops", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "949f5680-a7a5-4c1e-ac19-bb4bae658d5c",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "6805ef10-ab91-4d97-af80-9d326255497d",
+      "prerequisites": [],
+      "topics": ["loops", "pattern_recognition", "strings"],
+      "difficulty": 7
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "76491cb2-25a8-4495-ba3e-85aace65319e",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "a15922b1-467f-4db4-a023-0bb262333551",
+      "prerequisites": [],
+      "topics": ["arrays", "parsing"],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "67c3cb10-b893-428a-82d0-79602aef2775",
+      "prerequisites": [],
+      "topics": ["randomness", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "a190ad11-db1c-4624-a477-e1d0c91d8b4f",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "space-age",
+      "uuid": "1763159f-3358-42d0-9ad0-2eb90baca600",
+      "prerequisites": [],
+      "topics": ["functions"],
+      "difficulty": 1
+    },
+    {
+      "slug": "meetup",
+      "uuid": "e597f659-f31a-4a1b-a697-d91ede672642",
+      "prerequisites": [],
+      "topics": ["functions", "interfaces"],
+      "difficulty": 5
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "54a0753e-c161-4dfd-a7b0-02dc7a923d82",
+      "prerequisites": [],
+      "topics": ["maps", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "triangle",
+      "uuid": "d23a2c36-7182-4fd0-84db-34b27fabda2e",
+      "prerequisites": [],
+      "topics": ["conditionals"],
+      "difficulty": 3
+    },
+    {
+      "slug": "grains",
+      "uuid": "c3dc3764-72b9-4926-9747-61db90553e2b",
+      "prerequisites": [],
+      "topics": ["bitwise_operations"],
+      "difficulty": 2
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "9155f4ea-3566-4a57-a2c5-76535d931ccc",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "52dce31c-f8ab-44db-accd-573f4b82dcf9",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 7
+    },
+    {
+      "slug": "binary",
+      "uuid": "1cc6a583-3def-4d15-a45a-4b1fe16826bf",
+      "prerequisites": [],
+      "topics": ["math", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "ba755932-b301-41cc-b7f2-5e6d2e130325",
+      "prerequisites": [],
+      "topics": ["loops", "math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "7ed4434a-3564-4194-b91a-d3baeec9c519",
+      "prerequisites": [],
+      "topics": ["arrays", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "177ecdf4-f249-4193-b9e1-8f1c6480bfad",
+      "prerequisites": [],
+      "topics": ["filtering", "strings", "text_formatting"],
+      "difficulty": 7
+    },
+    {
+      "slug": "trinary",
+      "uuid": "c8246de0-29b1-4f92-8b00-b766e395ad66",
+      "prerequisites": [],
+      "topics": ["math", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "2fbd008c-5007-4403-ae71-f4d1f5ccaf8f",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "acronym",
+      "uuid": "9d6f19f3-416e-4aeb-b426-7499853b21de",
+      "prerequisites": [],
+      "topics": ["regular_expressions", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "say",
+      "uuid": "090b2615-cd05-442b-be74-9f11bd5a83a5",
+      "prerequisites": [],
+      "topics": ["logic", "strings", "text_formatting"],
+      "difficulty": 10
+    },
+    {
+      "slug": "sieve",
+      "uuid": "7ea05dd1-2c3c-499e-8608-dc76d30c5457",
+      "prerequisites": [],
+      "topics": ["loops", "math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "series",
+      "uuid": "0ab70460-3a2f-4c37-bb78-716ba720fe34",
+      "prerequisites": [],
+      "topics": ["arrays", "logic", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "ed2e467d-621d-42de-afdd-f9b49efbc263",
+      "prerequisites": [],
+      "topics": [
+        "classes",
+        "conditionals",
+        "loops",
+        "pairs",
+        "strings",
+        "variables"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "clock",
+      "uuid": "fab94f5a-d4da-4a18-a70a-b27c80b14851",
+      "prerequisites": [],
+      "topics": ["classes", "time"],
+      "difficulty": 5
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "a384c32c-d8db-4877-816b-44de7c3ed324",
+      "prerequisites": [],
+      "topics": ["strings", "text_formatting"],
+      "difficulty": 7
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "675b0a5c-0587-4dc5-8004-1f82769a2ddd",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "c2e8e3fc-a39c-434b-87dd-9524636aa804",
+      "prerequisites": [],
+      "topics": ["math", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "0d5e4c9e-4351-41b1-9154-ee900ad0e60e",
+      "prerequisites": [],
+      "topics": ["logic", "loops"],
+      "difficulty": 5
+    },
+    {
+      "slug": "allergies",
+      "uuid": "80ae6a8e-8464-4f3a-afed-14d424757413",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "filtering"],
+      "difficulty": 3
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "15c741a0-944d-4b06-a096-6af63137347a",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "4a517292-3472-40f2-b4b8-5c8c25219ea5",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "stacks"],
+      "difficulty": 3
+    },
+    {
+      "slug": "pangram",
+      "uuid": "22ada9c4-a2b5-4a54-83d6-597dc3b90b89",
+      "prerequisites": [],
+      "topics": ["loops", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "abdd7aa3-25f6-4d27-a4dc-6bd1ea2f718c",
+      "prerequisites": [],
+      "topics": ["arrays", "conditionals", "loops", "searching"],
+      "difficulty": 4
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "3463598a-c622-4138-97d3-0c71cbe718c6",
+      "prerequisites": [],
+      "topics": ["algorithms", "classes"],
+      "difficulty": 10
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "0a3220c6-07a9-ed80-4d2d-1fc65de969b771a46d5",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "loops", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "ea8d6224-0440-6d80-1569-a04127908a200d2ecf0",
+      "prerequisites": [],
+      "topics": ["classes", "math", "operator_overloading"],
+      "difficulty": 6
+    },
+    {
+      "slug": "luhn",
+      "uuid": "885865bc-a197-436f-94bc-b1998d5cc081",
+      "prerequisites": [],
+      "topics": ["math", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "1035aa3f-030a-425b-84f1-1967f344d155",
+      "prerequisites": [],
+      "topics": ["algorithms", "loops", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "92788dbc-feb2-43a6-99c0-af21ce318b01",
+      "prerequisites": [],
+      "topics": ["algorithms", "classes", "data_structures"],
+      "difficulty": 6
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "c74f60b3-48fe-46c5-ae52-5e4b0787ba84",
+      "prerequisites": [],
+      "topics": ["functions", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "c8ca89ef-b63d-40e5-9d57-bfa796e704ea",
+      "prerequisites": [],
+      "topics": ["arrays", "bitwise_operations"],
+      "difficulty": 2
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "fb73e822-4831-4d33-a049-44a514bfa46a",
+      "prerequisites": [],
+      "topics": ["filtering", "maps", "sequences"],
+      "difficulty": 3
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "95a162a4-d825-4874-9e2f-014787cbdfb5",
+      "prerequisites": [],
+      "topics": ["optional_values", "strings", "text_formatting"],
+      "difficulty": 1
+    }
   ]
 }

--- a/languages/csharp/config.json
+++ b/languages/csharp/config.json
@@ -4,7 +4,10 @@
   "active": true,
   "blurb": "C# is a modern, object-oriented language with lots of great features, such as type-inference and async/await. The tooling is excellent, and there is extensive, well-written documentation.",
   "version": 3,
-  "online_editor": { "indent_style": "space", "indent_size": 4 },
+  "online_editor": {
+    "indent_style": "space",
+    "indent_size": 4
+  },
   "exercises": {
     "concept": [
       {
@@ -813,6 +816,890 @@
       "slug": "while-loops",
       "name": "While Loops",
       "blurb": "TODO: add blurb for while-loops concept"
+    }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "6c88f46b-5acb-4fae-a6ec-b48ae3f8168f",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "57f02d0e-7b75-473b-892d-26a7d980c4ce",
+      "prerequisites": [],
+      "topics": ["optional_values", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "8ba15933-29a2-49b1-a9ce-70474bad3007",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "b7116dfb-1107-4546-9f95-f15acdb6f6a4",
+      "prerequisites": [],
+      "topics": ["dates"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color",
+      "uuid": "5314dbee-4a0d-4fd6-a98a-36a746ee0d5c",
+      "prerequisites": [],
+      "topics": ["arrays"],
+      "difficulty": 1
+    },
+    {
+      "slug": "space-age",
+      "uuid": "612f058b-c6d9-4c97-913a-eeeb59ef61e1",
+      "prerequisites": [],
+      "topics": ["floating_point_numbers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "high-scores",
+      "uuid": "f52d9be9-7044-4001-8678-dcae91a8d7f3",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 1
+    },
+    {
+      "slug": "hamming",
+      "uuid": "05162ee0-38ac-40ad-a591-d70a74b6963a",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "caca1c6a-b998-431e-b6af-ca2d47b7708f",
+      "prerequisites": [],
+      "topics": ["dictionaries", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "46b8aea8-1528-43cb-a754-495ec2790ce2",
+      "prerequisites": [],
+      "topics": ["classes", "randomness", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "allergies",
+      "uuid": "2ac228d8-7bf0-4946-8352-6541df02c0a2",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "filtering"],
+      "difficulty": 3
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "ec1cc254-8e66-40d0-87bf-971d54c541c4",
+      "prerequisites": [],
+      "topics": ["lists", "sorting"],
+      "difficulty": 3
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "8a0a291d-8330-4901-bdbe-f974e163158e",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "657ac368-9b17-4f87-b815-decfe2bc0b5d",
+      "prerequisites": [],
+      "topics": ["classes", "queues"],
+      "difficulty": 4
+    },
+    {
+      "slug": "clock",
+      "uuid": "83e4cb1e-456f-4c74-ae82-6895f0bd73ae",
+      "prerequisites": [],
+      "topics": ["classes", "equality"],
+      "difficulty": 4
+    },
+    {
+      "slug": "bob",
+      "uuid": "da00f894-dbc8-485e-adba-a79d5ebee3ad",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "a2070019-e56d-4d48-994b-300411598707",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "bae1f3a4-b63d-4efd-921a-133b3d5e379c",
+      "prerequisites": [],
+      "topics": ["algorithms", "matrices"],
+      "difficulty": 5
+    },
+    {
+      "slug": "tournament",
+      "uuid": "d9359f25-dc94-496c-adc3-57fe541857fe",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "variable-length-quantity",
+      "uuid": "4c49ea84-8765-42b0-b4ab-5dead802eeee",
+      "prerequisites": [],
+      "topics": ["algorithms", "bitwise_operations"],
+      "difficulty": 7
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "0409f45f-b65e-4404-a9e7-2ef432d834b2",
+      "prerequisites": [],
+      "topics": ["arrays", "tuples"],
+      "difficulty": 8
+    },
+    {
+      "slug": "forth",
+      "uuid": "a2ba6202-f6e0-46f4-95e4-5921656f2e1a",
+      "prerequisites": [],
+      "topics": ["parsing", "stacks"],
+      "difficulty": 10
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "14395318-c7b9-11e7-abc4-cec278b6b50a",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "d985d4a9-1a2b-4bb1-ad08-961b8d36ee2e",
+      "prerequisites": [],
+      "topics": ["arrays", "math", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "series",
+      "uuid": "9ca46617-4995-45cc-a2dd-b8630eaa288b",
+      "prerequisites": [],
+      "topics": ["arrays", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "3c0563dc-665a-45b4-9b29-f133e235efd0",
+      "prerequisites": [],
+      "topics": ["extension_methods", "sequences", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "c4efbf8a-8e76-4700-807d-830a4938f4d0",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "integers", "loops", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "8150604d-4cdc-414a-a523-dd65ac536f0e",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "rational-numbers",
+      "uuid": "9ae7f7ed-75d8-4d03-967c-53846634ae07",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "440b0b23-220d-4706-98f0-9a89fce85acb",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "5554c048-0de3-4a85-b043-7577f429cba4",
+      "prerequisites": [],
+      "topics": ["integers", "loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "grains",
+      "uuid": "372c71b6-6256-4fe2-bddc-55667e3861af",
+      "prerequisites": [],
+      "topics": ["integers"],
+      "difficulty": 2
+    },
+    {
+      "slug": "pangram",
+      "uuid": "a595d7a1-81d3-48f2-9921-e53b9b22e072",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "etl",
+      "uuid": "36b7602c-44e2-4589-a97d-127a0277b2a2",
+      "prerequisites": [],
+      "topics": ["dictionaries", "lists", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "29ae7f8e-a009-4175-9350-a8c684c89730",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "f92ff94a-73e6-41cb-a376-835c2368b358",
+      "prerequisites": [],
+      "topics": ["arrays", "searching"],
+      "difficulty": 3
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "5675771e-1a46-40bd-8923-f6e09642cc0c",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "strain",
+      "uuid": "fdb19da7-28df-429b-83e5-d024abe97870",
+      "prerequisites": [],
+      "topics": ["filtering", "sequences"],
+      "difficulty": 3
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "89c42da3-72a6-423d-a9c7-7caccbd9b1e6",
+      "prerequisites": [],
+      "topics": ["transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "proverb",
+      "uuid": "b0a978a6-9c3f-427e-8ada-0a3951ca14fd",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "75a2d5f0-5f5e-46a3-9dd2-3da415690e18",
+      "prerequisites": [],
+      "topics": ["lists", "strings", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "error-handling",
+      "uuid": "77e46f6b-1070-4267-a1b5-a2aac931975a",
+      "prerequisites": [],
+      "topics": ["exception_handling"],
+      "difficulty": 3
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "142c97b6-ae31-4b5f-944c-3eb789d9e051",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "triangle",
+      "uuid": "5b1713c7-1597-4e67-ac97-f305b207bc38",
+      "prerequisites": [],
+      "topics": ["enumerations", "integers"],
+      "difficulty": 3
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "4ae402a7-5345-429a-a6af-e95ec5b95e13",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "sieve",
+      "uuid": "1897605a-afd4-49fe-b6ee-cd822f0d8acc",
+      "prerequisites": [],
+      "topics": ["filtering", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "5c56211a-ae1e-4836-80b5-f22f5801b7a2",
+      "prerequisites": [],
+      "topics": ["classes"],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "babd38cc-cf21-42ca-9d33-f2ad75c82871",
+      "prerequisites": [],
+      "topics": ["classes", "enumerations"],
+      "difficulty": 3
+    },
+    {
+      "slug": "isogram",
+      "uuid": "4b7b65be-f777-4f64-94a0-4f9832f17a52",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "1ad236a9-7035-42e6-90ec-f6a4b94ad495",
+      "prerequisites": [],
+      "topics": ["arrays", "bitwise_operations"],
+      "difficulty": 3
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "b7458404-2534-4ed8-8350-7060fa4b5786",
+      "prerequisites": [],
+      "topics": ["enumerations", "parsing"],
+      "difficulty": 3
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "cb755a7d-e01d-4758-92ab-9d2e6518a3eb",
+      "prerequisites": [],
+      "topics": ["arrays", "matrices", "tuples"],
+      "difficulty": 4
+    },
+    {
+      "slug": "bank-account",
+      "uuid": "96c641c8-4c3c-47ff-9e32-9722b5ca2c37",
+      "prerequisites": [],
+      "topics": ["classes", "concurrency"],
+      "difficulty": 4
+    },
+    {
+      "slug": "acronym",
+      "uuid": "ddfb0a0e-8c58-4b9e-ad62-57d06ef10f5f",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "2d68e971-d717-4196-a348-d4675a47283a",
+      "prerequisites": [],
+      "topics": ["classes", "lists"],
+      "difficulty": 4
+    },
+    {
+      "slug": "matrix",
+      "uuid": "73509caa-9b3e-4d09-933f-364c1a7e5519",
+      "prerequisites": [],
+      "topics": ["matrices", "parsing"],
+      "difficulty": 4
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "4a6621bb-e55a-4ae2-89e3-3aa7e37a8656",
+      "prerequisites": [],
+      "topics": ["integers", "math", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "house",
+      "uuid": "97aa0e82-2fc3-49e2-ad27-faef2873b328",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "4d5a53df-3d6b-46cb-a964-71c676f3cd93",
+      "prerequisites": [],
+      "topics": ["integers", "math", "overloading"],
+      "difficulty": 4
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "2627fb4f-7884-4494-8f49-5888107643f1",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "anagram",
+      "uuid": "790216d1-4fd9-4a9b-94f8-e1e07a18c2b7",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "word-count",
+      "uuid": "6e8717a7-6888-474a-96ad-0760c6d3ff92",
+      "prerequisites": [],
+      "topics": ["dictionaries", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "456ffe2c-e241-4373-8bea-d4d328f815e9",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "meetup",
+      "uuid": "064096c1-89b0-4656-bd3e-08ca833aa0b1",
+      "prerequisites": [],
+      "topics": ["dates"],
+      "difficulty": 4
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "de5e2eff-2b80-4996-a322-dc59ebe25edd",
+      "prerequisites": [],
+      "topics": ["integers", "math", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "d5d48857-5325-45d2-9969-95a0d7bba370",
+      "prerequisites": [],
+      "topics": ["arrays", "loops", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "d714b1e6-48b5-44d6-9661-d0acd3dd657b",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "pattern_matching", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "markdown",
+      "uuid": "dee4abe1-c75f-4cb8-b5f3-5b5b77e1c7aa",
+      "prerequisites": [],
+      "topics": ["parsing", "refactoring", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "book-store",
+      "uuid": "8288d3e0-75a4-4a18-94c7-2fab3228dc58",
+      "prerequisites": [],
+      "topics": ["recursion"],
+      "difficulty": 5
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "3b5b11b0-9476-4d9b-a4c5-c5c48d3d32a8",
+      "prerequisites": [],
+      "topics": ["lists", "recursion"],
+      "difficulty": 5
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "54649fb0-6b14-44df-85af-ae1f7a62449d",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "d3702b93-7bb3-4e0a-8cd7-974ad93b0d3d",
+      "prerequisites": [],
+      "topics": ["loops", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "9ad05373-a049-47f9-a06a-80ad0a7b38fd",
+      "prerequisites": [],
+      "topics": ["lists", "recursion"],
+      "difficulty": 5
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "d40541a8-d7d6-4dab-8560-27c5055adbd0",
+      "prerequisites": [],
+      "topics": ["searching", "trees"],
+      "difficulty": 5
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "466f17d4-13d0-4d6e-8564-c8bdfede35d1",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "parallel-letter-frequency",
+      "uuid": "5863c898-2072-4543-9ab5-045fd6691de4",
+      "prerequisites": [],
+      "topics": ["dictionaries", "parallelism", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "0c5918d5-15cc-401f-b038-5fb2cd515ec7",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "3a09736e-4002-41aa-acf9-ff10a9392b24",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "grep",
+      "uuid": "a9909a03-ce2e-45d9-85f8-a77f44fb2466",
+      "prerequisites": [],
+      "topics": ["files", "searching", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "sublist",
+      "uuid": "89d3b074-190f-4520-8f87-cde6368fc58e",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 5
+    },
+    {
+      "slug": "tree-building",
+      "uuid": "b31bff08-a609-40ec-a1ee-46ba24e671f2",
+      "prerequisites": [],
+      "topics": ["refactoring", "trees"],
+      "difficulty": 5
+    },
+    {
+      "slug": "scale-generator",
+      "uuid": "c7d5acc6-68a6-4cd8-a28b-359dceb1e56f",
+      "prerequisites": [],
+      "topics": ["algorithms", "parsing"],
+      "difficulty": 5
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "49b557ad-0bf0-451b-9a12-6dd9eb0291a2",
+      "prerequisites": [],
+      "topics": ["classes", "lists"],
+      "difficulty": 5
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "dd95f3d8-6da4-4bb4-b5c1-bf00c818d586",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "ledger",
+      "uuid": "c1cc752e-99a2-4da3-8d0c-82e08f1c6110",
+      "prerequisites": [],
+      "topics": ["globalization", "refactoring", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "a6dff389-07ea-42cb-98ec-271ce7cfeda3",
+      "prerequisites": [],
+      "topics": ["sets"],
+      "difficulty": 5
+    },
+    {
+      "slug": "dot-dsl",
+      "uuid": "d128ec4b-190f-4726-b3e7-870be09531aa",
+      "prerequisites": [],
+      "topics": ["classes", "domain_specific_languages", "equality"],
+      "difficulty": 5
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "2a5ddf5e-e677-4eef-b759-087d71e15986",
+      "prerequisites": [],
+      "topics": ["parsing", "pattern_recognition"],
+      "difficulty": 5
+    },
+    {
+      "slug": "luhn",
+      "uuid": "20fe4853-0eee-4171-b3c1-8ef871b99d13",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "4ad0d49a-e10b-4f8b-b454-623b9396d559",
+      "prerequisites": [],
+      "topics": ["algorithms", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "yacht",
+      "uuid": "f808e80a-8e76-4f3d-840e-31a840c560f2",
+      "prerequisites": [],
+      "topics": ["games", "parsing", "sorting"],
+      "difficulty": 5
+    },
+    {
+      "slug": "word-search",
+      "uuid": "2b05d7dd-0f0b-4fa4-a2bf-9d7fa28a7543",
+      "prerequisites": [],
+      "topics": ["searching", "tuples"],
+      "difficulty": 6
+    },
+    {
+      "slug": "bowling",
+      "uuid": "64eff1cb-990d-45bc-a9e7-8f574e114ece",
+      "prerequisites": [],
+      "topics": ["algorithms", "loops"],
+      "difficulty": 6
+    },
+    {
+      "slug": "transpose",
+      "uuid": "2634c53c-ba4d-4729-b936-a7ec387f4789",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "60ef0713-70e2-4ee7-9207-86910e616ec1",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 6
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "63bdd2d4-b395-41ca-8c58-b3d94bf1e696",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "e338fed5-f850-4922-88b2-7e9ec0eb7299",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "change",
+      "uuid": "44796c6c-39b3-41c7-8ea5-ffb9738423b8",
+      "prerequisites": [],
+      "topics": ["arrays", "integers"],
+      "difficulty": 6
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "165b8599-726d-43dd-8511-1401525810de",
+      "prerequisites": [],
+      "topics": ["algorithms", "math", "strings", "tuples"],
+      "difficulty": 6
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "0ed2de0f-70da-4f04-834e-01bfb0aa48d3",
+      "prerequisites": [],
+      "topics": ["math", "tuples"],
+      "difficulty": 6
+    },
+    {
+      "slug": "poker",
+      "uuid": "d03a9508-336a-4425-8f47-f04317d1ba15",
+      "prerequisites": [],
+      "topics": ["games", "parsing", "sorting"],
+      "difficulty": 7
+    },
+    {
+      "slug": "diffie-hellman",
+      "uuid": "3bea029d-ccc2-48be-90f3-84bf2d5b825b",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "math", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "rectangles",
+      "uuid": "817ccde1-0593-4091-85a5-616f4f8823f0",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "wordy",
+      "uuid": "57ef1936-d187-4915-888b-374f09c794c7",
+      "prerequisites": [],
+      "topics": ["parsing", "strings", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "zebra-puzzle",
+      "uuid": "e167479e-e77d-4734-b8c0-a7cd686c74a3",
+      "prerequisites": [],
+      "topics": ["logic"],
+      "difficulty": 8
+    },
+    {
+      "slug": "hangman",
+      "uuid": "c9b12d50-09dc-4f43-9e7e-66b277432347",
+      "prerequisites": [],
+      "topics": ["events", "reactive_programming"],
+      "difficulty": 8
+    },
+    {
+      "slug": "diamond",
+      "uuid": "2f3faeb7-7cc3-42ed-9525-cd9c73922a8d",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 8
+    },
+    {
+      "slug": "two-bucket",
+      "uuid": "b33c3b86-e04b-4529-bdf5-9d553ad59f87",
+      "prerequisites": [],
+      "topics": ["logic"],
+      "difficulty": 8
+    },
+    {
+      "slug": "connect",
+      "uuid": "ca56c362-c9f5-4403-9a2d-2e31e54b35e3",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 8
+    },
+    {
+      "slug": "say",
+      "uuid": "34518ea7-c202-443a-b28f-e873f3207f89",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 8
+    },
+    {
+      "slug": "react",
+      "uuid": "3e86c66d-c66e-4e28-834d-09b33b2ee2d2",
+      "prerequisites": [],
+      "topics": ["classes", "events", "reactive_programming"],
+      "difficulty": 9
+    },
+    {
+      "slug": "go-counting",
+      "uuid": "1abbc58c-9a04-4b6f-afe1-85d3e4d202e1",
+      "prerequisites": [],
+      "topics": ["optional_values", "parsing", "tuples"],
+      "difficulty": 9
+    },
+    {
+      "slug": "sgf-parsing",
+      "uuid": "da255a02-8007-41e4-8a9e-7e2cfbe81be5",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 9
+    },
+    {
+      "slug": "zipper",
+      "uuid": "db77fbd1-29d9-40e6-a32e-9fb89acdc9fc",
+      "prerequisites": [],
+      "topics": ["recursion", "searching", "trees"],
+      "difficulty": 10
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "c6961cae-5e93-470a-98ce-e7cd6b9cfcbf",
+      "prerequisites": [],
+      "topics": ["dictionaries", "parsing"],
+      "difficulty": 10
+    },
+    {
+      "slug": "pov",
+      "uuid": "a5794706-58d2-48f7-8aab-78639d7bce77",
+      "prerequisites": [],
+      "topics": ["graphs", "recursion", "searching"],
+      "difficulty": 10
+    },
+    {
+      "slug": "rest-api",
+      "uuid": "4c89b6a8-0e89-46c9-5a7e-31bfe6a57007",
+      "prerequisites": [],
+      "topics": ["json", "parsing"],
+      "difficulty": 6
+    },
+    {
+      "slug": "binary",
+      "uuid": "cef7deef-54ce-4201-b263-7cd2098533f8",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "trinary",
+      "uuid": "c7dd8467-87e2-4997-a96e-a04cb8b891e8",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "octal",
+      "uuid": "c8555f37-9976-4f52-a5db-6a680ec8d53b",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "5d30c5a0-0f69-4b79-8c7e-3b1fe6a5707f",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "affine-cipher",
+      "uuid": "2462D9AE-6483-40C6-955A-79CB2AC25B34",
+      "prerequisites": [],
+      "topics": ["cryptography", "math", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "darts",
+      "uuid": "cdde6c8c-0608-467d-a749-b53ec6168ecc",
+      "prerequisites": [],
+      "topics": ["floating_point_numbers", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "dnd-character",
+      "uuid": "eb93b46e-203b-43f0-ad5c-de8d5ccf2061",
+      "prerequisites": [],
+      "topics": ["randomness"],
+      "difficulty": 3
+    },
+    {
+      "slug": "resistor-color-duo",
+      "uuid": "415b9893-c366-4ac1-a904-e0fccfcf18c7",
+      "prerequisites": [],
+      "topics": ["arrays"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color-trio",
+      "uuid": "328e6978-0384-445b-b07a-adfd017a9eff",
+      "prerequisites": [],
+      "topics": ["arrays", "conditionals"],
+      "difficulty": 1
     }
   ]
 }

--- a/languages/dart/config.json
+++ b/languages/dart/config.json
@@ -81,5 +81,314 @@
       "name": "Type Conversion",
       "blurb": "TODO: add blurb for type-conversion concept"
     }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "6b868b7b-cac4-41ff-a855-21f596637845",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "optional_values",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color",
+      "uuid": "b0e61aa6-5944-48b4-a91b-8960b6655e51",
+      "prerequisites": [],
+      "topics": ["arrays", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "57a75d7e-370b-4937-8dd4-429db1f26ff3",
+      "prerequisites": [],
+      "topics": ["conditionals", "optional_values", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color-duo",
+      "uuid": "98ae146a-67f9-49ae-9cd6-00882a374248",
+      "prerequisites": [],
+      "topics": ["arrays", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "f195282c-c7a3-4a85-bbc1-d4e85e62d54c",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "4bcfd789-dee6-4dd9-8524-076508504eda",
+      "prerequisites": [],
+      "topics": ["booleans", "integers", "logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "d74be875-bc1c-47a5-bf80-0c4c57ed200e",
+      "prerequisites": [],
+      "topics": ["conditionals", "equality", "loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "50c34698-7767-42b3-962f-21c735e49787",
+      "prerequisites": [],
+      "topics": ["loops", "strings", "text_formatting"],
+      "difficulty": 3
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "4f650701-9568-4d95-9f72-be4bde2c90ec",
+      "prerequisites": [],
+      "topics": ["equality", "integers", "logic", "math", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "isogram",
+      "uuid": "3c1b70fa-aaa8-4323-9aab-4c76da0a89e1",
+      "prerequisites": [],
+      "topics": ["algorithms", "logic", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "c1cdab6f-c18c-4173-828a-2191151d20d4",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "word-count",
+      "uuid": "b74dde02-03d0-4165-8302-e8ba119b486b",
+      "prerequisites": [],
+      "topics": ["lists", "loops", "maps", "regular_expressions"],
+      "difficulty": 2
+    },
+    {
+      "slug": "bob",
+      "uuid": "615a83cc-a905-435a-a30e-f052b61cfd4c",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "pattern_recognition",
+        "polymorphism",
+        "regular_expressions",
+        "strings"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "space-age",
+      "uuid": "c8bf7da7-d26d-48e8-a83b-1296972d2376",
+      "prerequisites": [],
+      "topics": ["floating_point_numbers", "integers", "math", "polymorphism"],
+      "difficulty": 2
+    },
+    {
+      "slug": "hamming",
+      "uuid": "91c8033d-f40c-4a90-9ec9-7081f6eba8d2",
+      "prerequisites": [],
+      "topics": ["conditionals", "equality", "loops", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "acronym",
+      "uuid": "3f8d18d4-4f31-405b-8aad-80f768b11db3",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "equality",
+        "loops",
+        "regular_expressions",
+        "strings"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "8649b2b4-02f6-4947-92b9-d1cc0d7c3594",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "regular_expressions"],
+      "difficulty": 2
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "0c0511fd-59aa-4480-a7cd-4de0e9303b86",
+      "prerequisites": [],
+      "topics": ["time"],
+      "difficulty": 3
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "3d4e326d-2419-4e93-ac29-5727dbc3fbf1",
+      "prerequisites": [],
+      "topics": ["conditionals", "equality", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "99147c39-e8d3-4166-9215-c47fb4832781",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "anagram",
+      "uuid": "6e811b53-4eb1-40f9-a811-b5113d68ae8a",
+      "prerequisites": [],
+      "topics": ["conditionals", "equality", "loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "89bb2ba8-86f2-4660-8739-4141eb9e6cf5",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "integers",
+        "lists",
+        "loops",
+        "math"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "diamond",
+      "uuid": "5bbd251d-b2eb-44a1-a9a6-8543afb7511c",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "508ebbf1-205e-4992-97d7-2865f06a3b2b",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "stacks"],
+      "difficulty": 3
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "f06d9bb0-0b8d-4b34-b6d4-5c5cfae0d93c",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers", "lists", "loops", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "darts",
+      "uuid": "5444c90c-9129-438a-a4be-b844cf1550e5",
+      "prerequisites": [],
+      "topics": ["conditionals", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "pangram",
+      "uuid": "0ea556b0-afcd-479d-bbad-68bc4556c1d0",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "regular_expressions", "sets", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "luhn",
+      "uuid": "54cd6a0c-cbd1-493d-b91d-baad9fec058c",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "booleans",
+        "loops",
+        "strings",
+        "type_conversion"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "2c60339e-d15a-41e7-ba4f-33fa18d2a732",
+      "prerequisites": [],
+      "topics": [
+        "classes",
+        "games",
+        "lists",
+        "logic",
+        "loops",
+        "math",
+        "object_oriented_programming"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "c52dfe2b-5634-4c0c-8ea2-3ca86e5d9a33",
+      "prerequisites": [],
+      "topics": ["integers", "loops", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "8cc3b7a3-6a63-4e3b-b64d-8a07d52d51f8",
+      "prerequisites": [],
+      "topics": ["exception_handling", "loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "597f86bc-6717-4a4c-a2c6-58241ac3d6cb",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "classes",
+        "generics",
+        "inheritance",
+        "logic",
+        "object_oriented_programming",
+        "searching",
+        "sorting",
+        "trees"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "b470633d-6d2c-4245-92eb-37ea80500f2b",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "allergies",
+      "uuid": "729f4c8b-678a-434c-a09e-a71aca4bb2c0",
+      "prerequisites": [],
+      "topics": ["arrays", "bitwise_operations", "conditionals", "loops"],
+      "difficulty": 2
+    },
+    {
+      "slug": "triangle",
+      "uuid": "387eb271-b02d-444f-a1e0-dbccea72f740",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops"],
+      "difficulty": 3
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "0687be19-99e8-4b85-b3da-6b91a10acaa3",
+      "prerequisites": [],
+      "topics": ["arrays", "bitwise_operations", "integers"],
+      "difficulty": 5
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "8fffb0bb-2f71-41a9-90f2-7006020ddc19",
+      "prerequisites": [],
+      "topics": ["classes", "enumerations", "logic", "loops"],
+      "difficulty": 4
+    }
   ]
 }

--- a/languages/elixir/config.json
+++ b/languages/elixir/config.json
@@ -478,5 +478,665 @@
       "name": "Tuples",
       "blurb": "TODO: add blurb for tuples concept"
     }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "cc96d65d-1c79-40d0-8fd2-9a6665a43b01",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "a4629a60-752f-4234-99f1-6b3ac0b4ba18",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "word-count",
+      "uuid": "4a24ba2f-ae92-4095-be53-64bc881422ea",
+      "prerequisites": [],
+      "topics": ["lists", "maps", "reduce"],
+      "difficulty": 2
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "4c0ece49-5710-43a1-88b3-2fb149de8552",
+      "prerequisites": [],
+      "topics": ["algorithms", "pattern_matching"],
+      "difficulty": 2
+    },
+    {
+      "slug": "bob",
+      "uuid": "d20b49dc-cb6d-45fc-a168-78d002072c75",
+      "prerequisites": [],
+      "topics": ["control_flow", "string_processing"],
+      "difficulty": 2
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "24db624b-7c80-409d-97d5-e1177f025c67",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "recursion"],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "e5e55560-852f-4551-b4da-c9f4a3141470",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "structs"],
+      "difficulty": 6
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "86658a31-d401-401b-80df-2c4df35f9b15",
+      "prerequisites": [],
+      "topics": ["enumeration", "lists", "recursion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "markdown",
+      "uuid": "5dfa24bf-e77c-47c6-88e1-e50cbeecd159",
+      "prerequisites": [],
+      "topics": ["refactoring"],
+      "difficulty": 5
+    },
+    {
+      "slug": "bank-account",
+      "uuid": "5d5e0f6c-f4b7-418e-88f8-4b1d0f99bfb0",
+      "prerequisites": [],
+      "topics": ["otp"],
+      "difficulty": 7
+    },
+    {
+      "slug": "zipper",
+      "uuid": "bc315734-051c-4735-9a8a-3aacb094d2ca",
+      "prerequisites": [],
+      "topics": ["algorithms", "recursion", "structs", "trees"],
+      "difficulty": 8
+    },
+    {
+      "slug": "bowling",
+      "uuid": "3b252cc6-cc55-4187-891e-c10aaabac81f",
+      "prerequisites": [],
+      "topics": ["algorithms", "pattern_matching", "structs"],
+      "difficulty": 8
+    },
+    {
+      "slug": "forth",
+      "uuid": "2abfa3e5-d358-4a07-91f9-d4ad04eb719d",
+      "prerequisites": [],
+      "topics": ["parsers"],
+      "difficulty": 10
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "7404e885-747a-46fc-be0c-c53f4b0e162f",
+      "prerequisites": [],
+      "topics": ["enumerables", "maps", "string_processing"],
+      "difficulty": 2
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "ea7da409-6bda-4cff-b26e-0909ba36f4f5",
+      "prerequisites": [],
+      "topics": ["binary_representation"],
+      "difficulty": 2
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "99b344ff-b74c-4af5-9952-7738b493ee7b",
+      "prerequisites": [],
+      "topics": ["string_processing"],
+      "difficulty": 2
+    },
+    {
+      "slug": "strain",
+      "uuid": "d51edc8a-893b-4b05-912f-759e0d85123b",
+      "prerequisites": [],
+      "topics": ["collections"],
+      "difficulty": 2
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "84af7be8-8f90-4990-9d48-b5324a0d4354",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "string_processing"],
+      "difficulty": 2
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "3aa45a2b-d3bc-4763-b11d-5d41a1cf505c",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "string_processing"],
+      "difficulty": 2
+    },
+    {
+      "slug": "space-age",
+      "uuid": "1d02554e-15f3-46aa-9f14-60b4049f3100",
+      "prerequisites": [],
+      "topics": ["pattern_matching"],
+      "difficulty": 2
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "9dfb5dfc-1123-492b-9383-2a4312c219a4",
+      "prerequisites": [],
+      "topics": ["enumerations", "reduce", "string_formatting"],
+      "difficulty": 3
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "e7c6a0d2-6aaf-4d55-99e2-8ffa65a5e8f0",
+      "prerequisites": [],
+      "topics": ["recursion", "reduce"],
+      "difficulty": 2
+    },
+    {
+      "slug": "acronym",
+      "uuid": "23989815-1b3f-4377-b6bf-ce9536432517",
+      "prerequisites": [],
+      "topics": ["string_processing"],
+      "difficulty": 2
+    },
+    {
+      "slug": "series",
+      "uuid": "4a084cb7-335d-41f1-8148-5d3abbce8ab0",
+      "prerequisites": [],
+      "topics": ["string_processing"],
+      "difficulty": 2
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "4522b139-6f0c-4172-a4fa-6a6adef33a9e",
+      "prerequisites": [],
+      "topics": ["conditionals"],
+      "difficulty": 2
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "f4f759ea-53e1-42d6-a580-6e7b7d6a99a0",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "sublist",
+      "uuid": "146dd0ed-5210-4b3c-bb4b-8d0a8e832aab",
+      "prerequisites": [],
+      "topics": ["enumeration", "lists"],
+      "difficulty": 2
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "cc198564-72e6-444b-93b6-6b7ecf4d1759",
+      "prerequisites": [],
+      "topics": ["reduce"],
+      "difficulty": 2
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "5b8eece1-845f-4a5a-8a2f-fe2bf66f5e57",
+      "prerequisites": [],
+      "topics": ["algorithms", "math", "reduce"],
+      "difficulty": 2
+    },
+    {
+      "slug": "pangram",
+      "uuid": "20a0bbf8-751c-477a-a2cb-dd7cf4e4896c",
+      "prerequisites": [],
+      "topics": ["enumerations", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "e5d2386a-3021-4329-a4b7-6164e49df776",
+      "prerequisites": [],
+      "topics": ["recursion"],
+      "difficulty": 1
+    },
+    {
+      "slug": "anagram",
+      "uuid": "21e70267-097e-476f-aaff-233483514802",
+      "prerequisites": [],
+      "topics": ["enumeration", "filter"],
+      "difficulty": 2
+    },
+    {
+      "slug": "matrix",
+      "uuid": "f0df392c-8ace-4639-b555-5e61e54a854e",
+      "prerequisites": [],
+      "topics": ["string_processing", "structs"],
+      "difficulty": 3
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "cf0084a0-7b1d-4714-b7b2-618e3ad6e147",
+      "prerequisites": [],
+      "topics": ["algorithms", "enumeration", "reduce"],
+      "difficulty": 3
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "e8b049b7-6648-412c-8a11-0c95a15e2641",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "string_processing"],
+      "difficulty": 3
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "6d0c0785-3514-44fc-9b5a-0758989d1c6a",
+      "prerequisites": [],
+      "topics": ["algorithms", "math", "recursion"],
+      "difficulty": 2
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "f71d5f38-fcc9-4044-ade9-f779a8686c69",
+      "prerequisites": [],
+      "topics": ["math", "numbers", "translation"],
+      "difficulty": 2
+    },
+    {
+      "slug": "hamming",
+      "uuid": "aca03bcb-eb70-4646-be34-8c1a44026e9b",
+      "prerequisites": [],
+      "topics": ["string_processing"],
+      "difficulty": 2
+    },
+    {
+      "slug": "triangle",
+      "uuid": "546d92c7-c57b-4cbb-a721-9c393817a193",
+      "prerequisites": [],
+      "topics": ["algorithms"],
+      "difficulty": 2
+    },
+    {
+      "slug": "isogram",
+      "uuid": "55a20a0f-0131-4e4e-b14f-f3cb49e3cc04",
+      "prerequisites": [],
+      "topics": ["algorithms", "reduce"],
+      "difficulty": 3
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "4e6d3ddf-b696-40dc-ba02-ed998e595be7",
+      "prerequisites": [],
+      "topics": ["maps"],
+      "difficulty": 3
+    },
+    {
+      "slug": "tournament",
+      "uuid": "29a6f3f4-0d20-4447-8916-b98270780e0e",
+      "prerequisites": [],
+      "topics": ["formatting", "sorting", "string_processing"],
+      "difficulty": 4
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "0aae3af1-7c35-4d7c-aecf-8f89c7fbc300",
+      "prerequisites": [],
+      "topics": ["lists", "recursion"],
+      "difficulty": 3
+    },
+    {
+      "slug": "leap",
+      "uuid": "3d0d82d7-fdff-4dd5-b720-7246317bb023",
+      "prerequisites": [],
+      "topics": ["algorithms"],
+      "difficulty": 3
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "ae72ff68-e4c9-472c-8a86-7adaaa9086ee",
+      "prerequisites": [],
+      "topics": ["string_processing"],
+      "difficulty": 3
+    },
+    {
+      "slug": "etl",
+      "uuid": "b3a4c561-344a-403e-b5b3-3533d51e65f4",
+      "prerequisites": [],
+      "topics": ["enumeration", "string_processing"],
+      "difficulty": 2
+    },
+    {
+      "slug": "meetup",
+      "uuid": "68fee2cd-a5bc-40f2-8936-a3bb10463498",
+      "prerequisites": [],
+      "topics": ["calendar", "pattern_matching", "time"],
+      "difficulty": 4
+    },
+    {
+      "slug": "grains",
+      "uuid": "b030fa38-8935-4665-98c3-77f8434a6ea1",
+      "prerequisites": [],
+      "topics": ["recursion", "reduce"],
+      "difficulty": 3
+    },
+    {
+      "slug": "change",
+      "uuid": "14bddd31-a68f-4a16-830f-6e8ecf8199f2",
+      "prerequisites": [],
+      "topics": ["enumeration", "reduce"],
+      "difficulty": 3
+    },
+    {
+      "slug": "parallel-letter-frequency",
+      "uuid": "1992eaf7-7fbe-4176-ad46-01e325c27bcb",
+      "prerequisites": [],
+      "topics": ["concurrency", "otp"],
+      "difficulty": 4
+    },
+    {
+      "slug": "binary",
+      "uuid": "29c3c9ff-c7f3-4646-9612-7cd768d237ab",
+      "prerequisites": [],
+      "topics": ["binary_operators", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "scale-generator",
+      "uuid": "94de8b3f-79d7-4367-821c-e239c95e32ca",
+      "prerequisites": [],
+      "topics": ["enumerations", "string_processing"],
+      "difficulty": 5
+    },
+    {
+      "slug": "luhn",
+      "uuid": "c38ca1a8-9f0e-49de-81f9-5712ce459839",
+      "prerequisites": [],
+      "topics": ["enumeration", "string_processing"],
+      "difficulty": 5
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "287331a4-64d5-4b35-b4c1-a1171dc338e1",
+      "prerequisites": [],
+      "topics": ["calendar", "time"],
+      "difficulty": 3
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "5bc0d877-ad13-461e-bdbd-cd262b875dbb",
+      "prerequisites": [],
+      "topics": ["algorithms", "structs"],
+      "difficulty": 7
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "b85c37c7-a76e-41fa-9ce6-abcdba2bd683",
+      "prerequisites": [],
+      "topics": ["algorithms", "enumeration", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "8e5c050a-ff42-4a23-ba32-84595b7476f4",
+      "prerequisites": [],
+      "topics": ["enumeration", "matricies", "string_processing"],
+      "difficulty": 5
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "8154a099-5d6f-4e71-83fe-45ab23475778",
+      "prerequisites": [],
+      "topics": ["math", "numbers", "string_processing"],
+      "difficulty": 3
+    },
+    {
+      "slug": "diamond",
+      "uuid": "89633764-ace4-4ad5-a1aa-22cae7be7d18",
+      "prerequisites": [],
+      "topics": ["algorithms", "enumeration"],
+      "difficulty": 5
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "89204af8-3914-404b-8984-39a8d60362c4",
+      "prerequisites": [],
+      "topics": ["algorithms", "recursion"],
+      "difficulty": 3
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "77fe5eb6-a35b-4af4-9512-275f140c25d6",
+      "prerequisites": [],
+      "topics": ["algorithms", "trees"],
+      "difficulty": 3
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "47328272-b2f6-42e4-a5a3-a5d276bfbdee",
+      "prerequisites": [],
+      "topics": ["math", "pattern_matching", "recursion"],
+      "difficulty": 3
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "cf4816a5-8cee-4a85-8bbb-236c0676123c",
+      "prerequisites": [],
+      "topics": ["enumeration", "math", "pattern_matching"],
+      "difficulty": 3
+    },
+    {
+      "slug": "diffie-hellman",
+      "uuid": "92caf2b9-3fca-401c-8daa-aaa0193e704f",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "sieve",
+      "uuid": "78cfa21b-bc7f-426b-9ef3-57b8639e887b",
+      "prerequisites": [],
+      "topics": ["enumeration", "math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "wordy",
+      "uuid": "087940a2-5372-4ff3-aa9f-ce2eb982d91c",
+      "prerequisites": [],
+      "topics": ["parsers"],
+      "difficulty": 6
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "eab8a96f-74af-4e3d-8039-d1d74714f72b",
+      "prerequisites": [],
+      "topics": ["encryption"],
+      "difficulty": 3
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "dbea6e3b-1c0c-471f-9af3-f8fd3cbb957a",
+      "prerequisites": [],
+      "topics": ["encryption", "string_processing"],
+      "difficulty": 3
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "79525094-76dd-4cf0-8956-fdd33de855e2",
+      "prerequisites": [],
+      "topics": ["enumeration", "math", "recursion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "132981c5-d3cd-426a-8a93-8a72b1cd8564",
+      "prerequisites": [],
+      "topics": ["algorithms", "encryption"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "087a2a3b-71e2-4473-ab2f-3be5240567b5",
+      "prerequisites": [],
+      "topics": ["algorithms", "math", "reduce"],
+      "difficulty": 5
+    },
+    {
+      "slug": "allergies",
+      "uuid": "9a1b599c-3175-4166-9b53-491a2f565db6",
+      "prerequisites": [],
+      "topics": ["binary_operators", "enumeration"],
+      "difficulty": 4
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "5ab8275f-bf1d-472d-9545-8ac622ce6f5d",
+      "prerequisites": [],
+      "topics": ["math", "reduce"],
+      "difficulty": 5
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "3daeb229-0638-443f-9ae2-222ebb88c11a",
+      "prerequisites": [],
+      "topics": ["encryption", "string_processing"],
+      "difficulty": 6
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "8d665135-31dc-490a-8f6d-51c6654099bd",
+      "prerequisites": [],
+      "topics": ["algorithms", "enumeration", "reduce"],
+      "difficulty": 7
+    },
+    {
+      "slug": "connect",
+      "uuid": "c36fd67a-a370-49b7-b778-9a542e2c5a75",
+      "prerequisites": [],
+      "topics": ["reduce", "string_processing"],
+      "difficulty": 7
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "bb9b24da-1ee6-42fb-936f-5fc41d97ee27",
+      "prerequisites": [],
+      "topics": ["math", "reduce"],
+      "difficulty": 4
+    },
+    {
+      "slug": "poker",
+      "uuid": "53d67dde-5a53-4d89-b77c-027d144135b9",
+      "prerequisites": [],
+      "topics": ["sorting"],
+      "difficulty": 7
+    },
+    {
+      "slug": "dot-dsl",
+      "uuid": "c316b8ef-7b2d-43d4-b402-f7d28b0cdaa7",
+      "prerequisites": [],
+      "topics": ["graphs", "structs"],
+      "difficulty": 8
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "1219528b-3438-4313-84c5-a9c1bbb6ffd3",
+      "prerequisites": [],
+      "topics": ["collections", "enumeration"],
+      "difficulty": 5
+    },
+    {
+      "slug": "clock",
+      "uuid": "e7cb9cd0-5893-4ebb-b801-f5d548945531",
+      "prerequisites": [],
+      "topics": ["integers", "logic", "protocols", "structs", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "grep",
+      "uuid": "b2630a58-6ee1-4b3b-ad5c-e09b8bfe2a30",
+      "prerequisites": [],
+      "topics": ["enumerations", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "say",
+      "uuid": "5ecbe1c9-12e3-42b6-921a-bc2d32011930",
+      "prerequisites": [],
+      "topics": ["pattern_matching"],
+      "difficulty": 3
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "3f321191-afb1-4aa1-995b-204aa460269e",
+      "prerequisites": [],
+      "topics": ["enumerations", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "01f7ce73-ad6a-42bb-a401-cbd485c081d4",
+      "prerequisites": [],
+      "topics": ["math", "recursion"],
+      "difficulty": 2
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "9fdeb525-90d8-45ca-9a24-ca46b4363e03",
+      "prerequisites": [],
+      "topics": ["algorithms", "enumerations", "recursion", "sorting", "trees"],
+      "difficulty": 4
+    },
+    {
+      "slug": "transpose",
+      "uuid": "ce270a34-add1-422c-bb86-53b310f05e27",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "0fb09d01-1f8b-4654-9004-52baa057412e",
+      "prerequisites": [],
+      "topics": ["string_processing"],
+      "difficulty": 3
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "cf28d2b2-763e-404b-90b0-637263d3bba6",
+      "prerequisites": [],
+      "topics": ["lists", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "7ed99829-acd8-4724-b92f-85146f1709f9",
+      "prerequisites": [],
+      "topics": ["algorithms", "backtracking", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "e7f3280e-0bef-4fac-8a69-cbfa2e5f818a",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "8f40f0f6-95e6-4a4c-a576-3d677ffbbd9f",
+      "prerequisites": [],
+      "topics": ["algorithms", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "dnd-character",
+      "uuid": "bd15a0e0-c19e-4a52-be6c-1a61d14c54cd",
+      "prerequisites": [],
+      "topics": ["random", "structs"],
+      "difficulty": 3
+    },
+    {
+      "slug": "resistor-color",
+      "uuid": "12efd520-e3e5-437f-b93e-38af14aa605d",
+      "prerequisites": [],
+      "topics": ["enumerables"],
+      "difficulty": 1
+    }
   ]
 }

--- a/languages/elm/config.json
+++ b/languages/elm/config.json
@@ -12,5 +12,329 @@
     "concept": [],
     "practice": []
   },
-  "concepts": []
+  "concepts": [],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "2c3902df-93e1-48d1-829d-4daa93a1f06f",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "0118175a-761f-4d05-8857-fe93745f490f",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "bob",
+      "uuid": "11ce2a73-3f43-4b14-b755-6c52dc71bdda",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "646c7164-cfa4-42c3-9af5-2f672e6ec81e",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "5ddfed31-b787-48f9-b3bf-4a8d157d1c3d",
+      "prerequisites": [],
+      "topics": ["dates"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "e943e3bf-920e-4541-95c3-be7bf6024afe",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "3af96d19-87d7-4d8b-aecb-f63122815501",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "space-age",
+      "uuid": "2ce5bcba-c708-4da0-ae11-4654b3e0d0a5",
+      "prerequisites": [],
+      "topics": ["floating_point_numbers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "75859d00-8772-4471-97a7-d6fe432edc5e",
+      "prerequisites": [],
+      "topics": ["lists", "math", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "0b4561f3-59a7-4463-a733-c7fa8f9f332a",
+      "prerequisites": [],
+      "topics": ["recursion", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "0edd5fa2-f1db-4572-9810-55a2c6729753",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "etl",
+      "uuid": "1f39d315-324c-4e2f-bf48-ce8432836596",
+      "prerequisites": [],
+      "topics": ["maps", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "c7749c5a-529e-4e46-8bdb-e33519f6d176",
+      "prerequisites": [],
+      "topics": ["maps", "sorting"],
+      "difficulty": 2
+    },
+    {
+      "slug": "grains",
+      "uuid": "41518694-4293-49f6-8af5-1cdad84acf78",
+      "prerequisites": [],
+      "topics": ["integers"],
+      "difficulty": 2
+    },
+    {
+      "slug": "hamming",
+      "uuid": "472c2e13-6608-4862-b884-a7e458e0bcdd",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "c9e00708-3d18-4a0b-a3de-cae4d979a981",
+      "prerequisites": [],
+      "topics": ["maps", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "pangram",
+      "uuid": "a70503ba-f1f3-4583-9226-c3ada98e9500",
+      "prerequisites": [],
+      "topics": ["booleans", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "e3e73171-c3d1-49f7-9511-d1f4a08e7a69",
+      "prerequisites": [],
+      "topics": ["filtering", "text_formatting"],
+      "difficulty": 2
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "2a71bafa-87ac-4f36-ba45-a1b24dcca67a",
+      "prerequisites": [],
+      "topics": ["strings", "integers", "lists", "algorithms", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "1F9FE5BC-8213-44FD-B7D1-5D4CC7F3A475",
+      "prerequisites": [],
+      "topics": ["algorithms", "lists", "recursion"],
+      "difficulty": 3
+    },
+    {
+      "slug": "isogram",
+      "uuid": "5f540090-061e-2f80-40a8-d9782700ed2efdf8965",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "1071ec57-5527-4eb1-b297-77355ed64547",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "6b8f952e-94ea-4264-accf-cdb28b3b4529",
+      "prerequisites": [],
+      "topics": ["records", "tuples"],
+      "difficulty": 3
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "16ccc1fa-34b0-4a7e-b3cf-33a711e857ea",
+      "prerequisites": [],
+      "topics": ["transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "strain",
+      "uuid": "992c5ed1-9127-42a4-b508-61c9487612c5",
+      "prerequisites": [],
+      "topics": ["filtering", "sequences"],
+      "difficulty": 3
+    },
+    {
+      "slug": "triangle",
+      "uuid": "767f6825-8736-4307-85c7-090a9a327fd9",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "acronym",
+      "uuid": "851ddd78-13a0-4d8f-adda-41abde670687",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "bdb8364b-d8b2-4d58-a824-1035cddedb42",
+      "prerequisites": [],
+      "topics": ["integers", "math", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "allergies",
+      "uuid": "29b5a28a-417a-4cee-ba6f-9dd942ceffaa",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "enumerations", "filtering"],
+      "difficulty": 4
+    },
+    {
+      "slug": "anagram",
+      "uuid": "5845a108-d8b2-41dd-b371-cf9eff7a2230",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "1902d726-5a62-475b-b7d3-7188a50e717f",
+      "prerequisites": [],
+      "topics": ["integers", "math", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "114b5717-0d82-459e-90c4-f00d8b6beb5b",
+      "prerequisites": [],
+      "topics": ["lists", "recursion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "b7e456d7-e383-4e03-9126-c9b57c1287e1",
+      "prerequisites": [],
+      "topics": ["lists", "math", "recursion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "series",
+      "uuid": "1e17ed2b-57b4-4cad-a684-ce7070d5023b",
+      "prerequisites": [],
+      "topics": ["lists", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "50770287-c734-46ba-b3a1-c36d31b6cc3c",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "word-count",
+      "uuid": "9c9507a6-8187-4ce6-b0bc-b4765effb74c",
+      "prerequisites": [],
+      "topics": ["maps", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "8322872b-e020-4a9e-9206-015c0fdacb62",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "luhn",
+      "uuid": "39464d44-1475-47c1-8f08-2aba9e6b2d85",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "d266a60c-4c41-4d98-a898-13dea7513cd8",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "loops", "integers", "math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "c1461035-6abe-4f17-a818-7a3ac6642c18",
+      "prerequisites": [],
+      "topics": ["recursion", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "0b2ac079-f7ed-4e90-a566-00c9fe0d5c88",
+      "prerequisites": [],
+      "topics": ["algorithms", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "transpose",
+      "uuid": "66fef1df-aa12-40eb-b572-7ea9b6a920ed",
+      "prerequisites": [],
+      "topics": ["matrices"],
+      "difficulty": 6
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "5b2f0983-6feb-4329-aff2-d822274a9882",
+      "prerequisites": [],
+      "topics": ["parsing", "stacks"],
+      "difficulty": 7
+    },
+    {
+      "slug": "sublist",
+      "uuid": "8e1cb827-2fa9-46a4-ac50-7f8b3ba66809",
+      "prerequisites": [],
+      "topics": ["lists", "recursion"],
+      "difficulty": 7
+    },
+    {
+      "slug": "say",
+      "uuid": "ea41b90d-3ff5-43c0-94e5-6b436feb99e5",
+      "prerequisites": [],
+      "topics": ["strings", "text_formatting", "transforming"],
+      "difficulty": 8
+    },
+    {
+      "slug": "wordy",
+      "uuid": "7fcc7c1e-c8d4-4701-8be7-06ab6e039885",
+      "prerequisites": [],
+      "topics": ["parsing"],
+      "difficulty": 8
+    }
+  ]
 }

--- a/languages/emacs-lisp/config.json
+++ b/languages/emacs-lisp/config.json
@@ -12,5 +12,239 @@
     "concept": [],
     "practice": []
   },
-  "concepts": []
+  "concepts": [],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "c4fdc935-885b-44bd-84e4-fae4a09e8c39",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "36e5dc3a-2122-484a-ae82-beb7b813e2cd",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "84eaff19-cb25-46af-a34e-1379e692e57b",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "equality", "integers", "logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "anagram",
+      "uuid": "d8906a7e-9d7e-4e8e-aff0-da877291d8dc",
+      "prerequisites": [],
+      "topics": ["equality", "filtering", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "c4875bc5-e295-4782-99c7-cb3370ac8e08",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "hamming",
+      "uuid": "2bfb508e-7ceb-4ae1-8316-1e2daf771807",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "equality",
+        "filtering",
+        "strings"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "7b6767b9-2efc-414d-83f7-def9c371d63d",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "strings", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "bob",
+      "uuid": "c02c7392-9478-4cfd-81eb-0cb8ebe78fe5",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "parsing", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "word-count",
+      "uuid": "1a3c64b1-8447-451f-985d-f7bd6d42bdb6",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "filtering",
+        "strings"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "7b421b14-c33c-41a6-9e7e-4f9b6fbe6fcc",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_loops",
+        "floating_point_numbers",
+        "integers",
+        "math"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "e9e27a75-143a-439f-98d0-a604724a7af2",
+      "prerequisites": [],
+      "topics": ["date", "integers", "time", "transforming", "variables"],
+      "difficulty": 1
+    },
+    {
+      "slug": "pangram",
+      "uuid": "28aea3bc-0ca0-4af9-868a-02e71c3d996",
+      "prerequisites": [],
+      "topics": ["control_flow_loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "binary",
+      "uuid": "7307e13e-7a18-4654-8df4-96951d4dccc6",
+      "prerequisites": [],
+      "topics": [
+        "bitwise_operations",
+        "control_flow_conditionals",
+        "integers",
+        "math"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "allergies",
+      "uuid": "e0d7220f-5d3a-4f10-842e-3d49df714cac",
+      "prerequisites": [],
+      "topics": [
+        "bitwise_operations",
+        "control_flow_conditionals",
+        "integers",
+        "text_formatting"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "55bc8c2a-1db3-4d26-b7c6-a778b61bf46b",
+      "prerequisites": [],
+      "topics": ["randomness", "strings", "variables"],
+      "difficulty": 2
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "89125ff6-f94b-46a4-9a5d-84539674238d",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "sequences",
+        "transforming"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "9a97c992-3da0-4f6d-b2f6-1f2683417e3b",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "filtering", "integers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "30971b02-79fc-40a1-aa70-ada3fec85548",
+      "prerequisites": [],
+      "topics": ["math", "number_theory"],
+      "difficulty": 1
+    },
+    {
+      "slug": "etl",
+      "uuid": "d8f4c530-02f0-44d3-b5b8-858fec4b6a9d",
+      "prerequisites": [],
+      "topics": ["control_flow_loops", "maps", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "aaff28dd-718b-48d4-b507-a0b9b01bb6ad",
+      "prerequisites": [],
+      "topics": ["control_flow_loops", "maps", "sorting", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "c211045e-da97-479d-9df4-5d812573e2d0",
+      "prerequisites": [],
+      "topics": ["interfaces", "parsing", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "grains",
+      "uuid": "d219aab6-11ec-4e0c-b041-f06c8d523946",
+      "prerequisites": [],
+      "topics": ["integers", "variables"],
+      "difficulty": 1
+    },
+    {
+      "slug": "acronym",
+      "uuid": "a252e137-8a63-4f26-b119-7264f12a257a",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "059141f0-f28d-4d10-a03a-7852dbfc2d2e",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "9e8f98f0-6fff-4389-a9a2-9ae43edefa21",
+      "prerequisites": [],
+      "difficulty": 2
+    },
+    {
+      "slug": "trinary",
+      "uuid": "c5239cf6-c5a3-4d81-a4d9-504c292ff11e",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "884cd761-e764-4c1e-8240-bb4454b43ea9",
+      "prerequisites": [],
+      "topics": ["cryptograpy", "strings", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "luhn",
+      "uuid": "bb10d7e4-6006-4dfd-81ae-45062a0ec999",
+      "prerequisites": [],
+      "topics": ["checksums", "list_operations", "strings"],
+      "difficulty": 3
+    }
+  ]
 }

--- a/languages/erlang/config.json
+++ b/languages/erlang/config.json
@@ -12,5 +12,554 @@
     "concept": [],
     "practice": []
   },
-  "concepts": []
+  "concepts": [],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "50547bc4-a78e-4450-9412-30bfa46c4a93",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "ea369b85-b180-48ca-b602-c40811fc865f",
+      "prerequisites": [],
+      "topics": ["strings", "arity"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "241eb25c-925b-4395-876c-c1dfe84e1c85",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "a21065ca-6aad-46b2-ada0-6a62abfcea2b",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 1
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "63c77b77-5a02-40ce-b5f6-372a5b3ae13d",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "math", "pattern_matching"],
+      "difficulty": 1
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "63259a44-cdec-4e25-ab0e-eddc6f9a9ca1",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "pattern_matching", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "8e9a98b1-bf4f-4c94-a258-a8618cc37f55",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "pattern_matching", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "bob",
+      "uuid": "fced3620-26f2-4439-822c-27e1d59e24e1",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "strain",
+      "uuid": "c10bfbab-0b58-4fcb-aadc-304bd4b73cfc",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "lists"],
+      "difficulty": 2
+    },
+    {
+      "slug": "hamming",
+      "uuid": "8b7390fc-da44-4f02-ad17-a7eb5c19cf2b",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "space-age",
+      "uuid": "f276e064-a6d4-4a50-b53b-f36c1b30c62f",
+      "prerequisites": [],
+      "topics": ["time"],
+      "difficulty": 2
+    },
+    {
+      "slug": "darts",
+      "uuid": "72c8d390-4f07-4ec2-8e5a-4f57cf04e29c",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "580309f9-65f1-480b-bdb6-c14846963c33",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "pattern_matching", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "7fd5455c-46d2-4484-9c7d-04fa6ef305f4",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "diamond",
+      "uuid": "fa949101-5771-477c-9221-0112dcbbdcde",
+      "prerequisites": [],
+      "topics": ["lists", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "grains",
+      "uuid": "c3070adc-d434-4989-8d6b-d9e483e32d1c",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "pattern_matching"],
+      "difficulty": 2
+    },
+    {
+      "slug": "isogram",
+      "uuid": "94b997bb-8e8d-4519-ba97-199d0f35a80a",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "pattern_matching", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "pangram",
+      "uuid": "9c092a14-475b-4b1b-ac4b-fb19467367ff",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_recursion",
+        "strings"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "d3cbfc9a-a495-4bf2-87d0-811d5f71fda6",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "ab852e36-3968-403f-93f5-53c7ecafa4c8",
+      "prerequisites": [],
+      "topics": ["control_flow_recursion", "math", "pattern_matching"],
+      "difficulty": 2
+    },
+    {
+      "slug": "triangle",
+      "uuid": "2972e0de-b5ca-4fdd-9dbf-648937763394",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals"],
+      "difficulty": 2
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "b6ff9201-e0fc-43e5-9501-cd0509f9ce1c",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "5af1c90a-f98d-4682-885b-9770c9223194",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "8c58533a-7a1f-11e8-adc0-fa7ae01bbebc",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "a639ce2f-48e3-46cd-9d11-955ba2a9eaaa",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "anagram",
+      "uuid": "8f0570ae-223f-4da4-8b84-268b797b28ad",
+      "prerequisites": [],
+      "topics": ["filtering", "lists", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "d8e38780-d04e-43fc-8606-97dc71e4974b",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "668f3947-3142-485e-89f8-e0e5060be29d",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "ba4cd1e4-b5f0-4efc-a4c8-58c5252cae9e",
+      "prerequisites": [],
+      "topics": ["algorithms"],
+      "difficulty": 3
+    },
+    {
+      "slug": "bracket-push",
+      "uuid": "f93f5f18-3e3b-11e8-b467-0ed5f89f718b",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "24ae9a43-4e1c-418b-97f6-2c83dbc0e14a",
+      "prerequisites": [],
+      "topics": ["dates"],
+      "difficulty": 3
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "4f5045d5-9ae1-4bdb-ac0b-a5d279a60ed8",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "13327e7d-0c07-4520-9b55-f9195b6224c3",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "3c79d343-a180-4cab-9622-04203cbc564a",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "pattern_matching", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "a2d4ca29-54e2-4969-bfc9-ee483acf9caf",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "control_flow_recursion"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "67bbcc69-31b7-41f2-a8e1-5a07d30e00d6",
+      "prerequisites": [],
+      "topics": ["pattern_matching"],
+      "difficulty": 4
+    },
+    {
+      "slug": "sublist",
+      "uuid": "2f974a71-a432-410b-a432-1e44950ad018",
+      "prerequisites": [],
+      "topics": ["lists", "sequences"],
+      "difficulty": 4
+    },
+    {
+      "slug": "word-count",
+      "uuid": "43df8921-f0c3-4a0c-9bdf-eb89405049ad",
+      "prerequisites": [],
+      "topics": ["lists", "maps", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "clock",
+      "uuid": "df90c039-8629-497a-a809-5ba2d1f8d52f",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "time"],
+      "difficulty": 4
+    },
+    {
+      "slug": "allergies",
+      "uuid": "51af2614-e349-4e90-b917-177a6017e786",
+      "prerequisites": [],
+      "topics": ["algorithms", "bitwise_operations"],
+      "difficulty": 4
+    },
+    {
+      "slug": "transpose",
+      "uuid": "9af2325d-0450-45a3-a0da-8a18fafa0b7f",
+      "prerequisites": [],
+      "topics": ["algorithms", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "85e23906-6fd8-486a-add8-a6c932cef7e3",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "series",
+      "uuid": "9ca527d7-5065-4856-8c95-07deb664da7e",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "parallel-letter-frequency",
+      "uuid": "be69c23b-7559-44fe-9e21-94a865199de7",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "d8ee01b3-307e-4835-a7cd-331e771111ae",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "sieve",
+      "uuid": "9cfae4bf-cff8-49bc-aee9-a37d553cef81",
+      "prerequisites": [],
+      "topics": ["filtering", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "51061693-8f01-4dc6-a4c0-0f76771423f8",
+      "prerequisites": [],
+      "topics": ["matrices"],
+      "difficulty": 4
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "8600a843-ec71-4f1a-b9fe-2ed515035101",
+      "prerequisites": [],
+      "topics": ["algorithms", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "b312ff0e-90e3-4dd8-99dc-df4a9deb1907",
+      "prerequisites": [],
+      "topics": ["math", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "rational-numbers",
+      "uuid": "8b379d6e-196f-4ccc-808d-91fb6255e474",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "5fc48c1b-0e1b-47b3-b30a-5281ec364aad",
+      "prerequisites": [],
+      "topics": ["math", "parsing", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "8ad0c97b-189d-46ac-bb72-2c72f1fe4728",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "change",
+      "uuid": "a71317c2-4d85-4449-811e-57d3a54a4d12",
+      "prerequisites": [],
+      "topics": ["algorithms"],
+      "difficulty": 5
+    },
+    {
+      "slug": "variable-length-quantity",
+      "uuid": "1acd7529-c487-4bea-9146-620b8ad5ef34",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "integers", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "satellite",
+      "uuid": "f69d4fd0-3547-4be0-8d09-f368b80b9df7",
+      "prerequisites": [],
+      "topics": ["trees"],
+      "difficulty": 5
+    },
+    {
+      "slug": "etl",
+      "uuid": "60fc4ea6-28b0-4914-bcc3-a0caefca3cb5",
+      "prerequisites": [],
+      "topics": ["algorithms", "maps", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "bank-account",
+      "uuid": "a7e2e89c-c599-4e30-a944-a9d4a98f2b94",
+      "prerequisites": [],
+      "topics": ["algorithms", "functions", "pattern_matching"],
+      "difficulty": 6
+    },
+    {
+      "slug": "luhn",
+      "uuid": "e938c3e6-0b0f-498e-a3ec-47251f5bb55c",
+      "prerequisites": [],
+      "topics": ["algorithms"],
+      "difficulty": 6
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "d1afdffa-0340-43b7-8015-4d706c10b8da",
+      "prerequisites": [],
+      "topics": ["algorithms", "math"],
+      "difficulty": 6
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "453aad9b-044e-473e-87c1-0193afb2cb13",
+      "prerequisites": [],
+      "topics": ["types"],
+      "difficulty": 6
+    },
+    {
+      "slug": "meetup",
+      "uuid": "249d0c9f-dadc-4168-ba9b-0c6bfe83618d",
+      "prerequisites": [],
+      "topics": ["control_flow_conditionals", "dates"],
+      "difficulty": 6
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "a534bd4a-8a72-11e8-9a94-a6cf71072f73",
+      "prerequisites": [],
+      "topics": ["cryptography", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "9bb14014-9732-11e8-9eb6-529269fb1459",
+      "prerequisites": [],
+      "topics": ["cryptography", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "589b763c-2b3a-11e8-b467-0ed5f89f718b",
+      "prerequisites": [],
+      "topics": ["math", "pattern_matching", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "bc74b87d-d257-41e5-9233-10324a78367c",
+      "prerequisites": [],
+      "topics": ["algorithms", "math", "performance"],
+      "difficulty": 6
+    },
+    {
+      "slug": "poker",
+      "uuid": "693be489-153f-409d-9c2d-52b718997785",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "forth",
+      "uuid": "95335b21-a840-45f3-8d65-d7de7aec228a",
+      "prerequisites": [],
+      "topics": ["algorithms", "parsing", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "058b48a9-03ec-43bc-88eb-9dbce8b79e59",
+      "prerequisites": [],
+      "topics": ["algorithms", "types"],
+      "difficulty": 7
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "2cf5d5ba-9820-4918-ac91-811b2a434655",
+      "prerequisites": [],
+      "topics": ["lists", "parsing", "strings", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "2fedc6bf-6006-4c2d-bba7-9c66265b6f62",
+      "prerequisites": [],
+      "topics": ["strings", "text_formatting"],
+      "difficulty": 7
+    },
+    {
+      "slug": "book-store",
+      "uuid": "21db1eaa-db00-49fc-9ec5-c2913a9ff616",
+      "prerequisites": [],
+      "topics": ["algorithms"],
+      "difficulty": 7
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "767acde9-cbca-4cdd-afed-125f14e92e10",
+      "prerequisites": [],
+      "topics": ["algorithms"],
+      "difficulty": 8
+    },
+    {
+      "slug": "zipper",
+      "uuid": "b6c242d3-40d5-484d-8466-1a32d2332288",
+      "prerequisites": [],
+      "topics": ["algorithms", "control_flow_recursion", "types"],
+      "difficulty": 8
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "625ad6f2-c9e8-4129-a290-057209f941c5",
+      "prerequisites": [],
+      "topics": ["algorithms"],
+      "difficulty": 8
+    },
+    {
+      "slug": "connect",
+      "uuid": "211c12df-5254-4abf-850b-a9596b2aba3a",
+      "prerequisites": [],
+      "topics": ["algorithms", "games", "parsing"],
+      "difficulty": 8
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "e80410bb-45e5-4007-ad97-e7470dd87ed5",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 2
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "56a794de-40ee-4ff2-a1dd-f9b83f62d4b0",
+      "prerequisites": [],
+      "topics": ["data_structures", "lists", "recursion"],
+      "difficulty": 3
+    }
+  ]
 }

--- a/languages/fsharp/config.json
+++ b/languages/fsharp/config.json
@@ -4,7 +4,10 @@
   "active": true,
   "blurb": "F# is a strongly-typed, functional language that is part of Microsoft's .NET language stack. Although F# is great for data science problems, it can elegantly handle almost every problem you throw at it.",
   "version": 3,
-  "online_editor": { "indent_style": "space", "indent_size": 4 },
+  "online_editor": {
+    "indent_style": "space",
+    "indent_size": 4
+  },
   "exercises": {
     "concept": [
       {
@@ -177,6 +180,879 @@
       "slug": "strings",
       "name": "Strings",
       "blurb": "TODO: add blurb for strings concept"
+    }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "302312cc-bd15-4ba0-8f2f-cbf411c40186",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "2ee3cc7a-db3f-4668-9983-ed6d0fea95d1",
+      "prerequisites": [],
+      "topics": ["optional_values", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "66d974b5-18fc-4993-b5f2-7beda4f4afa3",
+      "prerequisites": [],
+      "topics": ["control_flow_if_else_statements", "integers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "528a0023-8687-4524-8318-516d1e432d0d",
+      "prerequisites": [],
+      "topics": ["tuples"],
+      "difficulty": 3
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "0c953a84-e726-4b9f-a964-1950ac2f95f2",
+      "prerequisites": [],
+      "topics": ["filtering", "text_formatting"],
+      "difficulty": 2
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "e7085050-1611-4773-9032-0e0ffb56c20e",
+      "prerequisites": [],
+      "topics": ["recursion", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "space-age",
+      "uuid": "277d05db-0ba0-4de6-b5f8-090c251afffc",
+      "prerequisites": [],
+      "topics": ["discriminated_unions", "floating_point_numbers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "cf058dc8-db6f-4034-ac5b-22f1d8d0decc",
+      "prerequisites": [],
+      "topics": ["maps", "sorting"],
+      "difficulty": 2
+    },
+    {
+      "slug": "clock",
+      "uuid": "30c3a38e-1e44-4711-887e-fca301c26c1b",
+      "prerequisites": [],
+      "topics": ["structural_equality", "time"],
+      "difficulty": 3
+    },
+    {
+      "slug": "bob",
+      "uuid": "b3c4d578-10c8-47bc-b0ae-149ed8da530a",
+      "prerequisites": [],
+      "topics": ["control_flow_if_else_statements", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "0ea0d92f-5510-4ba9-b419-3f5ad029b74f",
+      "prerequisites": [],
+      "topics": ["algorithms", "text_formatting"],
+      "difficulty": 3
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "cf64cddf-63e2-4c71-ac15-0af617f82856",
+      "prerequisites": [],
+      "topics": ["enumerations", "parsing"],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "ecae4faa-c516-4a71-8d55-9c53403d8826",
+      "prerequisites": [],
+      "topics": ["records", "tuples"],
+      "difficulty": 3
+    },
+    {
+      "slug": "allergies",
+      "uuid": "221dff26-0495-4d4b-9363-14a5d7263271",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "enumerations", "filtering"],
+      "difficulty": 4
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "eca7e334-f549-4601-a515-9d1467d3d0ea",
+      "prerequisites": [],
+      "topics": ["parsing", "pattern_recognition"],
+      "difficulty": 5
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "a002e3db-8e9c-4cbf-b00f-f2090bae5d5a",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "tree-building",
+      "uuid": "a53fa908-f983-4da5-b1c1-3989bd2ea2f9",
+      "prerequisites": [],
+      "topics": ["refactoring", "trees"],
+      "difficulty": 5
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "e702b75e-4c9e-40ef-bcb1-674a87222c23",
+      "prerequisites": [],
+      "topics": ["lists", "math", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "8b66e691-508f-40d9-8cee-1d6aec27366e",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "math"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "e7f74f6c-16ea-40d8-94f7-7034bc6ee938",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "4e786e56-2658-445f-ac91-64dd9c38dbb3",
+      "prerequisites": [],
+      "topics": ["optional_values", "searching", "trees"],
+      "difficulty": 5
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "3969fb29-5997-4050-adb0-8c6e95f48013",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "1d377268-8892-460b-a84b-011fde1ff06b",
+      "prerequisites": [],
+      "topics": ["dates"],
+      "difficulty": 1
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "08be451e-65c1-4306-860e-ac0c4a02a546",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "3a015501-58bf-427c-8c4c-2197321f4a34",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "grains",
+      "uuid": "e3751098-5a15-4350-bf5d-507583de3386",
+      "prerequisites": [],
+      "topics": ["integers"],
+      "difficulty": 2
+    },
+    {
+      "slug": "hamming",
+      "uuid": "1dadf8c0-b15c-413f-987e-187d043910f0",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "e6f92e96-b26a-4eba-8759-e8976a8a9097",
+      "prerequisites": [],
+      "topics": ["maps", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "pangram",
+      "uuid": "dc133087-0548-49b4-8f17-0c26cf53bcdf",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "etl",
+      "uuid": "95e592a8-6663-4b07-894a-86a5cc310c67",
+      "prerequisites": [],
+      "topics": ["maps", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "darts",
+      "uuid": "fb3b73e1-673b-4907-821c-f85a157f53c1",
+      "prerequisites": [],
+      "topics": ["floating_point_numbers", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "high-scores",
+      "uuid": "c67d7118-2388-4421-baa1-cc3e4f0e2867",
+      "prerequisites": [],
+      "topics": ["lists", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "triangle",
+      "uuid": "47fd8f98-20d3-43fe-825f-27745e13908d",
+      "prerequisites": [],
+      "topics": ["integers"],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "3fbd466a-caf4-48ac-9a1e-796bc406ff1e",
+      "prerequisites": [],
+      "topics": ["randomness", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "error-handling",
+      "uuid": "fc7935f9-bffa-4eb1-b447-49379b45aac7",
+      "prerequisites": [],
+      "topics": [
+        "discriminated_unions",
+        "exception_handling",
+        "optional_values"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "e22fcca5-b23c-4feb-972f-9795dd1bd946",
+      "prerequisites": [],
+      "topics": ["transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "proverb",
+      "uuid": "5ca0e0ba-20ac-4d48-b2dc-0cdde06a8f3e",
+      "prerequisites": [],
+      "topics": ["algorithms", "text_formatting"],
+      "difficulty": 3
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "612395a5-238e-4be0-8ce0-4ac66f57056e",
+      "prerequisites": [],
+      "topics": ["lists", "strings", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "strain",
+      "uuid": "48ac8887-28db-4566-a415-c2d338dea104",
+      "prerequisites": [],
+      "topics": ["filtering", "sequences"],
+      "difficulty": 3
+    },
+    {
+      "slug": "isogram",
+      "uuid": "61404a27-62c3-43dc-93b7-7e4547e0a0d9",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "sieve",
+      "uuid": "a6511471-bc2c-4734-92fe-c6c5cf447efd",
+      "prerequisites": [],
+      "topics": ["filtering", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "929f98e4-a16c-464b-ac6c-59ca86dbd2b6",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "45fcf742-1b3a-422a-b476-5ee81d80057a",
+      "prerequisites": [],
+      "topics": ["discriminated_unions", "integers", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "c5b38251-14ba-4d98-a420-7a930f06167f",
+      "prerequisites": [],
+      "topics": ["lists", "searching"],
+      "difficulty": 3
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "ae78a960-2c55-44cb-9fd0-49b4bd5729c5",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "lists"],
+      "difficulty": 3
+    },
+    {
+      "slug": "word-count",
+      "uuid": "0c7a2f06-1e53-4043-9e1a-386e90e945b4",
+      "prerequisites": [],
+      "topics": ["maps", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "89cd6eb1-9671-42bd-a619-59013fb721b0",
+      "prerequisites": [],
+      "topics": ["algorithms", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "meetup",
+      "uuid": "3ce04665-95d1-4608-9763-5ee1b5f2584c",
+      "prerequisites": [],
+      "topics": ["dates"],
+      "difficulty": 4
+    },
+    {
+      "slug": "anagram",
+      "uuid": "cffcb076-295f-497f-8ef1-059a8fa65536",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "series",
+      "uuid": "4b07842c-dcef-4be0-a842-0b3b7a30c499",
+      "prerequisites": [],
+      "topics": ["lists", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "e86e88a0-802c-41f4-b2a1-c7a81b8e87de",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 4
+    },
+    {
+      "slug": "acronym",
+      "uuid": "926f9309-e0bb-457a-8f1d-8fa947ed5ce7",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "matrix",
+      "uuid": "632417fa-7bf7-4228-9b71-dbdd6738b223",
+      "prerequisites": [],
+      "topics": ["matrices", "parsing"],
+      "difficulty": 4
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "01e394ee-23d5-44e6-a37e-149ffaf5375e",
+      "prerequisites": [],
+      "topics": ["integers", "math", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "b3643992-583b-4e7a-a970-94bc7ae6739a",
+      "prerequisites": [],
+      "topics": ["integers", "math", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "house",
+      "uuid": "7d339c98-74ea-49d5-a97c-c0417e28468a",
+      "prerequisites": [],
+      "topics": ["algorithms", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "6bcde851-71ad-4985-b335-8ca67f99c22f",
+      "prerequisites": [],
+      "topics": ["integers", "math", "records"],
+      "difficulty": 4
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "526fc5b4-e96b-419a-8987-9b78e9bddc19",
+      "prerequisites": [],
+      "topics": ["lists", "matrices"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "fef76c19-db3c-442d-b2f5-b0dfae19ee43",
+      "prerequisites": [],
+      "topics": ["lists", "math", "recursion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "47602465-a92d-43a5-9e9a-8ef09ce2104d",
+      "prerequisites": [],
+      "topics": ["lists", "recursion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "18652e46-6dd2-4030-84af-be0965c92991",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "c339c32c-3310-4b8c-b4e6-0f9f651064b7",
+      "prerequisites": [],
+      "topics": ["loops", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "2e88193d-9f80-4d83-901b-bb5ac4b0804c",
+      "prerequisites": [],
+      "topics": ["recursion", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "dot-dsl",
+      "uuid": "dc50364b-b5b6-4e0b-ba58-32fb7d60a93b",
+      "prerequisites": [],
+      "topics": ["domain_specific_languages"],
+      "difficulty": 5
+    },
+    {
+      "slug": "parallel-letter-frequency",
+      "uuid": "c0d0ae0f-83fb-433a-8778-d38e8a6645aa",
+      "prerequisites": [],
+      "topics": ["parallellism", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "253f040d-35c2-4e1c-8651-d7a7410d7d0d",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 5
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "df6f311b-9deb-4d07-9a29-3d881556513e",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "26b00c8d-6282-48a8-b017-2ed3e6d48267",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "scale-generator",
+      "uuid": "02a8e767-7449-48a9-8d6b-f2cac708de50",
+      "prerequisites": [],
+      "topics": ["algorithms", "parsing"],
+      "difficulty": 5
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "3fb37bef-a754-4a64-8493-ba4254518017",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "f4dee9ea-fcdf-4623-8ae1-13bdf995f2cb",
+      "prerequisites": [],
+      "topics": ["algorithms", "text_formatting"],
+      "difficulty": 5
+    },
+    {
+      "slug": "grep",
+      "uuid": "da48b422-1c23-4272-87a4-415620d4e857",
+      "prerequisites": [],
+      "topics": ["files", "searching", "text_formatting"],
+      "difficulty": 5
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "ecee74aa-41f5-42aa-b99e-31e9589378e3",
+      "prerequisites": [],
+      "topics": ["sets"],
+      "difficulty": 5
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "8d381a54-04a1-45d3-84d3-933b0d94f440",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "ledger",
+      "uuid": "e860ad86-cd1f-474b-9e8e-d8a72ff4315c",
+      "prerequisites": [],
+      "topics": ["globalization", "refactoring", "text_formatting"],
+      "difficulty": 5
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "b62f8574-9bac-4b95-a76c-f13789ae2663",
+      "prerequisites": [],
+      "topics": ["queues", "records"],
+      "difficulty": 5
+    },
+    {
+      "slug": "luhn",
+      "uuid": "85ab318f-7842-486d-88de-f0ff7fbef069",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "bank-account",
+      "uuid": "cb629d30-0351-4023-bd51-423267164c24",
+      "prerequisites": [],
+      "topics": ["concurrency", "optional_values"],
+      "difficulty": 5
+    },
+    {
+      "slug": "markdown",
+      "uuid": "0688eb10-9581-45c0-a69a-13f20d534cb0",
+      "prerequisites": [],
+      "topics": ["parsing", "refactoring", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "0a10cd0b-ea37-4c78-a6a4-223203ac1c37",
+      "prerequisites": [],
+      "topics": ["algorithms", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "book-store",
+      "uuid": "3741977a-adff-47bb-a9c5-c2e444805bac",
+      "prerequisites": [],
+      "topics": ["recursion"],
+      "difficulty": 5
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "52f8f299-b93b-4f44-bd5b-b445741b285d",
+      "prerequisites": [],
+      "topics": ["algorithms", "matrices"],
+      "difficulty": 5
+    },
+    {
+      "slug": "yacht",
+      "uuid": "005721ef-264e-4f81-ae63-ae72b0e5310f",
+      "prerequisites": [],
+      "topics": ["discriminated_unions", "games", "parsing"],
+      "difficulty": 5
+    },
+    {
+      "slug": "tournament",
+      "uuid": "b5672a0c-aac5-4274-a458-39d018b74750",
+      "prerequisites": [],
+      "topics": ["parsing", "text_formatting"],
+      "difficulty": 6
+    },
+    {
+      "slug": "word-search",
+      "uuid": "8f8a79d1-78ed-4cdd-adcc-5cd6c6781dcd",
+      "prerequisites": [],
+      "topics": ["optional_values", "searching", "tuples"],
+      "difficulty": 6
+    },
+    {
+      "slug": "bowling",
+      "uuid": "1c8ad2ca-4aec-47af-94b1-ef7e2830b463",
+      "prerequisites": [],
+      "topics": ["algorithms"],
+      "difficulty": 6
+    },
+    {
+      "slug": "transpose",
+      "uuid": "3dfedd37-8159-446d-a332-e9d356f484ca",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "220cbe7e-e781-4ab9-84ec-2b89a3c97670",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 6
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "471c89f9-8b27-4898-8e98-58e4b2921616",
+      "prerequisites": [],
+      "topics": ["algorithms", "math", "strings", "tuples"],
+      "difficulty": 6
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "d993508d-b4d2-4f3f-a46d-35b753bf90a9",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 6
+    },
+    {
+      "slug": "rational-numbers",
+      "uuid": "913ce020-32ae-4b65-ae64-c924d25295dc",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 6
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "c418bba8-2185-4b45-92f1-0cfafbbe8ce5",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "677ca063-70fe-4cfc-8112-c5d78bd1ea44",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 7
+    },
+    {
+      "slug": "sublist",
+      "uuid": "d17b0c35-49a7-4ea6-b68c-7b2b56dc5968",
+      "prerequisites": [],
+      "topics": ["lists", "recursion"],
+      "difficulty": 7
+    },
+    {
+      "slug": "change",
+      "uuid": "03a1c773-5c48-4f70-a2de-b742197fa9d2",
+      "prerequisites": [],
+      "topics": ["integers", "recursion"],
+      "difficulty": 7
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "9e3fc78d-ac3b-4195-ad4c-9f99b0ee2678",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "diffie-hellman",
+      "uuid": "2a7e3e78-ab94-40f3-8f16-1d5aa84c2f85",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "math", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "f09d34d3-f12c-4c9a-9083-68172478278e",
+      "prerequisites": [],
+      "topics": ["lists", "tuples"],
+      "difficulty": 7
+    },
+    {
+      "slug": "rectangles",
+      "uuid": "d3f364e0-9866-4ec4-8197-dc248b96042b",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "wordy",
+      "uuid": "c721b3f2-4afc-4a30-bad5-77bd002c2819",
+      "prerequisites": [],
+      "topics": ["parsing", "strings", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "hangman",
+      "uuid": "ab0f1b66-011f-4aa3-89c5-c89427121279",
+      "prerequisites": [],
+      "topics": ["reactive_programming"],
+      "difficulty": 8
+    },
+    {
+      "slug": "zebra-puzzle",
+      "uuid": "ee021156-5520-4386-8b5d-9c648f30287c",
+      "prerequisites": [],
+      "topics": ["logic"],
+      "difficulty": 8
+    },
+    {
+      "slug": "poker",
+      "uuid": "411b93d0-214d-4d46-9081-16b9dd376174",
+      "prerequisites": [],
+      "topics": ["discriminated_unions", "games", "parsing", "sorting"],
+      "difficulty": 8
+    },
+    {
+      "slug": "diamond",
+      "uuid": "736a470f-412c-41fc-b92d-9bd59ef3bcce",
+      "prerequisites": [],
+      "topics": ["algorithms", "text_formatting"],
+      "difficulty": 8
+    },
+    {
+      "slug": "two-bucket",
+      "uuid": "78472676-26f0-4bef-813b-9b958c4c35df",
+      "prerequisites": [],
+      "topics": ["logic"],
+      "difficulty": 8
+    },
+    {
+      "slug": "connect",
+      "uuid": "dead8124-6942-4205-9ea8-3cb926c0dc47",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 8
+    },
+    {
+      "slug": "say",
+      "uuid": "7af901ca-24ea-4c24-a660-99b1f4338e01",
+      "prerequisites": [],
+      "topics": ["strings", "text_formatting", "transforming"],
+      "difficulty": 8
+    },
+    {
+      "slug": "react",
+      "uuid": "8eef5619-f331-46b3-a2c1-d581f523a815",
+      "prerequisites": [],
+      "topics": ["classes", "events", "reactive_programming"],
+      "difficulty": 9
+    },
+    {
+      "slug": "variable-length-quantity",
+      "uuid": "ef86703b-9e78-43f8-aa4c-203492ac622c",
+      "prerequisites": [],
+      "topics": ["algorithms", "bitwise_operations"],
+      "difficulty": 9
+    },
+    {
+      "slug": "go-counting",
+      "uuid": "01ffa95c-1966-4031-b0d2-64f254d85b82",
+      "prerequisites": [],
+      "topics": ["optional_values", "parsing", "tuples"],
+      "difficulty": 9
+    },
+    {
+      "slug": "lens-person",
+      "uuid": "443fdb8c-1a97-4086-be6a-b541faa961a5",
+      "prerequisites": [],
+      "topics": ["lenses"],
+      "difficulty": 9
+    },
+    {
+      "slug": "sgf-parsing",
+      "uuid": "fe0e98b3-d0d3-4bf6-bfaa-8aa0e61aa625",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 9
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "3d682945-5fa1-4121-9d5b-7bac60660de9",
+      "prerequisites": [],
+      "topics": ["maps", "parsing"],
+      "difficulty": 9
+    },
+    {
+      "slug": "zipper",
+      "uuid": "5369eea9-00c8-4044-b272-1ce8d0590ecf",
+      "prerequisites": [],
+      "topics": ["recursion", "searching", "trees"],
+      "difficulty": 10
+    },
+    {
+      "slug": "forth",
+      "uuid": "533981a1-632c-4ca8-a4ae-05f3ad1a810b",
+      "prerequisites": [],
+      "topics": ["parsing", "stacks"],
+      "difficulty": 10
+    },
+    {
+      "slug": "pov",
+      "uuid": "a6082751-98ca-45dc-aeed-cdd19a8da0ca",
+      "prerequisites": [],
+      "topics": ["graphs", "recursion", "searching"],
+      "difficulty": 10
+    },
+    {
+      "slug": "binary",
+      "uuid": "df8f4106-c1ce-4c33-86b2-ad61ba5ccc4a",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "trinary",
+      "uuid": "81904afe-a893-45be-99f8-2e074a6f1ad5",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "octal",
+      "uuid": "f29f9e56-c79b-4ae4-a0d0-29db78c677e4",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "f4f80d57-a248-49d3-9329-587eb2643d4f",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "rest-api",
+      "uuid": "b0aaf5ac-f94d-4995-af4a-b27068cf540e",
+      "prerequisites": [],
+      "topics": ["json", "parsing"],
+      "difficulty": 5
+    },
+    {
+      "slug": "dnd-character",
+      "uuid": "93550ca5-cd8c-42e3-88f3-e6ce41608342",
+      "prerequisites": [],
+      "topics": ["randomness"],
+      "difficulty": 3
+    },
+    {
+      "slug": "affine-cipher",
+      "uuid": "ae2f8b66-1d5f-4c19-ad84-b9a7e9e87d0e",
+      "prerequisites": [],
+      "topics": ["cryptography", "math", "strings"],
+      "difficulty": 3
     }
   ]
 }

--- a/languages/go/config.json
+++ b/languages/go/config.json
@@ -502,5 +502,926 @@
       "name": "Zero Value",
       "blurb": "TODO: add blurb for zero-value concept"
     }
+  ],
+  "practice": [
+    {
+      "slug": "gigasecond",
+      "uuid": "ea390e58-6ac5-4219-89bb-648852712a6a",
+      "prerequisites": [],
+      "topics": ["time"],
+      "difficulty": 1
+    },
+    {
+      "slug": "bob",
+      "uuid": "efdf07a1-e329-4d0f-90a1-374b9b8af748",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "acronym",
+      "uuid": "b39d9e79-dee0-4c70-a6c3-114bee8083f2",
+      "prerequisites": [],
+      "topics": ["regular_expressions", "strings", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "hello-world",
+      "uuid": "19957346-dedf-441e-85ea-656cac0d96d8",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "space-age",
+      "uuid": "5a6baa1c-8ca8-4ebe-a1d2-1e0687ca846a",
+      "prerequisites": [],
+      "topics": ["floating_point_numbers", "if_else_statements"],
+      "difficulty": 2
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "08a6c476-9ffe-4ae3-9996-cd299cc82fca",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "hamming",
+      "uuid": "52582415-8f7f-4ac5-857f-5c160ec48134",
+      "prerequisites": [],
+      "topics": ["equality", "loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "2f51e32a-9b1f-4100-9eec-517115c858e9",
+      "prerequisites": [],
+      "topics": ["conditionals", "filtering", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "20cbd8f9-f8e3-4767-a0f5-94810ba3f902",
+      "prerequisites": [],
+      "topics": ["loops", "maps", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "isogram",
+      "uuid": "c2064df8-cce5-4f03-9d85-0818b4e34112",
+      "prerequisites": [],
+      "topics": ["sequences", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "e2df2756-7a48-4b45-b601-91be91027dbd",
+      "prerequisites": [],
+      "topics": ["sequences", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "19628c8a-a89f-457e-9526-3d400024a927",
+      "prerequisites": [],
+      "topics": ["algorithms", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "luhn",
+      "uuid": "8b29da0e-8ead-4e72-a12a-d448c8434767",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "grains",
+      "uuid": "b4f6b08b-a132-447b-b447-66bf37ab20c6",
+      "prerequisites": [],
+      "topics": [
+        "bitwise_operations",
+        "if_else_statements",
+        "integers",
+        "type_conversion"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "clock",
+      "uuid": "7d2de21e-bf67-495e-8d90-05e1a35d5b99",
+      "prerequisites": [],
+      "topics": ["equality", "text_formatting", "time"],
+      "difficulty": 3
+    },
+    {
+      "slug": "parallel-letter-frequency",
+      "uuid": "bf366b19-63bf-4a75-9a35-08b881af6951",
+      "prerequisites": [],
+      "topics": ["concurrency"],
+      "difficulty": 3
+    },
+    {
+      "slug": "tree-building",
+      "uuid": "d0a2afab-e30d-4617-b646-413a44ecf2ed",
+      "prerequisites": [],
+      "topics": ["records", "refactoring", "sorting", "trees"],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "86b8f1e6-e088-403e-984a-abd360f5dcef",
+      "prerequisites": [],
+      "topics": ["randomness"],
+      "difficulty": 3
+    },
+    {
+      "slug": "tournament",
+      "uuid": "572d03ec-d763-400e-ba4f-5a6a92d5af98",
+      "prerequisites": [],
+      "topics": [
+        "integers",
+        "parsing",
+        "records",
+        "sorting",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "75b6e2e8-1e20-4f53-b7c5-e32f9f7eea58",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "pattern_recognition",
+        "sequences",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "matrix",
+      "uuid": "62aa3d20-65d8-440f-9d08-48bbc823f4fe",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "exception_handling",
+        "matrices",
+        "strings",
+        "type_conversion"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "sublist",
+      "uuid": "4174c0c6-cb8a-474c-9327-737b7a86326e",
+      "prerequisites": [],
+      "topics": ["arrays", "control_flow_loops"],
+      "difficulty": 3
+    },
+    {
+      "slug": "error-handling",
+      "uuid": "cd05b63b-df20-4c8d-8743-53033acf7696",
+      "prerequisites": [],
+      "topics": ["exception_handling"],
+      "difficulty": 5
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "40cc79a6-a6ea-45a0-944e-b4f3baabebc2",
+      "prerequisites": [],
+      "topics": ["arrays", "recursion"],
+      "difficulty": 3
+    },
+    {
+      "slug": "bank-account",
+      "uuid": "7cb6c78e-44e9-499b-a745-3ecb73bea3ab",
+      "prerequisites": [],
+      "topics": ["concurrency", "integers"],
+      "difficulty": 4
+    },
+    {
+      "slug": "paasio",
+      "uuid": "5dbec590-7a50-4398-987b-7252734216a2",
+      "prerequisites": [],
+      "topics": ["concurrency", "interfaces", "networking"],
+      "difficulty": 5
+    },
+    {
+      "slug": "leap",
+      "uuid": "fee57b09-2b67-4483-a2e5-3dfec0568b15",
+      "prerequisites": [],
+      "topics": ["booleans", "conditionals", "integers", "logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "fb03948c-11e8-440d-9a5d-979396451270",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 1
+    },
+    {
+      "slug": "triangle",
+      "uuid": "6769557a-33fa-4257-adbf-e66dc8c06f85",
+      "prerequisites": [],
+      "topics": ["booleans", "conditionals", "logic"],
+      "difficulty": 3
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "9a1870e0-dce7-496e-9521-2f2b606ac6c5",
+      "prerequisites": [],
+      "topics": ["arrays", "bitwise_operations", "integers"],
+      "difficulty": 5
+    },
+    {
+      "slug": "house",
+      "uuid": "11008fb0-4ef9-4aff-befb-c56f4084f96e",
+      "prerequisites": [],
+      "topics": ["recursion", "strings", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "92e2a192-5ee9-422a-8699-c231a7136b10",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "math", "recursion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "series",
+      "uuid": "2c5fb577-a9ce-4c4c-8fc8-fffb38d020d6",
+      "prerequisites": [],
+      "topics": ["arrays", "refactoring", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "95f49a88-6f01-4905-a8b1-a3fcec1f535a",
+      "prerequisites": [],
+      "topics": ["booleans", "errors", "games", "logic"],
+      "difficulty": 5
+    },
+    {
+      "slug": "etl",
+      "uuid": "73da448c-33b7-4565-ab48-1de5020d65ab",
+      "prerequisites": [],
+      "topics": ["loops", "maps", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "f0c25fde-960e-4161-a642-4414925b4d0a",
+      "prerequisites": [],
+      "topics": ["loops", "math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "6c919eab-7c63-444a-a485-db74d51c3430",
+      "prerequisites": [],
+      "topics": ["algorithms", "math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "pangram",
+      "uuid": "d14c6283-e57c-472c-8181-87f82d9088dd",
+      "prerequisites": [],
+      "topics": ["loops", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "a1c065d9-6971-4286-8413-c944e2dddefa",
+      "prerequisites": [],
+      "topics": [
+        "cryptography",
+        "filtering",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "12a16ab5-35fc-4fb2-a018-504953f3ad80",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "recursion",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "8ec72d61-d830-48cf-819d-cd4faf0cf67d",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "math", "sequences"],
+      "difficulty": 3
+    },
+    {
+      "slug": "sieve",
+      "uuid": "c3469a26-b133-43b4-ab7d-32ea04fa5ce4",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "loops", "math", "sorting"],
+      "difficulty": 3
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "10f091b1-deda-4fec-8e3c-9dabb080d473",
+      "prerequisites": [],
+      "topics": ["algorithms", "math"],
+      "difficulty": 6
+    },
+    {
+      "slug": "scale-generator",
+      "uuid": "478d8d31-454d-4a8a-af01-96864186d5f2",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "0b9e07de-c8e4-4d28-b589-897a7ef8062a",
+      "prerequisites": [],
+      "topics": ["filtering", "maps", "sequences"],
+      "difficulty": 3
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "362f93ab-51e8-4d6a-bd2f-b46432843eb9",
+      "prerequisites": [],
+      "topics": ["algorithms", "filtering", "integers", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "6c2499f7-d42c-4d0f-9680-f5f7650023ff",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 7
+    },
+    {
+      "slug": "anagram",
+      "uuid": "f1db7190-a53d-411d-b538-8dc3f75ddc32",
+      "prerequisites": [],
+      "topics": ["filtering", "parsing", "sorting", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "word-count",
+      "uuid": "b765fde9-84b4-44cc-bdf1-f66ac1ab8e2c",
+      "prerequisites": [],
+      "topics": ["sorting", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "allergies",
+      "uuid": "cbfd4cfb-abe7-45f9-80e4-3de3b2639fc8",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "enumeration"],
+      "difficulty": 4
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "bafd87ad-1dc5-4bbe-b853-ed330c3f155a",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "cryptography",
+        "loops",
+        "sorting",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "9bef2163-2a24-4d50-9610-e3cac2e7772a",
+      "prerequisites": [],
+      "topics": ["maps", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "eccfd2b3-93cf-41a8-b39b-c29596469e8e",
+      "prerequisites": [],
+      "topics": ["numbers", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "say",
+      "uuid": "5d742499-b130-458a-ba3e-a4c3d75419c3",
+      "prerequisites": [],
+      "topics": ["numbers", "strings", "text_formatting", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "c13edd0a-cd39-4f25-970c-c1f9e32bac2c",
+      "prerequisites": [],
+      "topics": ["queues", "structs"],
+      "difficulty": 5
+    },
+    {
+      "slug": "diamond",
+      "uuid": "47b9ad32-e9d9-4cbc-b106-540f3afbfa80",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "loops",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "react",
+      "uuid": "4b168cb9-605b-465d-8f89-3a3b760c1402",
+      "prerequisites": [],
+      "topics": ["callbacks", "interfaces", "reactive_programming"],
+      "difficulty": 9
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "ad12bbf9-e0c8-433a-8a6b-847ff2d36acf",
+      "prerequisites": [],
+      "topics": ["filtering", "loops", "sets"],
+      "difficulty": 4
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "84bda80c-b82c-45f6-95d4-5568d23a22dd",
+      "prerequisites": [],
+      "topics": ["algorithms", "cryptography", "strings", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "458053ea-43a9-409f-a1a6-a7f31329aca4",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "regular_expressions",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "strain",
+      "uuid": "7fbb0d9d-71d1-4654-8ca0-bb07ddbe6cb5",
+      "prerequisites": [],
+      "topics": ["arrays", "filtering", "loops"],
+      "difficulty": 2
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "4fe8ba14-20ba-4aa3-b134-7aed799a7522",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "dbf4d64e-c02d-4bdf-8be1-43f9acb5f2ad",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "b3f06c57-c0de-4b8f-bd16-782b2ce3f478",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "transpose",
+      "uuid": "7f19ebbd-b072-45e5-ad67-2fff8ad1c9e2",
+      "prerequisites": [],
+      "topics": ["loops", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "128e0b12-0ad2-431a-971c-ad4ab098b42d",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "diffie-hellman",
+      "uuid": "f3058f8b-7e0e-4adb-9add-1df23607d4ed",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "cryptography",
+        "integers",
+        "math",
+        "transforming"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "094ea17e-1759-443a-9117-7c72c6f68b8d",
+      "prerequisites": [],
+      "topics": ["loops", "strings", "text_formatting"],
+      "difficulty": 3
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "13e58d89-4dbb-4384-9268-2f8083588d7a",
+      "prerequisites": [],
+      "topics": ["parsing", "pattern_recognition"],
+      "difficulty": 7
+    },
+    {
+      "slug": "wordy",
+      "uuid": "1eb7d7b2-6367-4038-bb86-7dc6c682b6a3",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "integers",
+        "parsing",
+        "strings",
+        "type_conversion"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "5911d90f-ba2f-482f-8c92-c01c112d6fdd",
+      "prerequisites": [],
+      "topics": ["maps", "parsing", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "aa598f3e-9d2b-4f9f-8c14-46e0ac27d5be",
+      "prerequisites": [],
+      "topics": ["lists", "sorting", "structs"],
+      "difficulty": 5
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "c78102b0-aaa3-4edb-a315-4fcdc26ccae8",
+      "prerequisites": [],
+      "topics": ["arrays", "integers", "matrices", "searching"],
+      "difficulty": 5
+    },
+    {
+      "slug": "meetup",
+      "uuid": "fcf735fe-a659-40ae-858e-6d1e834a4faf",
+      "prerequisites": [],
+      "topics": ["dates", "time", "transforming", "type_conversion"],
+      "difficulty": 3
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "408f235e-f1ce-11e7-8c3f-9a214cf093ae",
+      "prerequisites": [],
+      "topics": ["arrays", "loops"],
+      "difficulty": 4
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "4368df53-39fb-4f36-97c2-39c399cd6d25",
+      "prerequisites": [],
+      "topics": ["data_structure", "pointer"],
+      "difficulty": 4
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "31c77516-6702-417e-9c6e-19c7e965d513",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "searching", "sorting"],
+      "difficulty": 5
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "ac680609-4e52-468d-bf17-afbf7b2fa74b",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "recursion",
+        "searching",
+        "sorting",
+        "structs",
+        "trees"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "4282b1f6-d1a2-41b4-9a7f-a9a145fb283b",
+      "prerequisites": [],
+      "topics": ["parsing", "records", "searching", "strings", "structs"],
+      "difficulty": 3
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "7b9201fa-92d2-43fd-8b35-4c552336570b",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "cryptography",
+        "interfaces",
+        "strings",
+        "transforming"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "pov",
+      "uuid": "cdbadf95-66ff-455f-bea3-eff5024afcb7",
+      "prerequisites": [],
+      "topics": ["graphs", "recursion", "structs", "transforming", "trees"],
+      "difficulty": 7
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "3bf049f8-7283-4370-aa0c-e10e99d9ef80",
+      "prerequisites": [],
+      "topics": ["arrays", "games", "loops", "matrices", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "fc0e4034-0744-43f8-9969-7789cff0607f",
+      "prerequisites": [],
+      "topics": ["concurrency", "loops", "sequences", "strings", "structs"],
+      "difficulty": 6
+    },
+    {
+      "slug": "word-search",
+      "uuid": "7fdf352b-e5a3-452e-91a2-03587be48ad0",
+      "prerequisites": [],
+      "topics": ["matrices", "searching", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "932a7ed0-c331-49b1-917b-a197198f642a",
+      "prerequisites": [],
+      "topics": ["integers", "math", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "connect",
+      "uuid": "395116bc-5be9-4140-a2ef-c7e8689149f2",
+      "prerequisites": [],
+      "topics": ["arrays", "games", "graphs", "loops", "searching"],
+      "difficulty": 9
+    },
+    {
+      "slug": "ledger",
+      "uuid": "7aa53a27-4ff3-4891-809f-2af728eb55a0",
+      "prerequisites": [],
+      "topics": [
+        "dates",
+        "integers",
+        "records",
+        "refactoring",
+        "sorting",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "markdown",
+      "uuid": "a7469032-c4d0-4e15-aa0c-4e9f6588b4c8",
+      "prerequisites": [],
+      "topics": ["refactoring", "strings", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "yacht",
+      "uuid": "37980ffd-acc7-44f4-ad32-43e0624457a8",
+      "prerequisites": [],
+      "topics": [
+        "equality",
+        "games",
+        "integers",
+        "parsing",
+        "pattern_matching",
+        "sequences"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "poker",
+      "uuid": "9be60690-39bb-4173-a2ed-faa4acd8f38f",
+      "prerequisites": [],
+      "topics": [
+        "equality",
+        "games",
+        "parsing",
+        "pattern_matching",
+        "sequences",
+        "strings"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "variable-length-quantity",
+      "uuid": "333231db-2605-438e-9eb0-d1bdc51c7419",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "integers", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "forth",
+      "uuid": "09d0d78f-f262-4f34-b1de-c2acd7ed80cd",
+      "prerequisites": [],
+      "topics": ["domain_specific_languages", "parsing", "stacks"],
+      "difficulty": 8
+    },
+    {
+      "slug": "change",
+      "uuid": "94a21509-ebd5-4a66-bb0e-0341e57e3c73",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "loops", "searching"],
+      "difficulty": 5
+    },
+    {
+      "slug": "bowling",
+      "uuid": "8d5aaf47-7503-4797-85ed-d35a8755cfd4",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "conditionals"],
+      "difficulty": 5
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "29ea064e-9d2a-11e7-abc4-cec278b6b50a",
+      "prerequisites": [],
+      "topics": ["parsing", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "0c17444e-65b0-4bc8-a7e1-ee6ab8c2e078",
+      "prerequisites": [],
+      "topics": ["conditionals", "control_flow_loops", "integers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "4fc21001-2ada-41f6-92b6-cf0152df18bf",
+      "prerequisites": [],
+      "topics": ["arrays", "loops", "matrices"],
+      "difficulty": 4
+    },
+    {
+      "slug": "book-store",
+      "uuid": "9265ef0c-a882-4e2e-9689-cd4fddac6097",
+      "prerequisites": [],
+      "topics": ["algorithms", "floating_point_numbers", "integers", "lists"],
+      "difficulty": 8
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "37821140-c0d0-4da8-8f50-47356705a615",
+      "prerequisites": [],
+      "topics": ["cryptography", "integers", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "proverb",
+      "uuid": "b6d05e8f-542b-4789-9cbc-7ba132a5f03d",
+      "prerequisites": [],
+      "topics": ["arrays", "loops", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "3530f2f0-ee5f-46a3-a8ee-e9927a637253",
+      "prerequisites": [],
+      "topics": ["arrays"],
+      "difficulty": 2
+    },
+    {
+      "slug": "zebra-puzzle",
+      "uuid": "e31199ac-e657-4997-b931-63893a575c08",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "searching"],
+      "difficulty": 6
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "2e5c9e76-decd-49db-be4b-353ebeb46b73",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "searching"],
+      "difficulty": 4
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "6b313720-104a-46c2-8290-4b4af121101f ",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "searching"],
+      "difficulty": 5
+    },
+    {
+      "slug": "two-bucket",
+      "uuid": "549bf4a0-b8eb-4f66-8990-7df6cdfaee0c",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "searching"],
+      "difficulty": 5
+    },
+    {
+      "slug": "grep",
+      "uuid": "ec5dab72-dd96-4dce-8886-aff52a6eb090",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "arrays",
+        "conditionals",
+        "searching",
+        "strings"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "rectangles",
+      "uuid": "e7e207dc-bf8b-4bbf-b06e-edd674e09a06",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "matrices",
+        "strings"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "13d25b60-e8e1-42da-a54f-ce020a2b86e9",
+      "prerequisites": [],
+      "topics": [
+        "functional_programming",
+        "lists",
+        "recursion",
+        "type_conversion"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "darts",
+      "uuid": "ea1f15aa-43b8-416e-9add-bf3852f6a158",
+      "prerequisites": [],
+      "topics": ["conditionals", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "binary",
+      "uuid": "bf2dcbc4-266f-4cad-9cd7-76d446360a5d",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "counter",
+      "uuid": "9a06556b-a661-4329-97a1-b5d0f0c7590c",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "0c9cef3d-57f6-479a-aca4-25f310426d6a",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "octal",
+      "uuid": "4840c889-ebe5-4082-98c0-b9ed8618f6eb",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "trinary",
+      "uuid": "52af9f03-8b6b-4d75-a363-124f3269dccd",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    }
   ]
 }

--- a/languages/haskell/config.json
+++ b/languages/haskell/config.json
@@ -14,5 +14,724 @@
     "concept": [],
     "practice": []
   },
-  "concepts": []
+  "concepts": [],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "c97d9dda-c7ee-4595-b447-693559d03ba5",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "0ad7d756-1cbd-44f4-a64f-0dc7e9eb40f4",
+      "prerequisites": [],
+      "topics": ["booleans", "expressions"],
+      "difficulty": 1
+    },
+    {
+      "slug": "space-age",
+      "uuid": "6cbb7841-9d96-4528-88e3-6e98a450fd7c",
+      "prerequisites": [],
+      "topics": ["sum_types"],
+      "difficulty": 1
+    },
+    {
+      "slug": "pangram",
+      "uuid": "42cb6880-0c4b-4455-815b-aac94c05db18",
+      "prerequisites": [],
+      "topics": ["higher_order_functions", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "bob",
+      "uuid": "e570c730-12e5-4b9e-adb0-eae85360e1b5",
+      "prerequisites": [],
+      "topics": ["guards", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "6eba4eac-8395-4ad6-ac21-3651a11ab4b4",
+      "prerequisites": [],
+      "topics": ["guards", "maybe", "number_theory", "recursion"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "85d77b8e-9b87-4d02-9fba-81f843bd66f1",
+      "prerequisites": [],
+      "topics": ["either", "traversable"],
+      "difficulty": 1
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "00feb0e9-ae1e-43fc-a0ea-8f2d0d0b9f49",
+      "prerequisites": [],
+      "topics": ["data_structures", "either", "higher_order_functions"],
+      "difficulty": 2
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "e125a32e-60ca-4e59-ae35-01f3b1907ccd",
+      "prerequisites": [],
+      "topics": ["math", "number_theory"],
+      "difficulty": 1
+    },
+    {
+      "slug": "grains",
+      "uuid": "197a543c-d9c7-41c3-814c-4b1ece3db568",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 2
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "8d643e12-54dd-40ff-9919-e89b301e2112",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "c8953b81-97f2-4c26-b2b8-aa7ef95c5ff1",
+      "prerequisites": [],
+      "topics": ["math", "number_theory"],
+      "difficulty": 1
+    },
+    {
+      "slug": "acronym",
+      "uuid": "4b5b2254-1c68-449a-8150-c1d33b8de9d1",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "928b22c5-f2bd-4496-8605-fcff2dad2c3a",
+      "prerequisites": [],
+      "topics": ["math", "maybe", "number_theory"],
+      "difficulty": 2
+    },
+    {
+      "slug": "hamming",
+      "uuid": "30686585-eb09-4514-8b2e-c9a0d9983133",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 2
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "ba13fdf3-9a36-4286-8b78-75964d1aa373",
+      "prerequisites": [],
+      "topics": ["define_type"],
+      "difficulty": 2
+    },
+    {
+      "slug": "isogram",
+      "uuid": "6eba4eac-6665-4ad6-ac21-3651a11ab4b4",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "diamond",
+      "uuid": "40d4aa74-6e4a-4579-810e-b4430bc172e8",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "etl",
+      "uuid": "8082b1fb-7e3b-4a7f-b857-479bdb0d65e3",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "39d5aa74-6e4a-4579-810e-b4430bc172e8",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "resistor-color-duo",
+      "uuid": "61be7bcd-42fb-44b7-a51d-1d081173f876",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "resistor-color-trio",
+      "uuid": "946a2c88-fd0c-4dbc-a5cf-75ad9147e80c",
+      "prerequisites": [],
+      "topics": ["data_types", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "5c5a9256-a55e-4bda-baf3-96d052732e11",
+      "prerequisites": [],
+      "topics": ["filtering", "lazy_evaluation", "library_reimplementation"],
+      "difficulty": 3
+    },
+    {
+      "slug": "strain",
+      "uuid": "b66851aa-c05e-4a52-aaab-387f193c1dc7",
+      "prerequisites": [],
+      "topics": ["lazy_evaluation", "library_reimplementation"],
+      "difficulty": 3
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "fd372449-0f01-4b2c-b42d-b56ede6f58fe",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 3
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "d1dc946d-a142-42ed-abec-e53605635c0d",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "e5a0bed3-90ca-4caa-a73f-2124940f84c9",
+      "prerequisites": [],
+      "topics": ["algorithms"],
+      "difficulty": 3
+    },
+    {
+      "slug": "yacht",
+      "uuid": "8e129e54-6b5c-4696-84bc-588bc1c7f0f7",
+      "prerequisites": [],
+      "topics": ["lists", "sum_types"],
+      "difficulty": 3
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "6eba4eac-8395-4ad6-ac21-3651a11ab4b5",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "382e4fbd-99d6-400b-962c-ebb4a411bcea",
+      "prerequisites": [],
+      "topics": ["refactoring"],
+      "difficulty": 3
+    },
+    {
+      "slug": "triangle",
+      "uuid": "28bf351c-0417-4113-83c9-e1e00992cd37",
+      "prerequisites": [],
+      "topics": ["math", "number_theory"],
+      "difficulty": 3
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "7157a846-5846-47a4-97c2-daad7f763512",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "f3e12dd1-d3c7-4955-975f-bfc471d689c7",
+      "prerequisites": [],
+      "topics": ["define_type"],
+      "difficulty": 3
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "4e10e864-2fe4-4926-b908-f70645698999",
+      "prerequisites": [],
+      "topics": ["define_type", "math", "number_theory"],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "c456adbd-fa8c-4ffe-aa8c-60a1fd1f429e",
+      "prerequisites": [],
+      "topics": ["define_type"],
+      "difficulty": 3
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "36d2d7f0-8e9c-4493-979c-080f7067494f",
+      "prerequisites": [],
+      "topics": ["bitwise_operations"],
+      "difficulty": 3
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "f750e380-fe16-42c0-8b3d-8acd7e443a6e",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 3
+    },
+    {
+      "slug": "dnd-character",
+      "uuid": "138db4fc-ee70-11e8-8eb2-f2801f1b9fd1",
+      "prerequisites": [],
+      "topics": ["random"],
+      "difficulty": 3
+    },
+    {
+      "slug": "anagram",
+      "uuid": "67c53230-82e8-4207-a811-abec27bef381",
+      "prerequisites": [],
+      "topics": ["filtering", "lists", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "896dfe3d-f3c9-4c42-bc8d-8de49a8c7766",
+      "prerequisites": [],
+      "topics": ["define_type", "library_reimplementation"],
+      "difficulty": 4
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "fd106381-478d-43b0-bdd2-c39e7044e01a",
+      "prerequisites": [],
+      "topics": [
+        "accumulator_strictness",
+        "filtering",
+        "library_reimplementation"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "meetup",
+      "uuid": "01401d15-6667-4f94-bcd2-ec5a70df1cc6",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 4
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "1c575894-ea99-4443-90c2-8172eaff7fea",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 4
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "8cc9254d-cda5-4a7d-ad50-921a99f1432d",
+      "prerequisites": [],
+      "topics": ["math", "number_theory"],
+      "difficulty": 4
+    },
+    {
+      "slug": "allergies",
+      "uuid": "3630c60f-3e18-42c2-bce4-10dc62d11b25",
+      "prerequisites": [],
+      "topics": ["algorithms", "bitwise_operations"],
+      "difficulty": 4
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "69b6b2d8-7d28-4fa1-84af-3c41857c1d16",
+      "prerequisites": [],
+      "topics": ["either", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "5f92b1d3-b2cb-463e-b6da-347473ef4c30",
+      "prerequisites": [],
+      "topics": ["either", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "clock",
+      "uuid": "fa84dc6c-a212-431a-b4c1-752be5c99af7",
+      "prerequisites": [],
+      "topics": ["define_type", "instance_num"],
+      "difficulty": 4
+    },
+    {
+      "slug": "matrix",
+      "uuid": "46502471-d2f8-4f25-a220-55b0caff435c",
+      "prerequisites": [],
+      "topics": ["define_type"],
+      "difficulty": 4
+    },
+    {
+      "slug": "house",
+      "uuid": "2ab43e18-085b-4493-b51d-71274481d960",
+      "prerequisites": [],
+      "topics": ["refactoring"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "ff0a20ef-1828-42f1-8c10-4bf53b488993",
+      "prerequisites": [],
+      "topics": ["math", "number_theory"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "eb01573e-36bb-4093-bf16-4bccd8a36909",
+      "prerequisites": [],
+      "topics": ["math", "number_theory"],
+      "difficulty": 4
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "00b6c83b-e652-4f71-a094-b3034f77fd7b",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 4
+    },
+    {
+      "slug": "series",
+      "uuid": "4c111498-9248-4f4a-9950-98fdac736d3b",
+      "prerequisites": [],
+      "topics": ["lists", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "sieve",
+      "uuid": "1ed4a7af-76eb-4b42-89b2-dcb97e509443",
+      "prerequisites": [],
+      "topics": ["math", "number_theory"],
+      "difficulty": 4
+    },
+    {
+      "slug": "proverb",
+      "uuid": "17ba80b8-1ca6-426b-880a-15de1d413032",
+      "prerequisites": [],
+      "topics": ["lists", "recursion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "e714ed04-e633-4814-8885-323968f39046",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 5
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "4b6d04f4-8cfc-4d8a-ac6e-77f3889f27c3",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "be179655-b1a2-4e57-a3f1-4834c467ef41",
+      "prerequisites": [],
+      "topics": ["stack"],
+      "difficulty": 5
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "dde7cf64-7e3b-4e5c-8a65-5d639fa8a307",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 5
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "ddfc0435-5378-4865-bbcb-a07754014db4",
+      "prerequisites": [],
+      "topics": ["math", "maybe", "number_theory"],
+      "difficulty": 5
+    },
+    {
+      "slug": "word-count",
+      "uuid": "5d36ba0a-3c57-471a-8956-e324e0384183",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "91887e6e-e935-441a-9cd1-754a877dc2be",
+      "prerequisites": [],
+      "topics": ["define_type", "maybe"],
+      "difficulty": 5
+    },
+    {
+      "slug": "luhn",
+      "uuid": "a602f191-581d-48ea-9441-1d6e8a51e71c",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "7e1cd145-0bdb-4f52-89e3-b21f98068a1f",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 5
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "90ac04fb-42d3-4666-b26a-2279057f6ef2",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "0b6af91e-8e1f-4ca5-bf30-53b427638e2b",
+      "prerequisites": [],
+      "topics": ["refactoring"],
+      "difficulty": 5
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "cd5ce9ad-b627-46e3-b6d8-872baf476bf1",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "781325ec-c772-4b56-80b0-2c56c5953122",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 5
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "c875009a-c8a0-47d0-bef6-d6f278565fe5",
+      "prerequisites": [],
+      "topics": ["define_type", "library_reimplementation"],
+      "difficulty": 5
+    },
+    {
+      "slug": "parallel-letter-frequency",
+      "uuid": "a3442b20-e2a7-4fc6-8bff-0e61d25b2bf3",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "transpose",
+      "uuid": "f58e07ae-08e9-4e64-b1d7-16033e46509b",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 5
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "2429b6d1-2ce8-487e-b0f7-a4d11970e6bd",
+      "prerequisites": [],
+      "topics": ["io_monad", "mutable_state", "random"],
+      "difficulty": 6
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "3a0f1014-8829-4b7e-aab7-f23f2fad22a2",
+      "prerequisites": [],
+      "topics": ["lists", "math", "maybe"],
+      "difficulty": 6
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "aec901e4-482f-4f00-8a26-a0c09fdb1365",
+      "prerequisites": [],
+      "topics": ["define_type", "io_monad", "random"],
+      "difficulty": 6
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "03bb14fb-d677-47fb-b283-b79c75c93855",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "say",
+      "uuid": "76384e4a-3d3e-4369-9a0d-55c47f91f17e",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 6
+    },
+    {
+      "slug": "bank-account",
+      "uuid": "44f2cb4d-1965-4d11-9373-bc3b5a624a8c",
+      "prerequisites": [],
+      "topics": ["define_type", "io_monad", "maybe", "mutable_state"],
+      "difficulty": 6
+    },
+    {
+      "slug": "sublist",
+      "uuid": "f49d76f7-f826-4b6a-a514-47af7e84144a",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 6
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "5bf7612c-427e-484d-bc67-8553fac4f64d",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "34b8a4fe-6761-4675-a5a9-e8c92c93fd8f",
+      "prerequisites": [],
+      "topics": [
+        "define_type",
+        "io_monad",
+        "library_reimplementation",
+        "maybe",
+        "mutable_state"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "zebra-puzzle",
+      "uuid": "893da7e3-1e7f-48d0-a8c2-8d84b9ec064f",
+      "prerequisites": [],
+      "topics": ["algorithms", "logic"],
+      "difficulty": 7
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "821f2081-dfc2-40c6-8e12-2907daa04416",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 7
+    },
+    {
+      "slug": "wordy",
+      "uuid": "0869734e-0629-4db9-8e62-af246e5f91ff",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 7
+    },
+    {
+      "slug": "change",
+      "uuid": "5af27112-48f2-423c-9607-03911ccc8049",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 7
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "154c2191-7746-497c-bf4e-37a5a5ffbb0b",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 7
+    },
+    {
+      "slug": "bowling",
+      "uuid": "cf896e0f-7971-4a4e-a164-412dd9176573",
+      "prerequisites": [],
+      "topics": ["either"],
+      "difficulty": 7
+    },
+    {
+      "slug": "poker",
+      "uuid": "35bf659b-b139-4d09-bdae-326319160a27",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 7
+    },
+    {
+      "slug": "connect",
+      "uuid": "2c009c74-fbf2-49f7-b626-0d9da10c18ea",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 8
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "14f8190f-c711-4399-b176-6efc5e3e71d1",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 8
+    },
+    {
+      "slug": "sgf-parsing",
+      "uuid": "033adeae-d94a-4832-ae99-8dd98acd6044",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 9
+    },
+    {
+      "slug": "go-counting",
+      "uuid": "8f1854d7-b8cb-4dfa-9e6a-8811b0891798",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 9
+    },
+    {
+      "slug": "lens-person",
+      "uuid": "056d6e6c-4d07-4bc0-b0d0-fb76a9ec8672",
+      "prerequisites": [],
+      "topics": ["lens"],
+      "difficulty": 9
+    },
+    {
+      "slug": "zipper",
+      "uuid": "e585c482-2088-40bf-bc97-bc6fac6a7a72",
+      "prerequisites": [],
+      "topics": ["define_type", "maybe"],
+      "difficulty": 10
+    },
+    {
+      "slug": "forth",
+      "uuid": "04c86a05-4d34-4a20-9489-db744c205bb6",
+      "prerequisites": [],
+      "topics": ["define_type", "either", "stack"],
+      "difficulty": 10
+    },
+    {
+      "slug": "pov",
+      "uuid": "010582a2-4c44-44fb-ac6b-bf1546d303a3",
+      "prerequisites": [],
+      "topics": ["maybe"],
+      "difficulty": 10
+    },
+    {
+      "slug": "binary",
+      "uuid": "48ca1682-ca1b-4a2c-be55-624620f336a7",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "317ef3e7-67ce-4940-bc90-eed1c4a27c19",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "964c07aa-abca-49b8-8428-1b81ee39066d",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "octal",
+      "uuid": "2566f8ee-28cf-4429-9ced-42759c810d7c",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "trinary",
+      "uuid": "d5997b60-e54c-4caa-beae-8614f0da3fb3",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    }
+  ]
 }

--- a/languages/j/config.json
+++ b/languages/j/config.json
@@ -14,5 +14,56 @@
     "concept": [],
     "practice": []
   },
-  "concepts": []
+  "concepts": [],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "b59cd640-e925-4570-aa6e-3d903651e9f1",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": false
+    },
+    {
+      "slug": "hamming",
+      "uuid": "ab2c70c9-a1db-4be4-bd74-a08fe72ccba8",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "4cc22c3d-766e-4593-96fe-2e26e06682b8",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "266be147-836e-42c7-91d0-6c577037c2ff",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": false
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "b6570e32-ed50-4ff9-bc9d-0202aa39b344",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": false
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "e044a725-8509-4978-ad3b-ab0546663986",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": false
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "14555b65-4f96-4d4b-bbb0-fcd0b21a1a15",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": false
+    }
+  ]
 }

--- a/languages/java/config.json
+++ b/languages/java/config.json
@@ -200,5 +200,1057 @@
       "name": "Ternary Operators",
       "blurb": "TODO: add blurb for ternary-operators concept"
     }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "f77dc7e3-35a8-4300-a7c8-2c1765e9644d",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "74515d45-565b-4be2-96c4-77e58efa9257",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "2c8afeed-480e-41f3-ad58-590fa8f88029",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "7c8294ee-5924-4bf8-a72f-31d0e2d7d9a0",
+      "prerequisites": [],
+      "topics": ["booleans", "integers", "logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color",
+      "uuid": "e5e821ed-fc1f-4419-9c90-ad4a0b564bea",
+      "prerequisites": [],
+      "topics": ["arrays", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "resistor-color-duo",
+      "uuid": "0ae1989d-df46-414d-ad1f-4bd0f0f78421",
+      "prerequisites": [],
+      "topics": ["arrays", "strings", "enumerations"],
+      "difficulty": 2
+    },
+    {
+      "slug": "darts",
+      "uuid": "4d400a44-b190-4a0c-affb-99fad8ea18da",
+      "prerequisites": [],
+      "topics": ["games"],
+      "difficulty": 2
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "8e1dd48c-e05e-4a72-bf0f-5aed8dd123f5",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "8e983ed2-62f7-439a-a144-fb8fdbdf4d30",
+      "prerequisites": [],
+      "topics": ["loops", "maps", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "dnd-character",
+      "uuid": "09bb515c-0270-4d34-8d56-89ee04588494",
+      "prerequisites": [],
+      "topics": ["games", "integers", "randomness"],
+      "difficulty": 2
+    },
+    {
+      "slug": "grains",
+      "uuid": "5ee66f39-5e37-4907-a6d9-f55d38324c6c",
+      "prerequisites": [],
+      "topics": ["loops", "math"],
+      "difficulty": 2,
+      "deprecated": false
+    },
+    {
+      "slug": "pangram",
+      "uuid": "133b0f84-bdc7-4508-a0a1-5732a7db81ef",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "regular_expressions", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "hamming",
+      "uuid": "ce899ca6-9cc7-47ba-b76f-1bbcf2630b76",
+      "prerequisites": [],
+      "topics": ["integers", "loops", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "bf1641c8-dc0d-4d38-9cfe-b4c132ea3553",
+      "prerequisites": [],
+      "topics": ["dates", "integers", "time"],
+      "difficulty": 3
+    },
+    {
+      "slug": "space-age",
+      "uuid": "e5b524cd-3a1c-468a-8981-13e8eeccb29d",
+      "prerequisites": [],
+      "topics": ["conditionals", "floating_point_numbers"],
+      "difficulty": 3
+    },
+    {
+      "slug": "acronym",
+      "uuid": "c31bbc6d-bdcf-44f7-bf35-5f98752e38d0",
+      "prerequisites": [],
+      "topics": ["loops", "parsing", "searching", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "afae9f2d-8baf-4bd7-8d7c-d486337f7c97",
+      "prerequisites": [],
+      "topics": [
+        "games",
+        "loops",
+        "pattern_matching",
+        "strings",
+        "transforming"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "d916e4f8-fda1-41c0-ab24-79e8fc3f1272",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "b0da59c6-1b55-405c-b163-007ebf09f5e8",
+      "prerequisites": [],
+      "topics": ["integers", "loops", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "71c7c174-7e2c-43c2-bdd6-7515fcb12a91",
+      "prerequisites": [],
+      "topics": [
+        "bitwise_operations",
+        "conditionals",
+        "cryptography",
+        "enumerations",
+        "integers",
+        "loops",
+        "transforming"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "d0dcc898-ec38-4822-9e3c-1a1829c9b2d9",
+      "prerequisites": [],
+      "topics": [
+        "enumerations",
+        "exception_handling",
+        "filtering",
+        "integers",
+        "math"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "331073b3-bd1a-4868-b767-a64ce9fd9d97",
+      "prerequisites": [],
+      "topics": ["arrays", "conditionals", "loops", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "micro-blog",
+      "uuid": "8295ae71-5c0e-49d0-bbe9-9b43a85bf2dd",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "yacht",
+      "uuid": "0cb45688-9598-49aa-accc-ed48c5d6962d",
+      "prerequisites": [],
+      "topics": [
+        "enumerations",
+        "filtering",
+        "games",
+        "pattern_matching",
+        "sorting"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "proverb",
+      "uuid": "9906491b-a638-408d-86a4-4ad320a92658",
+      "prerequisites": [],
+      "topics": ["arrays", "loops", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "838bc1d7-b2de-482a-9bfc-c881b4ccb04c",
+      "prerequisites": [],
+      "topics": ["integers", "loops", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "2f244afc-3e7b-4f89-92af-e2b427f4ef35",
+      "prerequisites": [],
+      "topics": ["arrays", "conditionals", "integers", "loops", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "luhn",
+      "uuid": "5227a76c-8ecb-4e5f-b023-6af65a057c41",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "booleans",
+        "loops",
+        "strings",
+        "type_conversion"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "matrix",
+      "uuid": "c1d4e0b4-6a0f-4be9-8222-345966621f53",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "integers",
+        "loops",
+        "pattern_matching",
+        "strings",
+        "type_conversion"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "triangle",
+      "uuid": "ec268d8e-997b-4553-8c67-8bdfa1ecb888",
+      "prerequisites": [],
+      "topics": ["booleans", "classes", "exception_handling"],
+      "difficulty": 4
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "b7310b6e-435c-4d5f-b2bd-31e586d0f238",
+      "prerequisites": [],
+      "topics": ["integers", "loops", "math", "strings", "type_conversion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "sieve",
+      "uuid": "6791d01f-bae4-4b63-ae76-86529ac49e36",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "lists", "loops", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "581afdbb-dfb6-4dc5-9554-a025b5469a3c",
+      "prerequisites": [],
+      "topics": ["arrays", "conditionals", "loops", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "9eb41883-55ef-4681-b5ac-5c2259302772",
+      "prerequisites": [],
+      "topics": ["cryptography", "integers", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "0b92ffee-c092-4ab1-ad78-76c8cf80e1b5",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "enumerations",
+        "lists",
+        "logic",
+        "loops",
+        "pattern_recognition",
+        "strings"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "1500d39a-c9d9-4d3a-9e77-fdc1837fc6ad",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "exception_handling",
+        "integers",
+        "math",
+        "recursion"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "2c69db99-648d-4bd7-8012-1fbdeff6ca0a",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "exception_handling",
+        "integers",
+        "lists",
+        "loops",
+        "math"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "8dfc2f0d-1141-46e9-95e2-6f35ccf6f160",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "integers",
+        "lists",
+        "loops",
+        "matrices",
+        "sets"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "error-handling",
+      "uuid": "846ae792-7ca7-43e1-b523-bb1ec9fa08eb",
+      "prerequisites": [],
+      "topics": ["exception_handling", "optional_values"],
+      "difficulty": 4
+    },
+    {
+      "slug": "diamond",
+      "uuid": "ecbd997b-86f4-4e11-9ff0-706ac2899415",
+      "prerequisites": [],
+      "topics": ["arrays", "lists", "loops", "strings", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "isogram",
+      "uuid": "c3e89c7c-3a8a-4ddc-b653-9b0ff9e1d7d8",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "parsing", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "variable-length-quantity",
+      "uuid": "d8a2c7ba-2040-4cfe-ab15-f90b3b61dd89",
+      "prerequisites": [],
+      "topics": [
+        "bitwise_operations",
+        "conditionals",
+        "exception_handling",
+        "lists",
+        "loops",
+        "transforming"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "a732a838-8170-458a-a85e-d6b4c46f97a1",
+      "prerequisites": [],
+      "topics": ["arrays", "lists", "loops", "recursion"],
+      "difficulty": 5
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "38bc80ae-d842-4c04-a797-48edf322504d",
+      "prerequisites": [],
+      "topics": ["arrays", "lists", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "5f9139e7-9fbb-496a-a0d7-a946283033de",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "pattern_matching",
+        "regular_expressions",
+        "strings"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "2d80fdfc-5bd7-4b67-9fbe-8ab820d89051",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "exception_handling",
+        "integers",
+        "maps",
+        "parsing",
+        "searching",
+        "strings"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "word-count",
+      "uuid": "3603b770-87a5-4758-91f3-b4d1f9075bc1",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers", "loops", "maps", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "4499a3f9-73a7-48bf-8753-d5b6abf588c9",
+      "prerequisites": [],
+      "topics": ["integers", "pattern_matching", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "d7c2eed9-64c7-4c4a-b45d-c787d460337f",
+      "prerequisites": [],
+      "topics": [
+        "pattern_matching",
+        "randomness",
+        "regular_expressions",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "599c08ec-7338-46ed-99f8-a76f78f724e6",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "integers",
+        "lists",
+        "loops",
+        "math"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "allergies",
+      "uuid": "6a617ddb-04e3-451c-bb30-27ccd0be9125",
+      "prerequisites": [],
+      "topics": [
+        "booleans",
+        "conditionals",
+        "enumerations",
+        "integers",
+        "lists",
+        "loops"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "bob",
+      "uuid": "34cd328c-cd96-492b-abd4-2b8716cdcd9a",
+      "prerequisites": [],
+      "topics": ["booleans", "conditionals", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "d2a76905-1c8c-4b03-b4f7-4fbff19329f3",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "arrays",
+        "exception_handling",
+        "integers",
+        "math",
+        "matrices"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "85aa50ac-0141-49eb-bc6f-62f3f7a97647",
+      "prerequisites": [],
+      "topics": ["stacks", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "series",
+      "uuid": "af80d7f4-c7d0-4d0b-9c30-09da120f6bb9",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "lists",
+        "loops",
+        "strings",
+        "type_conversion"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "d36ce010-210f-4e9a-9d6c-cb933e0a59af",
+      "prerequisites": [],
+      "topics": ["cryptography", "security", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "grep",
+      "uuid": "9c15ddab-7b52-43d4-b38c-0bf635b363c3",
+      "prerequisites": [],
+      "topics": [
+        "files",
+        "filtering",
+        "pattern_matching",
+        "searching",
+        "strings"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "knapsack",
+      "uuid": "ac179b77-98a5-4daf-9773-3d68b6cd8548",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "conditionals"],
+      "difficulty": 5
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "0639a1f8-5af4-4877-95c1-5db8e97c30bf",
+      "prerequisites": [],
+      "topics": ["conditionals", "logic"],
+      "difficulty": 6
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "163fcc6b-c054-4232-a88b-0aded846a6eb",
+      "prerequisites": [],
+      "topics": ["arrays", "integers", "loops", "matrices"],
+      "difficulty": 6
+    },
+    {
+      "slug": "rest-api",
+      "uuid": "809c0e3d-3494-4a85-843d-2bafa8752ce8",
+      "prerequisites": [],
+      "topics": ["strings", "parsing"],
+      "difficulty": 6
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "3e728cd4-5e5f-4c69-8a53-bc36d020fcdb",
+      "prerequisites": [],
+      "topics": ["integers", "logic", "loops", "maps", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "transpose",
+      "uuid": "57b76837-4610-466f-9373-d5c2697625f1",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "lists",
+        "loops",
+        "matrices",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "house",
+      "uuid": "6b51aca3-3451-4a64-ad7b-00b151d7548a",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "loops",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "dd3e6fd6-5359-4978-acd7-c39374cead4d",
+      "prerequisites": [],
+      "topics": ["arrays", "lists", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "56943095-de76-40bf-b42b-fa3e70f8df5e",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "strings",
+        "text_formatting",
+        "variables"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "5404109e-3ed9-4691-8eaf-af8b36024a44",
+      "prerequisites": [],
+      "topics": ["arrays", "classes", "conditionals", "games", "matrices"],
+      "difficulty": 6
+    },
+    {
+      "slug": "etl",
+      "uuid": "76d28d97-75d3-47eb-bb77-3d347b76f1b6",
+      "prerequisites": [],
+      "topics": ["lists", "maps", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "b4af5da1-601f-4b0f-bfb8-4a381851090c",
+      "prerequisites": [],
+      "topics": ["conditionals", "lists", "maps", "sorting", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "993bde9d-7774-4e7a-a381-9eee75f28ecb",
+      "prerequisites": [],
+      "topics": ["classes", "enumerations", "logic", "loops"],
+      "difficulty": 6
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "50136dc3-caf7-4fa1-b7bd-0cba1bea9176",
+      "prerequisites": [],
+      "topics": ["arrays", "recursion", "searching"],
+      "difficulty": 6
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "416a1489-12af-4593-8540-0f55285c96b4",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "games",
+        "integers",
+        "lists",
+        "matrices",
+        "strings"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "wordy",
+      "uuid": "3310a3cd-c0cb-45fa-8c51-600178be904a",
+      "prerequisites": [],
+      "topics": [
+        "exception_handling",
+        "integers",
+        "logic",
+        "parsing",
+        "pattern_matching",
+        "regular_expressions",
+        "strings",
+        "transforming"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "f7c2e4b5-1995-4dfe-b827-c9aff8ac5332",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "exception_handling",
+        "integers",
+        "loops",
+        "math"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "bank-account",
+      "uuid": "a242efc5-159d-492b-861d-12a1459fb334",
+      "prerequisites": [],
+      "topics": ["concurrency", "exception_handling", "integers"],
+      "difficulty": 6
+    },
+    {
+      "slug": "bowling",
+      "uuid": "4b3f7771-c642-4278-a3d9-2fb958f26361",
+      "prerequisites": [],
+      "topics": ["conditionals", "exception_handling", "games", "integers"],
+      "difficulty": 6
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "7ba5084d-3b75-4406-a0d7-87c26387f9c0",
+      "prerequisites": [],
+      "topics": ["algorithms", "generics", "lists"],
+      "difficulty": 6
+    },
+    {
+      "slug": "tournament",
+      "uuid": "486d342e-c834-40fc-b691-a4dab3f790da",
+      "prerequisites": [],
+      "topics": ["loops", "maps", "parsing", "sorting", "text_formatting"],
+      "difficulty": 6
+    },
+    {
+      "slug": "parallel-letter-frequency",
+      "uuid": "38a405e8-619d-400f-b53c-2f06461fdf9d",
+      "prerequisites": [],
+      "topics": ["concurrency", "maps", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "6e4ad4ed-cc02-4132-973d-b9163ba0ea3d",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "affine-cipher",
+      "uuid": "e6e3faaf-54c2-4782-93af-bb8d95403f2a",
+      "prerequisites": [],
+      "topics": ["cryptography", "security", "strings", "text_formatting"],
+      "difficulty": 6
+    },
+    {
+      "slug": "two-bucket",
+      "uuid": "210bf628-b385-443b-8329-3483cc6e8d7e",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "loops"],
+      "difficulty": 7
+    },
+    {
+      "slug": "zebra-puzzle",
+      "uuid": "b1e2bd39-3f4b-44c1-b7e2-258d4ee241f8",
+      "prerequisites": [],
+      "topics": ["logic"],
+      "difficulty": 7
+    },
+    {
+      "slug": "anagram",
+      "uuid": "fb10dc2f-0ba1-44b6-8365-5e48e86d1283",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "equality",
+        "lists",
+        "loops",
+        "strings"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "sublist",
+      "uuid": "d2aedbd7-092a-43d0-8a5e-ae3ebd5b9c7f",
+      "prerequisites": [],
+      "topics": ["enumerations", "generics", "lists", "loops", "searching"],
+      "difficulty": 7
+    },
+    {
+      "slug": "word-search",
+      "uuid": "b53bde52-cb5f-4d43-86ec-18aa509d62f9",
+      "prerequisites": [],
+      "topics": [
+        "games",
+        "logic",
+        "matrices",
+        "pattern_matching",
+        "searching",
+        "strings"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "e3e5ffe5-cfc1-467e-a28a-da0302130144",
+      "prerequisites": [],
+      "topics": ["algorithms", "exception_handling", "generics", "lists"],
+      "difficulty": 7
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "0a2d18aa-7b5e-4401-a952-b93d2060694f",
+      "prerequisites": [],
+      "topics": ["generics", "graphs", "searching", "sorting", "trees"],
+      "difficulty": 7
+    },
+    {
+      "slug": "meetup",
+      "uuid": "602511d5-7e89-4def-b072-4dd311816810",
+      "prerequisites": [],
+      "topics": ["conditionals", "dates", "enumerations", "loops"],
+      "difficulty": 7
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "162bebdc-9bf2-43c0-8460-a91f5fc16147",
+      "prerequisites": [],
+      "topics": [
+        "cryptography",
+        "lists",
+        "security",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "markdown",
+      "uuid": "cc18f2e5-4e36-47d6-aa60-8ca5ff54019a",
+      "prerequisites": [],
+      "topics": ["conditionals", "pattern_matching", "refactoring", "strings"],
+      "difficulty": 7
+    },
+    {
+      "slug": "poker",
+      "uuid": "57eeac00-741c-4843-907a-51f0ac5ea4cb",
+      "prerequisites": [],
+      "topics": ["games", "parsing", "sorting"],
+      "difficulty": 7
+    },
+    {
+      "slug": "clock",
+      "uuid": "97c8fcd4-85b6-41cb-9de2-b4e1b4951222",
+      "prerequisites": [],
+      "topics": [
+        "equality",
+        "integers",
+        "logic",
+        "object_oriented_programming",
+        "strings",
+        "time"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "tree-building",
+      "uuid": "aeaed0e4-0973-4035-8bc5-07480849048f",
+      "prerequisites": [],
+      "topics": ["maps", "records", "refactoring", "sorting", "trees"],
+      "difficulty": 7
+    },
+    {
+      "slug": "zipper",
+      "uuid": "25d2c7a5-1ec8-464a-b3de-ad1b27464ef1",
+      "prerequisites": [],
+      "topics": ["integers", "graphs", "trees"],
+      "difficulty": 7
+    },
+    {
+      "slug": "go-counting",
+      "uuid": "2e760ae2-fadd-4d31-9639-c4554e2826e9",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "games", "loops"],
+      "difficulty": 7
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "8e3cb20e-623b-4b4d-8a91-d1a51c0911b5",
+      "prerequisites": [],
+      "topics": ["algorithms", "exception_handling", "games", "lists"],
+      "difficulty": 7
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "5cbc6a67-3a53-4aad-ae68-ff469525437f",
+      "prerequisites": [],
+      "topics": ["exception_handling", "lists", "loops", "parsing", "strings"],
+      "difficulty": 8
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "626dc25a-062c-4053-a8c1-788e4dc44ca0",
+      "prerequisites": [],
+      "topics": ["classes", "exception_handling", "queues"],
+      "difficulty": 8
+    },
+    {
+      "slug": "rectangles",
+      "uuid": "64cda115-919a-4eef-9a45-9ec5d1af98cc",
+      "prerequisites": [],
+      "topics": ["arrays", "logic", "pattern_recognition", "strings"],
+      "difficulty": 8
+    },
+    {
+      "slug": "book-store",
+      "uuid": "e5f05d00-fe5b-4d78-b2fa-934c1c9afb32",
+      "prerequisites": [],
+      "topics": ["algorithms", "floating_point_numbers", "integers", "lists"],
+      "difficulty": 8
+    },
+    {
+      "slug": "diffie-hellman",
+      "uuid": "9b191b2f-b1a4-4c0e-b911-36666bff614d",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "math", "transforming"],
+      "difficulty": 8
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "f654831f-c34b-44f5-9dd5-054efbb486f2",
+      "prerequisites": [],
+      "topics": [
+        "cryptography",
+        "exception_handling",
+        "randomness",
+        "security",
+        "strings"
+      ],
+      "difficulty": 8
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "52d11278-0d65-4b5b-b387-1374fced3243",
+      "prerequisites": [],
+      "topics": ["floating_point_numbers", "math"],
+      "difficulty": 8
+    },
+    {
+      "slug": "rational-numbers",
+      "uuid": "50ed54ce-3047-4590-9fda-0a7e9aeeba30",
+      "prerequisites": [],
+      "topics": ["algorithms", "floating_point_numbers", "math"],
+      "difficulty": 8
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "a9836565-5c39-4285-b83a-53408be36ccc",
+      "prerequisites": [],
+      "topics": [
+        "filtering",
+        "functional_programming",
+        "generics",
+        "lists",
+        "loops"
+      ],
+      "difficulty": 8
+    },
+    {
+      "slug": "change",
+      "uuid": "bac1f4bc-eea9-43c1-8e95-097347f5925e",
+      "prerequisites": [],
+      "topics": ["algorithms", "exception_handling", "integers", "lists"],
+      "difficulty": 8
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "873c05de-b5f5-4c5b-97f0-d1ede8a82832",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers", "lists", "loops", "maps", "math"],
+      "difficulty": 8
+    },
+    {
+      "slug": "hangman",
+      "uuid": "ab3f8bf4-cfae-4f7a-b134-bb0fa4fafa63",
+      "prerequisites": [],
+      "topics": ["strings", "reactive_programming", "functional_programming"],
+      "difficulty": 8,
+      "deprecated": false
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "88505f95-89e5-4a08-8ed2-208eb818cdf1",
+      "prerequisites": [],
+      "topics": ["integers", "lists", "logic", "math"],
+      "difficulty": 9
+    },
+    {
+      "slug": "forth",
+      "uuid": "f0c0316d-3fb5-455e-952a-91161e7fb298",
+      "prerequisites": [],
+      "topics": [
+        "exception_handling",
+        "lists",
+        "logic",
+        "parsing",
+        "stacks",
+        "strings"
+      ],
+      "difficulty": 9
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "377fe38b-08ad-4f3a-8118-a43c10f7b9b2",
+      "prerequisites": [],
+      "topics": ["equality", "generics", "sets"],
+      "difficulty": 10
+    },
+    {
+      "slug": "satellite",
+      "uuid": "a5f8aef3-9661-49c7-9eb3-786ef9fe0e85",
+      "prerequisites": [],
+      "topics": ["trees", "graphs"],
+      "difficulty": 10
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "e58c29d2-80a7-40ef-bed0-4a184ae35f34",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "binary",
+      "uuid": "9ea6e0fa-b91d-4d17-ac8f-6d2dc30fdd44",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "6fe53a08-c123-465d-864a-ef18217203c4",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "octal",
+      "uuid": "14a29e82-f9b1-4662-b678-06992e306c01",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "strain",
+      "uuid": "2d195cd9-1814-490a-8dd6-a2c676f1d4cd",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "trinary",
+      "uuid": "ee3a8abe-6b19-4b47-9cf6-4d39ae915fb7",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    }
   ]
 }

--- a/languages/javascript/config.json
+++ b/languages/javascript/config.json
@@ -183,5 +183,1095 @@
       "name": "Variable Parameters",
       "blurb": "TODO: add blurb for variable-parameters concept"
     }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "9ce0f408-6d7b-4466-a390-75aeaf9492f2",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "optional_values",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "7f49e997-4435-4f34-a020-bddc92c838ed",
+      "prerequisites": [],
+      "topics": ["optional_values", "strings", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color",
+      "uuid": "53be6837-c224-45f1-bff3-d7f74d6285ce",
+      "prerequisites": [],
+      "topics": ["arrays", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color-duo",
+      "uuid": "de800041-3dcc-41b9-b101-7314ff685c93",
+      "prerequisites": [],
+      "topics": ["strings", "arrays"],
+      "difficulty": 2
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "fd7b62d4-266b-4e84-a526-bf3d47901216",
+      "prerequisites": [],
+      "topics": ["time"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "342974d6-9083-4754-a6c5-ed1e19e40ec5",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "space-age",
+      "uuid": "d9d757ed-ebe6-4d4a-aa73-f6834221cd54",
+      "prerequisites": [],
+      "topics": ["floating_point_numbers"],
+      "difficulty": 2
+    },
+    {
+      "slug": "pangram",
+      "uuid": "da5b2b34-a1a7-4970-81f9-4665d875398b",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "loops",
+        "lists",
+        "maps",
+        "searching",
+        "strings"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "matrix",
+      "uuid": "dd0b5e67-81f6-437e-8334-2ec0dfeb862a",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "loops",
+        "matrices",
+        "text_formatting"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "bob",
+      "uuid": "a5bf36f0-5d3c-41d4-8d54-e37e484e59cd",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "pattern_recognition",
+        "polymorphism",
+        "regular_expressions",
+        "strings"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "99493160-4673-402f-acda-62db5378148d",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "math", "strings", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "ec60a578-8889-46a1-b7b8-306dbd8551d5",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "arrays",
+        "conditionals",
+        "data_structures",
+        "loops",
+        "lists",
+        "optional_values"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "64637322-33bc-401f-8cec-1f9810a41f75",
+      "prerequisites": [],
+      "topics": ["arrays", "maps", "sorting"],
+      "difficulty": 5
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "7d9db056-5398-41b6-af3b-9707f5eb0dbc",
+      "prerequisites": [],
+      "topics": ["data_structures", "loops", "lists", "recursion"],
+      "difficulty": 6
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "03f4dfea-e6db-4754-b2c8-ca06c8b81ef1",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "exception_handling",
+        "randomness",
+        "regular_expressions",
+        "sets"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "62d60b42-93bc-4de9-90d1-1ca18a847812",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "loops",
+        "randomness",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "wordy",
+      "uuid": "9131bdb8-2e0f-4526-b113-8a77712e7216",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "parsing",
+        "pattern_recognition",
+        "regular_expressions",
+        "strings"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "74bbc9e3-edc5-41e0-84d7-5b2d98dd8370",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "arrays",
+        "bitwise_operations",
+        "conditionals",
+        "loops",
+        "games"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "leap",
+      "uuid": "7c8294ee-5924-4bf8-a72f-31d0e2d7d9a0",
+      "prerequisites": [],
+      "topics": ["booleans", "integers", "logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "e84c97eb-dbec-487c-b99f-ae9924e16293",
+      "prerequisites": [],
+      "topics": ["loops", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "b8dacb3a-51d0-4da7-a6d2-aa29867e2b8c",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "integers",
+        "math",
+        "recursion"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "triangle",
+      "uuid": "ed3ca73a-a0f0-46b8-8013-8b6d20758c8f",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "exception_handling", "integers"],
+      "difficulty": 3
+    },
+    {
+      "slug": "clock",
+      "uuid": "4e0e2c30-be33-49b6-b196-213888a93a0c",
+      "prerequisites": [],
+      "topics": ["dates", "globalization", "time"],
+      "difficulty": 5
+    },
+    {
+      "slug": "meetup",
+      "uuid": "98617798-b49d-4d43-9f65-7131ee73d626",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "dates",
+        "equality",
+        "exception_handling",
+        "time"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "etl",
+      "uuid": "db16804b-0f63-445d-8beb-99e0f7218d66",
+      "prerequisites": [],
+      "topics": ["loops", "integers", "maps", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "hamming",
+      "uuid": "d773c4ef-c09e-40e4-a7fe-01456cb4a12a",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "equality", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "f77ac2d1-cf3a-497d-bf04-b484a5a9cb37",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers", "strings", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "be6f3ab3-1593-4c2d-8a35-5f39c1d5c91f",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "loops",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "11771d47-1109-4579-a62b-e0b8e9583485",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "maps", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "allergies",
+      "uuid": "9d33d21c-e695-427f-9f58-dd9498d61318",
+      "prerequisites": [],
+      "topics": ["arrays", "bitwise_operations", "conditionals", "loops"],
+      "difficulty": 6
+    },
+    {
+      "slug": "word-count",
+      "uuid": "0073ff9a-cd6a-43cf-b8bf-4d5d8117b81b",
+      "prerequisites": [],
+      "topics": ["loops", "lists", "regular_expressions", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "7dfa878c-83a6-48ef-9170-b6633d51d601",
+      "prerequisites": [],
+      "topics": ["algorithms", "loops", "integers", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "c6691fd2-e10d-47df-acbf-3adeac5a2f89",
+      "prerequisites": [],
+      "topics": ["arrays", "conditionals", "loops", "integers", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "ea9a9a3e-ae6a-470d-8bb4-2afead507f24",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "luhn",
+      "uuid": "28872cc9-f1ef-487f-9a79-6bf7983148bf",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "integers", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "f43cdddf-eea8-4c4a-8359-c69e20ff9661",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "loops", "integers", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "grains",
+      "uuid": "d003975a-9045-4f03-9ad9-c15db584dc13",
+      "prerequisites": [],
+      "topics": ["loops", "integers"],
+      "difficulty": 5
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "394755a3-c743-4b85-b9b8-387907f4e32d",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "loops", "integers", "math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "f6799d10-0210-4c73-ac08-d5cac1a00ff3",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "integers",
+        "math"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "anagram",
+      "uuid": "309fa4f1-e03a-4ab2-b371-cdf742501cf7",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "acronym",
+      "uuid": "440d78d1-9dea-466f-9bd4-935eed067409",
+      "prerequisites": [],
+      "topics": ["loops", "regular_expressions", "strings", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "high-scores",
+      "uuid": "19b41c4a-1466-5c19-b547-40284189fd18",
+      "prerequisites": [],
+      "topics": ["arrays"],
+      "difficulty": 2
+    },
+    {
+      "slug": "isogram",
+      "uuid": "3df577af-2854-40ee-b211-9b608dbbad58",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "4d456646-3a9b-4393-9558-6b30e5c1039c",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "parsing",
+        "strings"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "82775adb-eabe-4d44-91f5-4080b8834a4a",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "series",
+      "uuid": "5178ae53-5364-46c9-bee3-70e6e8a8c2e3",
+      "prerequisites": [],
+      "topics": ["loops", "exception_handling", "strings", "text_formatting"],
+      "difficulty": 3
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "1f84305d-ea76-4fe2-9858-3b53576d683d",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "integers",
+        "math",
+        "regular_expressions",
+        "strings"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "transpose",
+      "uuid": "9c140fb7-cc8b-411b-b613-a0e0081a9c3f",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "lists",
+        "loops",
+        "matrices",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "rectangles",
+      "uuid": "f8c6786e-bf93-4f35-b649-03f4e39bb094",
+      "prerequisites": [],
+      "topics": ["arrays", "conditionals", "loops", "matrices", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "c1abafcc-0d44-4fb5-afae-bff3ce2e1b39",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "data_structures",
+        "loops",
+        "matrices"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "24c197ee-d492-4083-8615-629cb4b836b2",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "equality",
+        "exception_handling",
+        "integers",
+        "parsing",
+        "text_formatting"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "a01aa48c-65c4-4b1f-b3d9-3ec7da2ef754",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "equality",
+        "exception_handling",
+        "integers",
+        "matrices",
+        "optional_values",
+        "parsing"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "forth",
+      "uuid": "e4035939-4375-4720-87ae-e613f925f013",
+      "prerequisites": [],
+      "topics": ["domain_specific_languages", "parsing", "stacks"],
+      "difficulty": 8
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "62672dc7-e827-4c2e-a282-d6df45b60bbd",
+      "prerequisites": [],
+      "topics": ["algorithms", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "house",
+      "uuid": "a8b7187d-12eb-4efc-b966-87823654ccda",
+      "prerequisites": [],
+      "topics": ["arrays", "conditionals", "loops", "recursion", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "b902c746-60d1-4645-a5bc-dafadec0ef32",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "pattern_recognition",
+        "regular_expressions"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "16e25a38-7ce3-4ccd-b2f0-1550b837fe9b",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "games",
+        "regular_expressions",
+        "strings",
+        "transforming"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "proverb",
+      "uuid": "5626f5b6-207b-458b-92b6-eff2cadb240a",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "loops",
+        "optional_values",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "64de1776-d5c6-43fe-9abf-7e3aa08ae342",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "pattern_recognition",
+        "polymorphism",
+        "regular_expressions",
+        "strings"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "6573f168-d8fc-4ccf-a864-1a61f432fae1",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "resistor-color-trio",
+      "uuid": "7170d6a3-a32f-44d7-b82e-524485c58aaf",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops"],
+      "difficulty": 5
+    },
+    {
+      "slug": "say",
+      "uuid": "12989bb3-c593-4f68-bea4-e2c5b76bc3c0",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "integers",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "diamond",
+      "uuid": "6a1eee0e-f8d4-446d-9c52-f31c3700af1b",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "games",
+        "parsing",
+        "text_formatting"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "rational-numbers",
+      "uuid": "d8da6cdd-3804-40b0-9821-0dd5765876ff",
+      "prerequisites": [],
+      "topics": ["algorithms", "floating_point_numbers", "math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "sublist",
+      "uuid": "4be85b5e-6b13-11e7-907b-a6006ad3dba0",
+      "prerequisites": [],
+      "topics": ["arrays", "lists"],
+      "difficulty": 4
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "6c4b4e25-c115-4789-9058-d28ab6ca0d26",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "loops", "recursion"],
+      "difficulty": 6
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "75199d72-4cac-49ce-bffb-23fb659c57ae",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "data_structures",
+        "loops",
+        "equality",
+        "lists",
+        "recursion",
+        "sets"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "7c569e5d-bb00-44b8-8adc-34253790c19b",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "conditionals", "loops", "recursion"],
+      "difficulty": 7
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "bf0b1f95-3425-4345-8a12-3a80d49b49c9",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "data_structures",
+        "loops",
+        "exception_handling",
+        "lists"
+      ],
+      "difficulty": 8
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "a1591026-2f02-45f9-b189-24b2359eb43f",
+      "prerequisites": [],
+      "topics": ["arrays", "data_structures", "lists"],
+      "difficulty": 8
+    },
+    {
+      "slug": "word-search",
+      "uuid": "0125f5a7-8883-4553-a6c1-45f19544af5e",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "loops",
+        "equality",
+        "optional_values",
+        "parsing",
+        "text_formatting"
+      ],
+      "difficulty": 8
+    },
+    {
+      "slug": "variable-length-quantity",
+      "uuid": "6be39d1f-f68d-4a52-bd72-85a38ffd509e",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "two-bucket",
+      "uuid": "0bc6b478-40a8-47ab-889b-c403b922f7e5",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "arrays",
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "games",
+        "parsing"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "a602bd33-69fc-4b67-a3d3-95198853095e",
+      "prerequisites": [],
+      "topics": ["algorithms", "games"],
+      "difficulty": 7
+    },
+    {
+      "slug": "scale-generator",
+      "uuid": "b9c586e8-998b-4f5d-ab98-a08be29a9f19",
+      "prerequisites": [],
+      "topics": ["loops", "pattern_recognition", "strings", "arrays"],
+      "difficulty": 3
+    },
+    {
+      "slug": "connect",
+      "uuid": "2fa2c262-77ae-409b-bfd8-1d643faae772",
+      "prerequisites": [],
+      "topics": ["arrays", "conditionals", "loops", "games", "maps", "parsing"],
+      "difficulty": 7
+    },
+    {
+      "slug": "bowling",
+      "uuid": "dbf26ef1-62ff-4cb1-8ac7-09b022df3b2f",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "games",
+        "parsing",
+        "text_formatting"
+      ],
+      "difficulty": 8
+    },
+    {
+      "slug": "strain",
+      "uuid": "8407f9d5-7a7e-40c8-aace-a6a8294ae5e9",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "arrays",
+        "callbacks",
+        "conditionals",
+        "loops",
+        "filtering",
+        "lists"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "6ebe247c-3d11-48b7-8e6f-39f98359d233",
+      "prerequisites": [],
+      "topics": ["algorithms", "callbacks", "loops", "lists"],
+      "difficulty": 5
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "1a6c4a3b-d5db-4a5a-b123-66cf085defe6",
+      "prerequisites": [],
+      "topics": ["arrays", "recursion"],
+      "difficulty": 5
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "7ce09989-f202-4c3c-8b7e-72cef18808c3",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "integers",
+        "math"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "sieve",
+      "uuid": "127287d1-ba44-4400-884a-6fe5f72e210f",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "integers", "math", "recursion"],
+      "difficulty": 5
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "34625b04-844e-41e3-b02b-3443b6b0b7cb",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings", "text_formatting", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "diffie-hellman",
+      "uuid": "127eccbd-3009-4a8f-95c1-7d8aeb608550",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "arrays",
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "math"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "a70e6027-eebe-43a1-84a6-763faa736169",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "arrays",
+        "conditionals",
+        "loops",
+        "regular_expressions",
+        "text_formatting"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "4dc30879-a589-4dd3-b7b6-22261f9d1520",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "arrays",
+        "conditionals",
+        "loops",
+        "regular_expressions",
+        "sorting",
+        "text_formatting",
+        "transforming"
+      ],
+      "difficulty": 9
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "5174bd15-eee2-4b53-b3ee-ca3a8c958a31",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "games",
+        "parsing",
+        "strings"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "13444eff-005a-405e-9737-7b64d99c1a61",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "loops",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "f7452f71-795b-40b6-847c-67ef4bb9db45",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "integers", "lists", "math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "change",
+      "uuid": "cfa5741c-9fe9-4cb5-a322-d77ba8145f4b",
+      "prerequisites": [],
+      "topics": ["algorithms", "performance", "searching"],
+      "difficulty": 8
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "775ae0ec-8db7-4568-a188-963931cf5ee1",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "b28c34f4-f7af-47db-95c6-f920e020bbba",
+      "prerequisites": [],
+      "topics": ["algorithms", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "6ac4ad5f-a64a-4646-91c5-169d53f289f9",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "exception_handling",
+        "parsing",
+        "pattern_recognition",
+        "regular_expressions",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "darts",
+      "uuid": "6c64649b-ea81-4118-9e74-a0a55018ffbc",
+      "prerequisites": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "2fc4f834-a51c-42b8-a4d9-5263229e7648",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "pattern_recognition",
+        "transforming"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "d2d3cd13-b06c-4c24-9964-fb1554f70dd4",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "integers",
+        "math",
+        "parsing"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "8bafe6c4-9154-4037-9070-7f57f91d495a",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "games"],
+      "difficulty": 7
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "007a4cd4-7324-4512-8905-ead0c78146f7",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "equality",
+        "exception_handling",
+        "optional_values",
+        "parsing",
+        "text_formatting"
+      ],
+      "difficulty": 8
+    },
+    {
+      "slug": "react",
+      "uuid": "303c6969-9446-41aa-871a-11223a43e810",
+      "prerequisites": [],
+      "topics": ["algorithms", "events", "reactive_programming"],
+      "difficulty": 8
+    },
+    {
+      "slug": "zipper",
+      "uuid": "fd1575f3-3087-4cfa-8a26-168fba6d0606",
+      "prerequisites": [],
+      "topics": ["recursion", "searching", "trees"],
+      "difficulty": 8
+    },
+    {
+      "slug": "dnd-character",
+      "uuid": "b373e13c-f179-4b36-b6e8-2a0f41540344",
+      "prerequisites": [],
+      "topics": ["classes", "randomness"],
+      "difficulty": 2
+    },
+    {
+      "slug": "trinary",
+      "uuid": "1acf1d2d-a25e-4576-94de-0470abc872d9",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "integers",
+        "math",
+        "regular_expressions",
+        "strings"
+      ],
+      "difficulty": 4,
+      "deprecated": true
+    },
+    {
+      "slug": "octal",
+      "uuid": "dec66f89-39d0-4857-9679-a035cf4259d7",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "integers",
+        "math",
+        "regular_expressions",
+        "strings"
+      ],
+      "difficulty": 4,
+      "deprecated": true
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "8ed2c9fe-a13f-4313-abf9-125f351c85c9",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "integers",
+        "math",
+        "regular_expressions",
+        "strings"
+      ],
+      "difficulty": 4,
+      "deprecated": true
+    },
+    {
+      "slug": "point-mutations",
+      "uuid": "6d43709b-3809-4a6a-ab41-2a5ab841b5fb",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "binary",
+      "uuid": "0ba4d3b9-2519-49ac-bd93-f960aca6c11f",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "exception_handling",
+        "integers",
+        "math",
+        "regular_expressions",
+        "strings"
+      ],
+      "difficulty": 4,
+      "deprecated": true
+    },
+    {
+      "slug": "grep",
+      "uuid": "78bcbae1-a0f2-460c-ba89-e51844fe9397",
+      "prerequisites": [],
+      "topics": ["files", "searching", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "yacht",
+      "uuid": "77d0ab59-3824-4a79-9db3-e0bb35c6fc63",
+      "prerequisites": [],
+      "topics": ["arrays", "conditionals", "filtering", "games"],
+      "difficulty": 4
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "3d155146-f3a9-43c6-a662-2a0679949a12",
+      "prerequisites": [],
+      "topics": ["graph_theory"],
+      "difficulty": 6
+    }
   ]
 }

--- a/languages/julia/config.json
+++ b/languages/julia/config.json
@@ -155,5 +155,470 @@
             "name": "Unicode Identifiers",
             "blurb": "TODO: add blurb for unicode-identifiers concept"
         }
+    ],
+    "practice": [
+        {
+            "slug": "hello-world",
+            "uuid": "a668410d-41aa-4710-a68f-54521da6486d",
+            "prerequisites": [],
+            "topics": ["strings"],
+            "difficulty": 1
+        },
+        {
+            "slug": "leap",
+            "uuid": "8740c914-f008-4b6b-8e7d-7470e78e6a8e",
+            "prerequisites": [],
+            "topics": ["math", "conditionals", "integers"],
+            "difficulty": 1
+        },
+        {
+            "slug": "nucleotide-count",
+            "uuid": "54c24809-c6e7-419b-8ec3-6d8d128ca546",
+            "prerequisites": [],
+            "topics": ["chars", "loops", "strings"],
+            "difficulty": 1
+        },
+        {
+            "slug": "hamming",
+            "uuid": "878e9897-c4b6-40ff-9034-8f2aedf07a91",
+            "prerequisites": [],
+            "topics": ["exception_handling", "generators", "strings"],
+            "difficulty": 1
+        },
+        {
+            "slug": "rna-transcription",
+            "uuid": "0d5f865c-b704-445c-ac31-df34168f54aa",
+            "prerequisites": [],
+            "topics": [
+                "exception_handling",
+                "filtering",
+                "pattern_matching",
+                "strings"
+            ],
+            "difficulty": 1
+        },
+        {
+            "slug": "darts",
+            "uuid": "25e1ab6b-782b-4892-8220-f332ebe44b23",
+            "prerequisites": [],
+            "topics": ["conditionals", "math"],
+            "difficulty": 1
+        },
+        {
+            "slug": "bob",
+            "uuid": "9474a13b-09c1-4e4d-90e3-1a14fde5eb62",
+            "prerequisites": [],
+            "topics": ["conditionals", "strings", "unicode"],
+            "difficulty": 2
+        },
+        {
+            "slug": "run-length-encoding",
+            "uuid": "9814f832-8bd1-4a2b-9a1e-fc0e3e8541b5",
+            "prerequisites": [],
+            "topics": ["algorithms", "strings", "text_formatting"],
+            "difficulty": 1
+        },
+        {
+            "slug": "pangram",
+            "uuid": "4bc9a4f8-fc4d-4e6b-a93c-07069bbc5bc9",
+            "prerequisites": [],
+            "topics": ["arrays", "filtering", "strings"],
+            "difficulty": 1
+        },
+        {
+            "slug": "anagram",
+            "uuid": "d2cb1621-2a2e-4791-a6b6-fdbca74a5583",
+            "prerequisites": [],
+            "topics": ["arrays", "loops", "filtering", "sorting", "strings"],
+            "difficulty": 2
+        },
+        {
+            "slug": "binary-search",
+            "uuid": "325385bb-2a70-4c7a-8b4e-e6297fc69872",
+            "prerequisites": [],
+            "topics": ["arrays", "searching"],
+            "difficulty": 3
+        },
+        {
+            "slug": "rotational-cipher",
+            "uuid": "79ea05f1-3f27-4b92-bc47-0cebcd8d5a6f",
+            "prerequisites": [],
+            "topics": ["metaprogramming", "string_literals", "strings"],
+            "difficulty": 2
+        },
+        {
+            "slug": "atbash-cipher",
+            "uuid": "a4638670-941d-4213-8407-d9ebba70bd42",
+            "prerequisites": [],
+            "topics": ["conditionals", "loops", "strings"],
+            "difficulty": 1
+        },
+        {
+            "slug": "difference-of-squares",
+            "uuid": "16550822-4751-4bb3-9e15-80361006e2d6",
+            "prerequisites": [],
+            "topics": ["generators", "math"],
+            "difficulty": 1
+        },
+        {
+            "slug": "pascals-triangle",
+            "uuid": "bf709fe6-d269-467a-a3da-5bbdaf674f91",
+            "prerequisites": [],
+            "topics": [
+                "conditionals",
+                "exception_handling",
+                "integers",
+                "math"
+            ],
+            "difficulty": 1
+        },
+        {
+            "slug": "raindrops",
+            "uuid": "7a083573-2c68-47cc-8bc8-c0e483cf0e50",
+            "prerequisites": [],
+            "topics": ["arrays", "loops", "strings"],
+            "difficulty": 1
+        },
+        {
+            "slug": "scrabble-score",
+            "uuid": "5feec698-0bf8-4308-9f72-2cecaab5e75e",
+            "prerequisites": [],
+            "topics": ["arrays", "conditionals", "loops", "strings"],
+            "difficulty": 1
+        },
+        {
+            "slug": "word-count",
+            "uuid": "07875495-146f-44a3-b13a-e8e74a37b87d",
+            "prerequisites": [],
+            "topics": ["arrays", "loops", "strings"],
+            "difficulty": 1
+        },
+        {
+            "slug": "luhn",
+            "uuid": "cc08d672-9c58-4e7a-bfb7-344cbad811f7",
+            "prerequisites": [],
+            "topics": ["math", "conditionals", "strings"],
+            "difficulty": 1
+        },
+        {
+            "slug": "roman-numerals",
+            "uuid": "58c41643-971c-4199-a10f-7dc21093e5e3",
+            "prerequisites": [],
+            "topics": ["loops", "strings"],
+            "difficulty": 1
+        },
+        {
+            "slug": "isogram",
+            "uuid": "19f9e7c4-f2a5-4636-b7b2-4e0a15977e01",
+            "prerequisites": [],
+            "topics": ["arrays", "conditionals", "loops", "strings"],
+            "difficulty": 1
+        },
+        {
+            "slug": "etl",
+            "uuid": "bccc00fa-811c-4bf9-8e55-07a0d0affb08",
+            "prerequisites": [],
+            "topics": ["arrays", "sorting", "strings"],
+            "difficulty": 2
+        },
+        {
+            "slug": "collatz-conjecture",
+            "uuid": "d1d5a74a-d488-4e2e-bd63-b74730057c98",
+            "prerequisites": [],
+            "topics": ["exception_handling", "conditionals", "math"],
+            "difficulty": 2
+        },
+        {
+            "slug": "sieve",
+            "uuid": "5e3b376a-06ab-442f-8d18-710db7778db6",
+            "prerequisites": [],
+            "topics": ["arrays", "conditionals", "loops", "filtering", "math"],
+            "difficulty": 2
+        },
+        {
+            "slug": "trinary",
+            "uuid": "c09ed7ec-fa7c-4f6a-994f-3d3eb7f22df4",
+            "prerequisites": [],
+            "topics": ["arrays", "integers", "math", "strings"],
+            "difficulty": 2
+        },
+        {
+            "slug": "secret-handshake",
+            "uuid": "d2c85375-c0e7-4e04-88f1-08736e5afa04",
+            "prerequisites": [],
+            "topics": ["arrays", "filtering"],
+            "difficulty": 2
+        },
+        {
+            "slug": "phone-number",
+            "uuid": "f7a3f344-a9fa-4a36-ac44-12bc8673899e",
+            "prerequisites": [],
+            "topics": [
+                "conditionals",
+                "pattern_matching",
+                "regular_expressions",
+                "strings"
+            ],
+            "difficulty": 1
+        },
+        {
+            "slug": "triangle",
+            "uuid": "f5be4623-2a9a-4bf5-bb32-dd81eddf0683",
+            "prerequisites": [],
+            "topics": ["conditionals"],
+            "difficulty": 1
+        },
+        {
+            "slug": "transpose",
+            "uuid": "e5a6d640-cd76-4453-8247-fd34ffed4fe5",
+            "prerequisites": [],
+            "topics": ["arrays", "conditionals", "loops", "strings"],
+            "difficulty": 2
+        },
+        {
+            "slug": "clock",
+            "uuid": "39bc1f1e-68e3-4d35-880b-d6b6fa174605",
+            "prerequisites": [],
+            "topics": ["time", "multiple_dispatch", "structs"],
+            "difficulty": 5
+        },
+        {
+            "slug": "complex-numbers",
+            "uuid": "eca7e62c-7bbf-436c-8011-2920cb2ab1c1",
+            "prerequisites": [],
+            "topics": ["math", "multiple_dispatch", "structs"],
+            "difficulty": 10
+        },
+        {
+            "slug": "rational-numbers",
+            "uuid": "0caf0209-be6e-4585-a90b-e41c94c5fa40",
+            "prerequisites": [],
+            "topics": ["math", "multiple_dispatch", "structs"],
+            "difficulty": 8
+        },
+        {
+            "slug": "custom-set",
+            "uuid": "b47377f7-84af-4a10-83ef-c2444a4f8940",
+            "prerequisites": [],
+            "topics": ["iterators", "multiple_dispatch", "structs"],
+            "difficulty": 8
+        },
+        {
+            "slug": "robot-name",
+            "uuid": "7cb2d96a-4707-4cec-9ead-313fcb5fbb94",
+            "prerequisites": [],
+            "topics": ["randomness", "strings", "structs"],
+            "difficulty": 5
+        },
+        {
+            "slug": "gigasecond",
+            "uuid": "c64e03cc-1952-4b2d-9a53-25c43187a4e6",
+            "prerequisites": [],
+            "topics": ["dates"],
+            "difficulty": 1
+        },
+        {
+            "slug": "robot-simulator",
+            "uuid": "e4b19962-ebc1-4f12-9ac8-45f17faeaa55",
+            "prerequisites": [],
+            "topics": ["structs"],
+            "difficulty": 6
+        },
+        {
+            "slug": "resistor-color-trio",
+            "uuid": "39e831d0-ea7a-4df9-b9cb-64ccb996ee0e",
+            "prerequisites": [],
+            "topics": ["arrays", "loops", "text_formatting", "strings"],
+            "difficulty": 2
+        },
+        {
+            "slug": "grains",
+            "uuid": "4cc2a5d6-e662-4d99-81d4-05d6bcd500f4",
+            "prerequisites": [],
+            "topics": ["exception_handling"],
+            "difficulty": 1
+        },
+        {
+            "slug": "spiral-matrix",
+            "uuid": "3a2facfd-5ec8-49a0-a5aa-2229f07da896",
+            "prerequisites": [],
+            "topics": ["iterators", "matrix"],
+            "difficulty": 3
+        },
+        {
+            "slug": "isbn-verifier",
+            "uuid": "22b64a2b-7f08-444d-be6e-8b42e5c9207c",
+            "prerequisites": [],
+            "topics": [
+                "math",
+                "conditionals",
+                "metaprogramming",
+                "strings",
+                "structs"
+            ],
+            "difficulty": 5
+        },
+        {
+            "slug": "armstrong-numbers",
+            "uuid": "af4ae5d7-8d9d-4d21-b5d3-62f4fd8b4719",
+            "prerequisites": [],
+            "topics": ["math", "integers", "math"],
+            "difficulty": 1
+        },
+        {
+            "slug": "pythagorean-triplet",
+            "uuid": "a534b8ed-da88-4945-bb25-f6633977740b",
+            "prerequisites": [],
+            "topics": [
+                "conditionals",
+                "type_conversion",
+                "loops",
+                "variables",
+                "tuples",
+                "integers",
+                "lists",
+                "arrays",
+                "logic",
+                "math",
+                "algorithms",
+                "functional_programming"
+            ],
+            "difficulty": 7
+        },
+        {
+            "slug": "dnd-character",
+            "uuid": "fcb9ef0e-ed97-4420-a38f-9bf690c23a3b",
+            "prerequisites": [],
+            "topics": [
+                "variables",
+                "integers",
+                "structs",
+                "games",
+                "randomness",
+                "math",
+                "test_driven_development"
+            ],
+            "difficulty": 5
+        },
+        {
+            "slug": "reverse-string",
+            "uuid": "e73f19f7-17bc-4d51-a00a-c2b58c1fa8e6",
+            "prerequisites": [],
+            "topics": [
+                "generics",
+                "loops",
+                "variables",
+                "strings",
+                "integers",
+                "lists",
+                "arrays",
+                "text_formatting",
+                "data_structures",
+                "functional_programming"
+            ],
+            "difficulty": 3
+        },
+        {
+            "slug": "acronym",
+            "uuid": "929493e2-56b2-41d7-aedc-7cc4831078ba",
+            "prerequisites": [],
+            "topics": ["arrays", "loops", "strings"],
+            "difficulty": 1
+        },
+        {
+            "slug": "prime-factors",
+            "uuid": "b6b7e95b-c4ca-438c-a5e7-d76cb44e5b19",
+            "prerequisites": [],
+            "topics": ["math", "integers"],
+            "difficulty": 1
+        },
+        {
+            "slug": "minesweeper",
+            "uuid": "9a47bffd-4dd2-48ce-b47b-753271305966",
+            "prerequisites": [],
+            "topics": [
+                "loops",
+                "conditionals",
+                "variables",
+                "strings",
+                "integers",
+                "lists",
+                "booleans",
+                "arrays",
+                "text_formatting"
+            ],
+            "difficulty": 2
+        },
+        {
+            "slug": "accumulate",
+            "uuid": "e11e9623-f763-4bea-a6d9-7085956ce959",
+            "prerequisites": [],
+            "topics": [
+                "broadcast",
+                "conditionals",
+                "variables",
+                "integers",
+                "arrays"
+            ],
+            "difficulty": 2,
+            "deprecated": true
+        },
+        {
+            "slug": "allergies",
+            "uuid": "4eced190-062f-4a7b-8c92-87ff02f1e343",
+            "prerequisites": [],
+            "topics": [
+                "loops",
+                "conditionals",
+                "integers",
+                "lists",
+                "booleans",
+                "enumerations",
+                "arrays",
+                "bitwise_operations"
+            ],
+            "difficulty": 1
+        },
+        {
+            "slug": "matching-brackets",
+            "uuid": "bf5c1f49-963a-4397-bb67-b58e1b7d45e3",
+            "prerequisites": [],
+            "topics": [
+                "loops",
+                "conditionals",
+                "variables",
+                "integers",
+                "booleans",
+                "stacks",
+                "arrays",
+                "data_structures",
+                "algorithms"
+            ],
+            "difficulty": 5
+        },
+        {
+            "slug": "perfect-numbers",
+            "uuid": "4fc89443-1c5c-492a-850f-7990869caae6",
+            "prerequisites": [],
+            "topics": [
+                "loops",
+                "conditionals",
+                "variables",
+                "integers",
+                "lists",
+                "strings",
+                "logic",
+                "math",
+                "functional_programming"
+            ],
+            "difficulty": 3
+        },
+        {
+            "slug": "circular-buffer",
+            "uuid": "3dc9bbde-d344-4a36-a7e1-433637974dfc",
+            "prerequisites": [],
+            "topics": ["data_structures", "generics", "structs"],
+            "difficulty": 8
+        }
     ]
 }

--- a/languages/kotlin/config.json
+++ b/languages/kotlin/config.json
@@ -27,5 +27,794 @@
     "indent_size": 4
   },
   "solution_pattern": "reference",
-  "active": true
+  "active": true,
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "58c16459-348a-4536-8228-43379174735e",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "0000e75e-9b43-11e8-98d0-529269fb1459",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "dnd-character",
+      "uuid": "a550dafa-bcec-448c-a7dd-af0ebd4e1070",
+      "prerequisites": [],
+      "topics": ["integers", "randomness"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "40f85461-c256-4b96-8d5b-0509f42fab17",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "resistor-color",
+      "uuid": "9d62b45c-1acf-4ae6-b990-73e5bc2b5893",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 2
+    },
+    {
+      "slug": "resistor-color-duo",
+      "uuid": "84bdc53f-aa1f-4ddf-9c5d-95b03cfff72d",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 2
+    },
+    {
+      "slug": "resistor-color-trio",
+      "uuid": "ae4df67d-c848-42e6-9fd7-d3cec83c1691",
+      "prerequisites": [],
+      "topics": ["math", "type_conversion", "lists"],
+      "difficulty": 3
+    },
+    {
+      "slug": "transpose",
+      "uuid": "045de074-eeb3-499e-9cf4-65b75d9988fc",
+      "prerequisites": [],
+      "topics": ["lists", "loops", "maps", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "leap",
+      "uuid": "639e59b6-84aa-4f13-9718-537606703c43",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers"],
+      "difficulty": 2
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "9772c916-c619-445c-834d-af7dbf1ad2d9",
+      "prerequisites": [],
+      "topics": ["loops", "maps", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "darts",
+      "uuid": "c2b49ff6-e7bf-40bb-b619-9cdfaa43c065",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "conditionals", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "pangram",
+      "uuid": "0e9ca09d-c32e-4fed-930f-1b7c10b67dc2",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "regular_expressions", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "hamming",
+      "uuid": "7151ff23-ebc6-43d7-86b6-81cf0dd45309",
+      "prerequisites": [],
+      "topics": ["integers", "loops", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "1eb4c9d3-0085-4ca3-b1bb-9a20b88a1e7f",
+      "prerequisites": [],
+      "topics": ["dates", "integers", "time"],
+      "difficulty": 3
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "10b6cca2-6c36-4017-9464-32aa11c59f85",
+      "prerequisites": [],
+      "topics": ["object_oriented_programming", "sets", "varargs"],
+      "difficulty": 3
+    },
+    {
+      "slug": "space-age",
+      "uuid": "a91ce7e9-9a2a-44de-b10c-cc1be63df2a1",
+      "prerequisites": [],
+      "topics": ["conditionals", "floating_point_numbers"],
+      "difficulty": 3
+    },
+    {
+      "slug": "acronym",
+      "uuid": "d8288e46-2e8c-42e4-8e14-20b1efd0f574",
+      "prerequisites": [],
+      "topics": ["loops", "parsing", "searching", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "4d8a68eb-eee9-4c51-97b8-57f3b69f5970",
+      "prerequisites": [],
+      "topics": [
+        "games",
+        "loops",
+        "pattern_matching",
+        "strings",
+        "transforming"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "483b5124-b5b2-4bb0-aa69-b04e3ea6aeb6",
+      "prerequisites": [],
+      "topics": [
+        "loops",
+        "regular_expressions",
+        "strings",
+        "transforming",
+        "type_conversion"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "matrix",
+      "uuid": "46ab876c-cde2-4fa7-8970-b250ad8ccf74",
+      "prerequisites": [],
+      "topics": [
+        "loops",
+        "strings",
+        "pattern_matching",
+        "type_conversion",
+        "transforming"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "wordy",
+      "uuid": "3c7a3c6b-8dc7-4e5a-ba72-e1a4bffb0bc4",
+      "prerequisites": [],
+      "topics": ["loops", "pattern_matching", "strings", "recursion"],
+      "difficulty": 3
+    },
+    {
+      "slug": "scale-generator",
+      "uuid": "dfa35a61-07da-4317-8c25-0c630e551d8c",
+      "prerequisites": [],
+      "topics": ["lists", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "2928cf06-dab8-4522-a6d8-b2a15d7d356b",
+      "prerequisites": [],
+      "topics": ["strings", "text_formatting", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "93ee76ba-d19f-4c72-b011-676f40dcda5e",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "d54a68fc-02dd-45ee-8c6f-3efb781ed0d2",
+      "prerequisites": [],
+      "topics": ["integers", "loops", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "feee3ee9-81d5-4a4f-ad98-e1ecf21757ed",
+      "prerequisites": [],
+      "topics": [
+        "bitwise_operations",
+        "conditionals",
+        "cryptography",
+        "enumerations",
+        "integers",
+        "loops",
+        "transforming"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "yacht",
+      "uuid": "2702ffe9-26c3-4f68-86dc-2993dfa2de91",
+      "prerequisites": [],
+      "topics": [
+        "enums",
+        "functional_programming",
+        "lists",
+        "pattern_matching"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "ad7c8fd8-acf0-40d0-8a30-d959c4b0252a",
+      "prerequisites": [],
+      "topics": [
+        "enumerations",
+        "exception_handling",
+        "filtering",
+        "integers",
+        "math"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "d3f960e5-cf19-4308-a1bc-897777f62689",
+      "prerequisites": [],
+      "topics": ["arrays", "conditionals", "integers", "loops", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "luhn",
+      "uuid": "3cf8a650-6a25-416e-a0af-036f41c11cca",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "booleans",
+        "loops",
+        "strings",
+        "type_conversion"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "triangle",
+      "uuid": "e282536b-267f-490c-a453-758135051a54",
+      "prerequisites": [],
+      "topics": ["conditionals", "exception_handling", "integers", "recursion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "aa11e242-77b9-4ba7-97a2-d9b36e454a9d",
+      "prerequisites": [],
+      "topics": ["integers", "loops", "math", "strings", "type_conversion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "grains",
+      "uuid": "1fa1e0f9-6410-4197-8778-debeb274e6d4",
+      "prerequisites": [],
+      "topics": ["integers"],
+      "difficulty": 4
+    },
+    {
+      "slug": "forth",
+      "uuid": "81d48ea4-0e88-45f2-839f-fe13e2059e92",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "integers"],
+      "difficulty": 4
+    },
+    {
+      "slug": "sieve",
+      "uuid": "87ca4323-8a19-4529-962d-0f2ee63ebb2f",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "lists", "loops", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "0b92ffee-c092-4ab1-ad78-76c8cf80e1b5",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "enumerations",
+        "lists",
+        "logic",
+        "loops",
+        "pattern_recognition",
+        "strings"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "ab52d0f4-a001-4d44-951e-0cfc396374f3",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "exception_handling",
+        "integers",
+        "math",
+        "recursion"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "b325401a-c8f0-49da-9f1a-a83318e780c9",
+      "prerequisites": [],
+      "topics": ["cryptography", "security", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "affine-cipher",
+      "uuid": "94fdd990-101b-4daf-8692-75085e6563f2",
+      "prerequisites": [],
+      "topics": ["cryptography", "security", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "6e2bbe8d-b6ab-4675-9c31-5b437cefd0c4",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "exception_handling",
+        "integers",
+        "lists",
+        "loops",
+        "math"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "371901d4-0728-4abd-8374-1905d7d70329",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "exception_handling",
+        "integers",
+        "loops"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "diamond",
+      "uuid": "03c71e34-ecaf-47a4-9854-48600e1bf0d4",
+      "prerequisites": [],
+      "topics": ["arrays", "lists", "loops", "strings", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "isogram",
+      "uuid": "e5338be9-6f51-4448-9b10-20de7b1338b9",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "parsing", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "c67907b6-0d8b-4b12-9c41-6069845952a3",
+      "prerequisites": [],
+      "topics": ["stacks", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "cb2ce8e5-f143-4423-a3bc-959f4222c186",
+      "prerequisites": [],
+      "topics": ["arrays", "lists", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "49e730fb-7031-4de9-9bfd-b86564f20d8a",
+      "prerequisites": [],
+      "topics": ["cryptography", "algorithms", "strings", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "2c8c1c16-bbb8-49e5-a248-f7a473c2bc86",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "pattern_matching",
+        "regular_expressions",
+        "strings"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "62bd648a-e959-4ec4-8a5f-09e08fa0b2c8",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "exception_handling",
+        "integers",
+        "maps",
+        "parsing",
+        "searching",
+        "strings"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "word-count",
+      "uuid": "3b8b77ef-da2d-499d-9513-8fe771e86b3e",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers", "loops", "maps", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "e3407da5-0524-4565-b724-9778bba1033f",
+      "prerequisites": [],
+      "topics": ["arrays", "integers", "loops", "matrices"],
+      "difficulty": 5
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "ce475b23-5dfc-4049-90c5-0c387926686f",
+      "prerequisites": [],
+      "topics": [
+        "pattern_matching",
+        "randomness",
+        "regular_expressions",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "0e92ba19-2727-4a5e-be38-e88878322c53",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "integers",
+        "lists",
+        "loops",
+        "math"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "allergies",
+      "uuid": "a826af04-b7f3-426e-9bce-42375d0d928b",
+      "prerequisites": [],
+      "topics": [
+        "booleans",
+        "conditionals",
+        "enumerations",
+        "integers",
+        "lists",
+        "loops"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "bob",
+      "uuid": "f3713067-7f37-4dd6-a189-c80f46dab8ec",
+      "prerequisites": [],
+      "topics": ["booleans", "conditionals", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "67db30e4-b4d8-4224-b0f8-19a00af40387",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "arrays",
+        "exception_handling",
+        "integers",
+        "math",
+        "matrices"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "cbbbd7db-224f-45ca-a108-4dc6bc98e4a0",
+      "prerequisites": [],
+      "topics": ["stacks", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "series",
+      "uuid": "9caa5fd9-a774-4d4c-951d-053a4f3f2726",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "lists",
+        "loops",
+        "strings",
+        "type_conversion"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "3905dff6-7835-44ff-a8c9-7f4d184ab714",
+      "prerequisites": [],
+      "topics": ["algorithms", "loops", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "7c24087a-ca61-48d3-9cb9-c3fde2edba86",
+      "prerequisites": [],
+      "topics": ["cryptography", "integers", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "400d8014-9f75-43da-8a1c-93d95d91f4d2",
+      "prerequisites": [],
+      "topics": ["integers", "loops", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "bank-account",
+      "uuid": "12e1d685-32be-4b2c-a40b-c68e5b60de1d",
+      "prerequisites": [],
+      "topics": ["concurrency", "exception_handling", "integers"],
+      "difficulty": 6
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "da466ad5-6837-47d8-af39-2c0563d35a3c",
+      "prerequisites": [],
+      "topics": ["integers", "logic", "loops", "maps", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "34f0e7d0-29df-44e5-a7a7-4a12584af62e",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "strings",
+        "text_formatting",
+        "variables"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "etl",
+      "uuid": "f0f297f2-429f-4626-8b7f-0706a1e8f255",
+      "prerequisites": [],
+      "topics": ["lists", "maps", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "fc977979-c8a4-44b6-a685-c8a32bd12bc3",
+      "prerequisites": [],
+      "topics": ["algorithms", "generics", "lists"],
+      "difficulty": 6
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "62eb71dd-18ba-427f-a27a-86e993b4055a",
+      "prerequisites": [],
+      "topics": ["conditionals", "lists", "maps", "sorting", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "6e3b294b-16a3-4ebb-a78b-4bf7f6b96736",
+      "prerequisites": [],
+      "topics": ["classes", "enumerations", "logic", "loops"],
+      "difficulty": 6
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "c8815b6c-19b8-4f4d-9be4-6717e933591a",
+      "prerequisites": [],
+      "topics": ["arrays", "generics", "recursion", "searching"],
+      "difficulty": 6
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "12a9dd9f-28ed-4159-baf3-d28654cb8fa7",
+      "prerequisites": [],
+      "topics": ["arrays", "generics", "recursion", "searching"],
+      "difficulty": 5
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "8eb6f225-fa3d-4a33-b476-2cae45053c82",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "games",
+        "integers",
+        "lists",
+        "matrices",
+        "strings"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "19d00436-f26a-47ad-b13e-128181dc09f3",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "exception_handling",
+        "integers",
+        "loops",
+        "math"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "say",
+      "uuid": "5607dae5-13aa-4cd4-8b4c-d270516182d7",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "zebra-puzzle",
+      "uuid": "fe876a9b-2991-4624-a6fe-4311cb78f068",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "conditionals", "games"],
+      "difficulty": 9
+    },
+    {
+      "slug": "anagram",
+      "uuid": "f754e1cc-cb88-4776-ab11-3e6ae8362d5a",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "conditionals",
+        "equality",
+        "lists",
+        "loops",
+        "strings"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "sublist",
+      "uuid": "ebfdf40a-1fde-4c88-aa93-95e3190f5261",
+      "prerequisites": [],
+      "topics": ["enumerations", "generics", "lists", "loops", "searching"],
+      "difficulty": 7
+    },
+    {
+      "slug": "meetup",
+      "uuid": "d617987e-64b8-4c21-89a9-66a932c4668d",
+      "prerequisites": [],
+      "topics": ["conditionals", "dates", "enumerations", "loops"],
+      "difficulty": 7
+    },
+    {
+      "slug": "clock",
+      "uuid": "1dcefdea-5447-4622-a064-079aad781398",
+      "prerequisites": [],
+      "topics": [
+        "equality",
+        "integers",
+        "logic",
+        "object_oriented_programming",
+        "strings",
+        "time"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "c52c4b61-dca2-4b73-87b6-b4f2f63d9fdb",
+      "prerequisites": [],
+      "topics": ["algorithms", "exception_handling", "games", "lists"],
+      "difficulty": 7
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "34f1d5bf-f31f-415e-9905-4d48e6205d28",
+      "prerequisites": [],
+      "topics": [
+        "filtering",
+        "functional_programming",
+        "generics",
+        "lists",
+        "loops"
+      ],
+      "difficulty": 8
+    },
+    {
+      "slug": "diffie-hellman",
+      "uuid": "9b191b2f-b1a4-4c0e-b911-36666bff614d",
+      "prerequisites": [],
+      "topics": ["cryptography", "randomness", "algorithms", "integers"],
+      "difficulty": 8
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "e23b06de-bd91-482f-9783-b0334b75b489",
+      "prerequisites": [],
+      "topics": [
+        "cryptography",
+        "exception_handling",
+        "randomness",
+        "security",
+        "strings"
+      ],
+      "difficulty": 8
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "83dec96f-9cdf-4b9b-abc4-cbd2066d919a",
+      "prerequisites": [],
+      "topics": ["floating_point_numbers", "math"],
+      "difficulty": 8
+    },
+    {
+      "slug": "change",
+      "uuid": "0d69c1cd-f190-4b3b-8472-bf78c02acbc5",
+      "prerequisites": [],
+      "topics": ["algorithms", "exception_handling", "integers", "lists"],
+      "difficulty": 8
+    },
+    {
+      "slug": "react",
+      "uuid": "240788cd-afa5-4fd6-8df0-a158239c0610",
+      "prerequisites": [],
+      "topics": [
+        "generics",
+        "functional_programming",
+        "classes",
+        "reactive_programming"
+      ],
+      "difficulty": 10
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "86015770-603b-44cf-aedf-f2a7cf79c841",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "binary",
+      "uuid": "def44955-c048-4b74-8777-2fb7d779b09e",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "13b1a62e-8e0e-4d57-b8c9-341b41f25cf5",
+      "prerequisites": [],
+      "topics": ["string", "integers"],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "strain",
+      "uuid": "8ae8492d-620c-4446-9928-5b4d78d496d9",
+      "prerequisites": [],
+      "topics": ["arrays", "filtering"],
+      "difficulty": 0,
+      "deprecated": true
+    }
+  ]
 }

--- a/languages/nim/config.json
+++ b/languages/nim/config.json
@@ -12,5 +12,534 @@
     "concept": [],
     "practice": []
   },
-  "concepts": []
+  "concepts": [],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "4817a6c0-6c9f-41ce-b53e-54ee3c0a6e40",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "b7ad6238-bb8e-4629-8a6f-5eddb8568d87",
+      "prerequisites": [],
+      "topics": ["conditionals", "optional_values", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "5f1ac3f4-6d30-4487-a9aa-b7e88fe9fb08",
+      "prerequisites": [],
+      "topics": ["booleans", "conditionals", "logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "f572ed7b-a1e7-47ab-a9c3-71ba988d3699",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "isogram",
+      "uuid": "b1eb9f3c-8724-4b88-a545-2fe34b12b9cf",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "loops", "maps", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "pangram",
+      "uuid": "81009e3e-37ff-4f28-a84a-6935c32f96fa",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "filtering",
+        "logic",
+        "loops",
+        "strings"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "532d4c60-52ff-4271-a346-b7c00ca83560",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "logic",
+        "loops",
+        "maps",
+        "strings",
+        "transforming"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "hamming",
+      "uuid": "7a9e6a30-dc8d-4c7e-bfdd-34922253532e",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "filtering",
+        "logic",
+        "loops",
+        "sequences",
+        "sets",
+        "strings"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "word-count",
+      "uuid": "ca6093d1-f2cb-4d28-9a56-312154f1179f",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "logic",
+        "pattern_recognition",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "dccdbae7-e882-4171-a517-04562113d059",
+      "prerequisites": [],
+      "topics": ["dates", "time"],
+      "difficulty": 1
+    },
+    {
+      "slug": "bob",
+      "uuid": "ced77a52-47fc-461f-942b-ed2e0d671d1c",
+      "prerequisites": [],
+      "topics": ["conditionals", "equality", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "825b54b4-68a8-4302-9e9b-61960a3df88e",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "83f70468-941b-4d7d-9df7-6f8b6a54f6bc",
+      "prerequisites": [],
+      "topics": ["algorithms", "loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "grains",
+      "uuid": "40dcc736-1904-418e-bb69-2186b3bb0a83",
+      "prerequisites": [],
+      "topics": ["integers", "type_conversion"],
+      "difficulty": 2
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "aaeadc9c-d92d-4d5a-a601-e7836f59dd9f",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "anagram",
+      "uuid": "81816524-33b8-4e06-ad31-65efc9b1fec2",
+      "prerequisites": [],
+      "topics": ["algorithms", "logic", "parsing", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "allergies",
+      "uuid": "58bb800a-5b64-44bc-8282-77972b71e615",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "classes", "enumerations"],
+      "difficulty": 1
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "88dde3e7-95c8-4a5f-8514-1c489917966e",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "4f71d4e9-749e-46ec-a2c8-e17497f1468a",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "e6f013ed-1dfc-4330-8f3c-3bc851f05fa4",
+      "prerequisites": [],
+      "topics": ["loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "acronym",
+      "uuid": "cc35f8f2-488e-40f7-adcd-1e690cabc6f8",
+      "prerequisites": [],
+      "topics": ["regular_expressions", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "356db5da-2a2b-40cc-bf72-d5046cb003f9",
+      "prerequisites": [],
+      "topics": [
+        "classes",
+        "conditionals",
+        "filtering",
+        "integers",
+        "lists",
+        "sorting",
+        "strings"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "91f1314c-5272-4a88-afee-747794236e2a",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers", "logic", "loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "space-age",
+      "uuid": "64f70cfe-e34c-43ee-9b9a-72fe54884599",
+      "prerequisites": [],
+      "topics": ["conditionals", "floating_point_numbers", "integers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "b44d1ecb-48db-4841-be99-f48ba2602748",
+      "prerequisites": [],
+      "topics": ["games", "loops", "maps", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "c52b74a0-e885-4a2b-9a97-9ab62e07662e",
+      "prerequisites": [],
+      "topics": ["algorithms", "lists", "loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "bb8af717-9e8d-498c-85cf-e6e77a84919e",
+      "prerequisites": [],
+      "topics": ["parsing", "recursion", "stacks", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "7131aec2-34c6-465f-a689-3a1cb297df3a",
+      "prerequisites": [],
+      "topics": ["arrays", "exception_handling", "games", "logic", "matrices"],
+      "difficulty": 1
+    },
+    {
+      "slug": "triangle",
+      "uuid": "4d520486-fb44-4f84-a261-4c2039a9b89c",
+      "prerequisites": [],
+      "topics": ["classes", "conditionals"],
+      "difficulty": 1
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "c95b43a3-f702-473e-bdd5-aa6708ba1ce3",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "afb513c4-fcfb-4211-bcbc-7807063d301c",
+      "prerequisites": [],
+      "topics": ["maps", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "4e35d149-d3b2-4e98-85bd-7a21783b59d4",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "react",
+      "uuid": "5904b7d1-08a3-4565-979c-a8e2f1e440fd",
+      "prerequisites": [],
+      "topics": ["callbacks", "events", "reactive_programming"],
+      "difficulty": 8
+    },
+    {
+      "slug": "clock",
+      "uuid": "f1ebb810-ec96-4415-ae97-c76a0a714267",
+      "prerequisites": [],
+      "topics": ["equality", "text_formatting", "time"],
+      "difficulty": 1
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "a6e88c81-4f8b-45bb-8656-74f5a9554a12",
+      "prerequisites": [],
+      "topics": ["cryptography", "strings", "text_formatting", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "darts",
+      "uuid": "c83824af-bac6-4e59-9bf0-df5ab3f83a3d",
+      "prerequisites": [],
+      "topics": ["conditionals", "floating_point_numbers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "diamond",
+      "uuid": "675520e4-b763-4bdb-8d6a-740b12834fcb",
+      "prerequisites": [],
+      "topics": ["strings", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "diffie-hellman",
+      "uuid": "bf9a2fc3-def5-4bfc-a944-91bb213ad8b5",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "cryptography",
+        "integers",
+        "math",
+        "randomness"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "etl",
+      "uuid": "da9807c2-959d-49e0-86a9-44de02501f37",
+      "prerequisites": [],
+      "topics": ["maps", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "high-scores",
+      "uuid": "957a8f39-1c9e-43ef-917c-d70278314278",
+      "prerequisites": [],
+      "topics": ["sequences", "sorting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "e184b588-f6a1-4e07-ab31-5cedfd4f26c7",
+      "prerequisites": [],
+      "topics": ["parsing", "strings", "type_conversion"],
+      "difficulty": 1
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "3df571f3-e47f-469b-b427-ac0f5167f964",
+      "prerequisites": [],
+      "topics": ["enumerations", "parsing", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "6491e319-9bb9-4e02-8048-77598c0c7b98",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "math", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "luhn",
+      "uuid": "a8de14a7-aa77-4e5e-83cd-fa4321dd7a36",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "matrix",
+      "uuid": "273015db-0c65-49f8-b216-50160dbad8b0",
+      "prerequisites": [],
+      "topics": ["matrices", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "meetup",
+      "uuid": "adfbdcef-4d75-446f-9bfe-d3c7f28d8d2f",
+      "prerequisites": [],
+      "topics": ["dates", "enumerations", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "9ba153ad-bd49-4c26-9d80-dadb496cb637",
+      "prerequisites": [],
+      "topics": ["algorithms", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "92579b80-194a-430f-b0e1-f2854ea8b505",
+      "prerequisites": [],
+      "topics": ["enumerations", "filtering", "integers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "7cb027d9-6841-443a-9168-fb1347abe891",
+      "prerequisites": [],
+      "topics": ["conditionals", "parsing", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "869c033a-052c-4031-9402-970824bb520a",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "2121a163-8dce-4267-b8de-d1952c1491e8",
+      "prerequisites": [],
+      "topics": ["maps", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "proverb",
+      "uuid": "8d876470-08d5-4efe-b9d1-4a6812c1e586",
+      "prerequisites": [],
+      "topics": ["loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color",
+      "uuid": "b239a0f3-47b5-4583-985f-c98efca8259e",
+      "prerequisites": [],
+      "topics": ["arrays", "enumerations"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color-duo",
+      "uuid": "85c8f6d3-5802-4894-9929-5aa62d7a4840",
+      "prerequisites": [],
+      "topics": ["arrays", "enumerations", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color-trio",
+      "uuid": "6aa72d75-5c41-427a-a0fd-3253859e0f3e",
+      "prerequisites": [],
+      "topics": ["arrays", "enumerations", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "5d2fa542-245a-4c5b-bfe1-bd667091c556",
+      "prerequisites": [],
+      "topics": ["randomness", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "b60b8bfd-a2a7-4da0-8a22-894fff5abab2",
+      "prerequisites": [],
+      "topics": ["cryptography", "integers", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "8809c138-3973-479e-9331-82a7f719f5cb",
+      "prerequisites": [],
+      "topics": ["integers", "matrices", "searching"],
+      "difficulty": 1
+    },
+    {
+      "slug": "say",
+      "uuid": "ef24428e-289c-48d0-967b-961d95246f3c",
+      "prerequisites": [],
+      "topics": ["integers", "strings", "text_formatting", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "scale-generator",
+      "uuid": "b81e2ff7-5d11-499d-acc5-0448d1b1af47",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "09623b3d-05ee-4825-aae8-6434c9538366",
+      "prerequisites": [],
+      "topics": [
+        "bitwise_operations",
+        "conditionals",
+        "integers",
+        "lists",
+        "logic",
+        "loops",
+        "transforming"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "series",
+      "uuid": "ac78d616-2521-470c-a09f-aaffc96d3795",
+      "prerequisites": [],
+      "topics": ["sequences", "strings", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sieve",
+      "uuid": "538e773f-ac66-4a1f-9b12-3eacd45b5084",
+      "prerequisites": [],
+      "topics": ["algorithms", "filtering", "integers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "32c1262c-4f60-45cf-a5eb-aae7ea19acfc",
+      "prerequisites": [],
+      "topics": ["integers", "matrices"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sublist",
+      "uuid": "08719e83-36ac-4f9a-9075-6edca3648d5d",
+      "prerequisites": [],
+      "topics": ["enumerations", "searching", "sequences"],
+      "difficulty": 1
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "b38a3fcc-f5cf-4366-b0b4-e39b8c81e3f6",
+      "prerequisites": [],
+      "topics": ["pattern_recognition", "strings", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "yacht",
+      "uuid": "9908f5fe-5df7-4e88-aab7-25959ed67985",
+      "prerequisites": [],
+      "topics": ["conditionals", "games", "integers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "binary",
+      "uuid": "3acf148d-df9e-4897-8c9f-c17a3ba5e4b6",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    }
+  ]
 }

--- a/languages/perl5/config.json
+++ b/languages/perl5/config.json
@@ -12,5 +12,469 @@
     "concept": [],
     "practice": []
   },
-  "concepts": []
+  "concepts": [],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "e436ce92-78b9-4b3b-b87e-581fa54cdc65",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "749dac4a-a746-4af7-aca6-db9e69ccad8c",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "bob",
+      "uuid": "835a4c46-c837-4684-a1ed-7d257c786d77",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "0b512415-2dcf-4dfb-a58f-2765f9a1427b",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "grains",
+      "uuid": "55316f62-e3b0-4be7-a478-9fc5ea827d15",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "85154a10-06e3-4543-8513-4de30b43d015",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "hamming",
+      "uuid": "5c35f654-8689-4fb3-af81-71fbe0c165f9",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "etl",
+      "uuid": "e193fb19-5122-405f-88e0-59e5ee94f64b",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "332370f1-a782-4ffb-a41a-867bf392f05f",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "word-count",
+      "uuid": "4693c5a5-948b-4650-9a37-9eb8ee2cfa6d",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "anagram",
+      "uuid": "c95418a3-d868-42dc-b39d-2505d255fecf",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "590270ac-b638-4292-bbdc-eee1705904f1",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "proverb",
+      "uuid": "9aad3797-7001-424b-b38d-1e9db7a99581",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "space-age",
+      "uuid": "8f6d6a60-426c-4da0-af4e-7395b2c880d3",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "c1eb4de7-41fe-4395-b5ef-a79a8187e727",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "clock",
+      "uuid": "163f929c-206b-430b-8ac7-ad7b5c062f3d",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "bcfc5046-ec4e-4b6e-a5c6-811883f021a0",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "triangle",
+      "uuid": "1384080d-d9db-4de7-a1db-090fd15ed7e6",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "70eaa806-235f-4513-aaff-c827ed80a1ad",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "802e2ef6-68e5-4116-a94a-ae0ddb33406d",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "3029f30c-77b6-49a3-909f-26ca868e5b22",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "4b9872a8-bb21-4b1a-952b-032efa13b1da",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "f9fcab93-a6d8-4e36-aee5-3333a1c874ce",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "39defad0-2828-4d3e-991f-5e624c68a37e",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "08343954-918c-4383-a6b8-b8d3d6ef836c",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "allergies",
+      "uuid": "7fd51712-d08f-475b-86c8-2945d054dc54",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "80c6212c-6b25-45b9-b09f-4c085d02f561",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "series",
+      "uuid": "35e90496-58a6-48be-ad55-14e3a145bd5c",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "luhn",
+      "uuid": "d5f021a7-d797-4561-aef9-1d5c7a9610d8",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "house",
+      "uuid": "5ab75e9e-39ae-4f7c-9cc8-e9ddd9d78415",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "0f2e5082-9d97-414d-aa82-d03aed48d81a",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "strain",
+      "uuid": "fe458d54-f002-4a96-a49f-1ca40e679f72",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "64c1e2fd-1d47-4734-8d45-206fb5bd1f57",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "7b8c4795-4317-4145-8240-6c3c19c1067c",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "21c90e54-55b3-4f23-af90-00323964027b",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "wordy",
+      "uuid": "b2c9b704-0266-4c16-a2f7-54294789a7f1",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "a13a649a-3ce8-4bbb-ae93-41441e699c8a",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "46e78725-bc28-4536-9149-9d001033be07",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "ab72941e-040b-4254-8908-1832b602f4ee",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "2e7e50a5-9790-4479-a26a-0e57823b00de",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "9393df8b-f005-4972-a1b9-f9c55dc906bd",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "matrix",
+      "uuid": "ee231adc-6770-47b0-88b2-6a7cf3140224",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "3fc3e55d-ecf0-4c5b-8612-937c96a0cb45",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "say",
+      "uuid": "72f91fb8-88f3-43e3-8a4a-8ad258fa161c",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "89a265f6-37b9-47fb-9ea5-5dba09852e48",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "meetup",
+      "uuid": "bd880111-6a69-4310-a79f-13735471c8ef",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "b190f24e-134f-402b-b2b4-98b3a6f84465",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "70c36cde-e574-4b6d-9f71-3d284694ecb1",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "4866701e-bd9c-41f9-a3e2-43c0ef39ad57",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "5e93b912-3e08-425a-999d-48dca196a442",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "a0832961-e751-4f51-b1d4-e0c5bc5acf27",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "9c855ef0-08b4-4810-9a58-285a44082b94",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sieve",
+      "uuid": "edcec766-70fb-41bd-a2fd-09815a01d76e",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "43a4799d-5bdf-47af-b6e0-fdc74277589d",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "239a4e5e-9a09-4a2d-af2d-252dcf36a3a7",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "ea8450d8-85a3-4530-a5cc-7314abe554eb",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "9986bde0-92cc-434a-b32c-663f789bd41d",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "8cbf6c2c-6f89-4e2e-a63f-5ea5af41f033",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "500cf4b8-d442-423a-957a-b95325b8a718",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "b615b598-d69a-4ba9-9052-79243b292734",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "sublist",
+      "uuid": "4e2c69bc-b83f-45b4-872b-43bbdc559ece",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 1
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "2e604b17-7886-47ad-83a5-1199dc1838a4",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "binary",
+      "uuid": "2e74fa26-f946-4b79-87b9-27f60f03af8f",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "trinary",
+      "uuid": "88643b77-3889-4395-81a0-c73526ce879a",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "742bccfd-20f9-44f1-8935-e84384807088",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "point-mutations",
+      "uuid": "a6f46028-7334-4504-877e-eda8ebdd9ea9",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    }
+  ]
 }

--- a/languages/purescript/config.json
+++ b/languages/purescript/config.json
@@ -26,5 +26,203 @@
       "name": "Booleans",
       "blurb": "TODO: add blurb for booleans concept"
     }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "c41a2961-f7ca-4eaf-83cf-48762fc39c06",
+      "prerequisites": [],
+      "topics": ["maybe", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "1a95beb7-5bb2-44c4-aee7-5790bcb38865",
+      "prerequisites": [],
+      "topics": ["booleans", "modulo"],
+      "difficulty": 1
+    },
+    {
+      "slug": "pangram",
+      "uuid": "aaf7a72c-ada0-4e43-8cc1-78d9e60ee151",
+      "prerequisites": [],
+      "topics": ["chars", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "bob",
+      "uuid": "021a1f60-6086-4d8f-a8be-0f64cfd9620d",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "d530077b-1eed-44cd-9791-5f78001c7372",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "recursion", "type_variables"],
+      "difficulty": 1
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "b2d299f3-c382-4271-bd9e-f9d5615e5403",
+      "prerequisites": [],
+      "topics": ["arithmetics", "math", "maybe"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "b7648fa5-1aff-477c-973c-079245060d73",
+      "prerequisites": [],
+      "topics": ["maybe", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "a686d00c-4dd4-4208-88c9-d17b00d97b28",
+      "prerequisites": [],
+      "topics": ["arithmetics", "arrays", "math", "modulo"],
+      "difficulty": 1
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "f0ce38ee-402f-451d-abd0-e3dc56d5cde4",
+      "prerequisites": [],
+      "topics": ["modulo"],
+      "difficulty": 1
+    },
+    {
+      "slug": "hamming",
+      "uuid": "3cd10a88-9cc0-4dcd-a2f3-1f5bcb5eaf07",
+      "prerequisites": [],
+      "topics": ["iterating_over_two_lists_at_once"],
+      "difficulty": 1
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "c956e70b-4e34-451b-9374-19b9f2aefa37",
+      "prerequisites": [],
+      "topics": ["chars", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "acronym",
+      "uuid": "79a091fa-7987-44e1-9146-fffa28352ee2",
+      "prerequisites": [],
+      "topics": ["chars", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "triangle",
+      "uuid": "d8d3d3dd-01f8-4289-afe2-60595a580240",
+      "prerequisites": [],
+      "topics": ["algebraic_data_types", "type_classes"],
+      "difficulty": 2
+    },
+    {
+      "slug": "word-count",
+      "uuid": "d9bda7fe-51c1-42f0-9631-fcb7ddd163b8",
+      "prerequisites": [],
+      "topics": ["maps", "regex", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "meetup",
+      "uuid": "d0942b01-fe68-46b3-be66-8e19592f666b",
+      "prerequisites": [],
+      "topics": ["dates"],
+      "difficulty": 7
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "d077a175-2219-439c-9bfa-3098239e4cd6",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "bracket-push",
+      "uuid": "dd60d894-9bab-4d53-96a2-11e77aa3e7f8",
+      "prerequisites": [],
+      "topics": ["dates"],
+      "difficulty": 5
+    },
+    {
+      "slug": "allergies",
+      "uuid": "9270773b-20f0-4e82-b0fd-e651af9d8415",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "maps"],
+      "difficulty": 3
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "79011a26-c8b8-4fea-bdce-f8e3d37bee23",
+      "prerequisites": [],
+      "topics": ["base_conversion", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "0029ced5-503b-4491-a309-7f0176598dd0",
+      "prerequisites": [],
+      "topics": ["algorithms", "binary_search"],
+      "difficulty": 5
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "864d3c8b-fffe-4228-87f3-a56173b14eb4",
+      "prerequisites": [],
+      "topics": ["arithmetics", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "diamond",
+      "uuid": "bbaa71d1-be6a-444f-8661-006a40ef8a09",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "e4f49f2e-87bd-4506-9184-d90bec0adde5",
+      "prerequisites": [],
+      "topics": ["matrices", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "isogram",
+      "uuid": "9cb54162-d19c-4155-aca9-e2b26f4d4da5",
+      "prerequisites": [],
+      "topics": ["maps", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "etl",
+      "uuid": "750d7b11-8201-4a83-b743-f2751d1743f6",
+      "prerequisites": [],
+      "topics": ["maps"],
+      "difficulty": 2
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "78527833-8200-4085-8427-650aafb1990c",
+      "prerequisites": [],
+      "topics": ["math", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "83b533f1-a712-4d6a-bc97-505c6e7c9161",
+      "prerequisites": [],
+      "topics": ["arrays", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "09a9ab8e-acaf-4f3d-96ff-789321a53785",
+      "prerequisites": [],
+      "topics": ["conditionals", "pattern_matching", "strings"],
+      "difficulty": 1
+    }
   ]
 }

--- a/languages/python/config.json
+++ b/languages/python/config.json
@@ -106,5 +106,1071 @@
       "name": "Tuples",
       "blurb": "TODO: add blurb for tuples concept"
     }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "f458c48a-4a05-4809-9168-8edd55179349",
+      "prerequisites": [],
+      "topics": ["conditionals", "optional_values", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "4177de10-f767-4306-b45d-5e9c08ef4753",
+      "prerequisites": [],
+      "topics": ["conditionals", "optional_values", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "82d82e32-cb30-4119-8862-d019563dd1e3",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers", "text_formatting"],
+      "difficulty": 2
+    },
+    {
+      "slug": "high-scores",
+      "uuid": "574d6323-5ff5-4019-9ebe-0067daafba13",
+      "prerequisites": [],
+      "topics": ["classes", "conditionals", "sequences", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "matrix",
+      "uuid": "b564927a-f08f-4287-9e8d-9bd5daa7081f",
+      "prerequisites": [],
+      "topics": ["integers", "loops", "matrices", "type_conversion"],
+      "difficulty": 2
+    },
+    {
+      "slug": "hamming",
+      "uuid": "8648fa0c-d85f-471b-a3ae-0f8c05222c89",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "filtering",
+        "logic",
+        "loops",
+        "sequences",
+        "sets",
+        "strings"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "isogram",
+      "uuid": "d1a98c79-d3cc-4035-baab-0e334d2b6a57",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "loops", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "d41238ce-359c-4a9a-81ea-ca5d2c4bb50d",
+      "prerequisites": [],
+      "topics": ["lists", "strings", "text_formatting"],
+      "difficulty": 5
+    },
+    {
+      "slug": "word-count",
+      "uuid": "04316811-0bc3-4377-8ff5-5a300ba41d61",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "logic",
+        "pattern_recognition",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "d081446b-f26b-41a2-ab7f-dd7f6736ecfe",
+      "prerequisites": [],
+      "topics": ["games", "loops", "maps", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "acronym",
+      "uuid": "038c7f7f-02f6-496f-9e16-9372621cc4cd",
+      "prerequisites": [],
+      "topics": ["regular_expressions", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "42a2916c-ef03-44ac-b6d8-7eda375352c2",
+      "prerequisites": [],
+      "topics": ["arrays", "classes", "optional_values", "variables"],
+      "difficulty": 1
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "aadde1a8-ed7a-4242-bfc0-6dddfd382cf3",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "filtering",
+        "integers",
+        "lists",
+        "sorting",
+        "strings"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "luhn",
+      "uuid": "34dde040-672e-472f-bf2e-b87b6f9933c0",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "loops",
+        "pattern_matching",
+        "security"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "clock",
+      "uuid": "459fda78-851e-4bb0-a416-953528f46bd7",
+      "prerequisites": [],
+      "topics": ["classes", "logic", "text_formatting", "time"],
+      "difficulty": 4
+    },
+    {
+      "slug": "markdown",
+      "uuid": "88610b9a-6d3e-4924-a092-6d2f907ed4e2",
+      "prerequisites": [],
+      "topics": ["refactoring", "text_formatting"],
+      "difficulty": 3
+    },
+    {
+      "slug": "tournament",
+      "uuid": "49377a3f-38ba-4d61-b94c-a54cfc9034d0",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "maps", "parsing"],
+      "difficulty": 5
+    },
+    {
+      "slug": "book-store",
+      "uuid": "4899b2ef-675f-4d14-b68a-1a457de91276",
+      "prerequisites": [],
+      "topics": ["lists", "loops", "recursion"],
+      "difficulty": 5
+    },
+    {
+      "slug": "leap",
+      "uuid": "b6acda85-5f62-4d9c-bb4f-42b7a360355a",
+      "prerequisites": [],
+      "topics": ["booleans", "conditionals", "logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rest-api",
+      "uuid": "2abe6eed-c7e4-4ad7-91e3-778bc5176726",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 8
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "d39f86fe-db56-461c-8a93-d87058af8366",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "pangram",
+      "uuid": "bebf7ae6-1c35-48bc-926b-e053a975eb10",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "filtering",
+        "logic",
+        "loops",
+        "strings"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "ca7c5ef1-5135-4fb4-8e68-669ef0f2a51a",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "logic",
+        "loops",
+        "maps",
+        "strings",
+        "transforming"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "7961c852-c87a-44b0-b152-efea3ac8555c",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "integers",
+        "parsing",
+        "strings",
+        "type_conversion"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "22606e91-57f3-44cf-ab2d-94f6ee6402e8",
+      "prerequisites": [],
+      "topics": ["dates", "time"],
+      "difficulty": 1
+    },
+    {
+      "slug": "bob",
+      "uuid": "009a80e2-7901-4d3b-9af2-cdcbcc0b49ae",
+      "prerequisites": [],
+      "topics": ["conditionals", "equality", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "yacht",
+      "uuid": "22f937e5-52a7-4956-9dde-61c985251a6b",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "equality",
+        "games",
+        "integers",
+        "pattern_matching",
+        "sequences"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "505e7bdb-e18d-45fd-9849-0bf33492efd9",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "meetup",
+      "uuid": "a5aff23f-7829-403f-843a-d3312dca31e8",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "dates",
+        "parsing",
+        "pattern_recognition",
+        "strings"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "e9b0defc-dac5-11e7-9296-cec278b6b50a",
+      "prerequisites": [],
+      "topics": ["algorithms", "loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "4c408aab-80b9-475d-9c06-b01cd0fcd08f",
+      "prerequisites": [],
+      "topics": ["logic", "loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "913b6099-d75a-4c27-8243-476081752c31",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "anagram",
+      "uuid": "43eaf8bd-0b4d-4ea9-850a-773f013325ef",
+      "prerequisites": [],
+      "topics": ["algorithms", "logic", "parsing", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "allergies",
+      "uuid": "83627e35-4689-4d9b-a81b-284c2c084466",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "classes", "enumerations"],
+      "difficulty": 1
+    },
+    {
+      "slug": "series",
+      "uuid": "aa4c2e85-b8f8-4309-9708-d8ff805054c2",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "conditionals", "loops"],
+      "difficulty": 1
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "ca474c47-57bb-4995-bf9a-b6937479de29",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "classes",
+        "conditionals",
+        "loops",
+        "tuples",
+        "variables"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "sieve",
+      "uuid": "ad0192e6-7742-4922-a53e-791e25eb9ba3",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "lists", "loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "02b91a90-244d-479e-a039-0e1d328c0be9",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "6e0caa0a-6a1a-4f03-bf0f-e07711f4b069",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "say",
+      "uuid": "2f86ce8e-47c7-4858-89fc-e7729feb0f2f",
+      "prerequisites": [],
+      "topics": ["loops", "parsing", "text_formatting", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "21624a3e-6e43-4c0e-94b0-dee5cdaaf2aa",
+      "prerequisites": [],
+      "topics": ["conditionals", "logic", "loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "07481204-fe88-4aa2-995e-d40d1ae15070",
+      "prerequisites": [],
+      "topics": ["algorithms", "lists", "recursion", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "bffe2007-717a-44ee-b628-b9c86a5001e8",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers", "logic", "loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "space-age",
+      "uuid": "f8303c4d-bbbb-495b-b61b-0f617f7c9a13",
+      "prerequisites": [],
+      "topics": ["conditionals", "floating_point_numbers", "integers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "grains",
+      "uuid": "a24e6d34-9952-44f4-a0cd-02c7fedb4875",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "integers", "type_conversion"],
+      "difficulty": 1
+    },
+    {
+      "slug": "etl",
+      "uuid": "a3b24ef2-303a-494e-8804-e52a67ef406b",
+      "prerequisites": [],
+      "topics": ["loops", "maps", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "41dd9178-76b4-4f78-b71a-b5ff8d12645b",
+      "prerequisites": [],
+      "topics": ["algorithms", "logic", "loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "a5bc16da-8d55-4840-9523-686aebbaaa7e",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "regular_expressions",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "09b2f396-00d7-4d89-ac47-5c444e00dd99",
+      "prerequisites": [],
+      "topics": ["cryptography", "strings", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "e8685468-8006-480f-87c6-6295700def38",
+      "prerequisites": [],
+      "topics": ["strings", "text_formatting", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sublist",
+      "uuid": "cc5eb848-09bc-458c-8fb6-3a17687cb4eb",
+      "prerequisites": [],
+      "topics": ["lists", "loops", "searching"],
+      "difficulty": 1
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "7b53865e-a981-46e0-8e47-6f8e1f3854b3",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "enumerations",
+        "equality",
+        "filtering",
+        "lists",
+        "logic",
+        "loops",
+        "math",
+        "searching",
+        "sets",
+        "tuples",
+        "variables"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "77ee3b0e-a4e9-4257-bcfc-ff2c8f1477ab",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "classes",
+        "conditionals",
+        "exception_handling",
+        "queues"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "bf30b17f-6b71-4bb5-815a-88f8181b89ae",
+      "prerequisites": [],
+      "topics": [
+        "pattern_matching",
+        "randomness",
+        "regular_expressions",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "6434cc19-1ea3-43dd-9580-72267ec76b80",
+      "prerequisites": [],
+      "topics": ["algorithms", "cryptography", "lists", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "a20924d2-fe6d-4714-879f-3239feb9d2f2",
+      "prerequisites": [],
+      "topics": ["algorithms", "lists", "loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "71c96c5f-f3b6-4358-a9c6-fc625e2edda2",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "lists",
+        "loops",
+        "matrices",
+        "sets"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "b7984882-65df-4993-a878-7872c776592a",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "c23ae7a3-3095-4608-8720-ee9ce8938f26",
+      "prerequisites": [],
+      "topics": ["algorithms", "logic", "loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "0d5b2a0e-31ff-4c8c-a155-0406f7dca3ae",
+      "prerequisites": [],
+      "topics": [
+        "bitwise_operations",
+        "conditionals",
+        "integers",
+        "lists",
+        "logic",
+        "loops",
+        "transforming"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "fa795dcc-d390-4e98-880c-6e8e638485e3",
+      "prerequisites": [],
+      "topics": ["loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "45229a7c-6703-4240-8287-16645881a043",
+      "prerequisites": [],
+      "topics": ["parsing", "recursion", "stacks", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "7e768b54-4591-4a30-9ddb-66ca13400ca3",
+      "prerequisites": [],
+      "topics": ["games", "lists", "loops", "parsing", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "b280c252-5320-4e53-8294-1385d564eb02",
+      "prerequisites": [],
+      "topics": ["arrays", "exception_handling", "games", "logic", "matrices"],
+      "difficulty": 1
+    },
+    {
+      "slug": "wordy",
+      "uuid": "af50bb9a-e400-49ce-966f-016c31720be1",
+      "prerequisites": [],
+      "topics": [
+        "logic",
+        "parsing",
+        "pattern_matching",
+        "regular_expressions",
+        "transforming",
+        "type_conversion"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "f384c6f8-987d-41a2-b504-e50506585526",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "pattern_matching",
+        "regular_expressions",
+        "strings"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "98ca48ed-5818-442c-bce1-308c8b3b3b77",
+      "prerequisites": [],
+      "topics": ["lists", "parsing", "pattern_recognition"],
+      "difficulty": 1
+    },
+    {
+      "slug": "house",
+      "uuid": "7c2e93ae-d265-4481-b583-a496608c6031",
+      "prerequisites": [],
+      "topics": [
+        "pattern_recognition",
+        "recursion",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "triangle",
+      "uuid": "f0bc144f-3226-4e53-93ee-e60316b29e31",
+      "prerequisites": [],
+      "topics": [
+        "classes",
+        "conditionals",
+        "object_oriented_programming",
+        "pattern_matching"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "dot-dsl",
+      "uuid": "a9c2fbda-a1e4-42dd-842f-4de5bb361b91",
+      "prerequisites": [],
+      "topics": [
+        "classes",
+        "domain_specific_languages",
+        "equality",
+        "graphs",
+        "lists",
+        "object_oriented_programming",
+        "test_driven_development",
+        "transforming"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "transpose",
+      "uuid": "dc6e61a2-e9b9-4406-ba5c-188252afbba1",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "tree-building",
+      "uuid": "aeaed0e4-0973-4035-8bc5-07480849048f",
+      "prerequisites": [],
+      "topics": ["maps", "records", "refactoring", "sorting", "trees"],
+      "difficulty": 3
+    },
+    {
+      "slug": "poker",
+      "uuid": "dcc0ee26-e384-4bd4-8c4b-613fa0bb8188",
+      "prerequisites": [],
+      "topics": ["conditionals", "lists", "loops", "parsing"],
+      "difficulty": 1
+    },
+    {
+      "slug": "zebra-puzzle",
+      "uuid": "7e1d90d5-dbc9-47e0-8e26-c3ff83b73c2b",
+      "prerequisites": [],
+      "topics": ["logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rectangles",
+      "uuid": "4bebdd8d-a032-4993-85c5-7cc74fc89312",
+      "prerequisites": [],
+      "topics": ["algorithms", "logic", "pattern_recognition"],
+      "difficulty": 1
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "a8288e93-93c5-4e0f-896c-2a376f6f6e5e",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "lists", "loops", "searching"],
+      "difficulty": 1
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "818c6472-b734-4ff4-8016-ce540141faec",
+      "prerequisites": [],
+      "topics": [
+        "callbacks",
+        "conditionals",
+        "filtering",
+        "functional_programming",
+        "lists",
+        "loops",
+        "searching",
+        "variables"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "4c6edc8a-7bc0-4386-a653-d1091fe49301",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "lists"],
+      "difficulty": 1
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "ca7a8b16-e5d5-4211-84f0-2f8e35b4a665",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "lists"],
+      "difficulty": 3
+    },
+    {
+      "slug": "rational-numbers",
+      "uuid": "1d21cd68-10ac-427d-be6d-77152bceacc4",
+      "prerequisites": [],
+      "topics": ["classes", "equality", "floating_point_numbers", "math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "diamond",
+      "uuid": "a7bc6837-59e4-46a1-89a2-a5aa44f5e66e",
+      "prerequisites": [],
+      "topics": ["lists", "loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "variable-length-quantity",
+      "uuid": "aa4332bd-fc38-47a4-8bff-e1b660798418",
+      "prerequisites": [],
+      "topics": ["algorithms", "bitwise_operations", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "a2ff75f9-8b2c-4c4b-975d-913711def9ab",
+      "prerequisites": [],
+      "topics": ["integers", "math", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "grep",
+      "uuid": "ecc97fc6-2e72-4325-9b67-b56c83b13a91",
+      "prerequisites": [],
+      "topics": ["files", "searching", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "bowling",
+      "uuid": "ca970fee-71b4-41e1-a5c3-b23bf574eb33",
+      "prerequisites": [],
+      "topics": ["classes", "exception_handling", "logic"],
+      "difficulty": 5
+    },
+    {
+      "slug": "word-search",
+      "uuid": "dc2917d5-aaa9-43d9-b9f4-a32919fdbe18",
+      "prerequisites": [],
+      "topics": ["searching", "strings"],
+      "difficulty": 6
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "66466141-485c-470d-b73b-0a3d5a957c3d",
+      "prerequisites": [],
+      "topics": ["conditionals", "logic"],
+      "difficulty": 6
+    },
+    {
+      "slug": "scale-generator",
+      "uuid": "8cd58325-61fc-46fd-85f9-425b4c41f3de",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "c89243f3-703e-4fe0-8e43-f200eedf2825",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "change",
+      "uuid": "889df88a-767d-490f-92c4-552d8ec9de34",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "loops"],
+      "difficulty": 4
+    },
+    {
+      "slug": "connect",
+      "uuid": "f5503274-ac23-11e7-abc4-cec278b6b50a",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "33f689ee-1d9c-4908-a71c-f84bff3510df",
+      "prerequisites": [],
+      "topics": ["loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "go-counting",
+      "uuid": "d4ddeb18-ac22-11e7-abc4-cec278b6b50a",
+      "prerequisites": [],
+      "topics": ["classes", "control_flow", "parsing", "tuples"],
+      "difficulty": 4
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "7f4d5743-7ab8-42ca-b393-767f7e9a4e97",
+      "prerequisites": [],
+      "topics": ["equality", "math", "tuples"],
+      "difficulty": 6
+    },
+    {
+      "slug": "diffie-hellman",
+      "uuid": "92e2d5f8-7d8a-4e81-a55c-52fa6be80c74",
+      "prerequisites": [],
+      "topics": ["algorithms", "math"],
+      "difficulty": 7
+    },
+    {
+      "slug": "two-bucket",
+      "uuid": "6f530d0c-d13e-4270-b120-e42c16691a66",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "control_flow", "loops"],
+      "difficulty": 5
+    },
+    {
+      "slug": "forth",
+      "uuid": "14e1dfe3-a45c-40c1-bf61-2e4f0cca5579",
+      "prerequisites": [],
+      "topics": ["parsing", "stacks"],
+      "difficulty": 5
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "f229746e-5ea9-4774-b3e0-9b9c2ebf9558",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "loops"],
+      "difficulty": 4
+    },
+    {
+      "slug": "zipper",
+      "uuid": "569210ea-71c1-4fd2-941e-6bf0d953019e",
+      "prerequisites": [],
+      "topics": ["recursion", "searching", "trees"],
+      "difficulty": 8
+    },
+    {
+      "slug": "error-handling",
+      "uuid": "0dac0feb-e1c8-497e-9a1b-e96e0523eea6",
+      "prerequisites": [],
+      "topics": ["exception_handling"],
+      "difficulty": 3
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "54995590-65eb-4178-a527-0d7b1526a843",
+      "prerequisites": [],
+      "topics": ["lists", "tuples"],
+      "difficulty": 7
+    },
+    {
+      "slug": "pov",
+      "uuid": "d98b1080-36d4-4357-b12a-685d204856bf",
+      "prerequisites": [],
+      "topics": ["graphs", "recursion", "searching", "trees"],
+      "difficulty": 9
+    },
+    {
+      "slug": "react",
+      "uuid": "4c0d0d6b-347e-40ae-9b51-08555fe76cb9",
+      "prerequisites": [],
+      "topics": ["callbacks", "events", "reactive_programming"],
+      "difficulty": 8
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "df7cd9b9-283a-4466-accf-98c4a7609450",
+      "prerequisites": [],
+      "topics": [
+        "classes",
+        "object_oriented_programming",
+        "recursion",
+        "searching",
+        "trees"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "hangman",
+      "uuid": "adad6be5-855d-4d61-b14a-22e468ba5b44",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "bb07c236-062c-2980-483a-a221e4724445dcd6f32",
+      "prerequisites": [],
+      "topics": ["sets"],
+      "difficulty": 5
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "b0c7cf95-6470-4c1a-8eaa-6775310926a2",
+      "prerequisites": [],
+      "topics": ["algorithms", "control_flow", "lists"],
+      "difficulty": 2
+    },
+    {
+      "slug": "sgf-parsing",
+      "uuid": "0d6325d1-c0a3-456e-9a92-cea0559e82ed",
+      "prerequisites": [],
+      "topics": ["parsing", "trees"],
+      "difficulty": 7
+    },
+    {
+      "slug": "bank-account",
+      "uuid": "83a3ff95-c043-401c-bc2c-547d52344b02",
+      "prerequisites": [],
+      "topics": ["classes", "concurrency", "conditionals"],
+      "difficulty": 4
+    },
+    {
+      "slug": "ledger",
+      "uuid": "c2e9d08d-1a58-4d9a-a797-cea265973bd4",
+      "prerequisites": [],
+      "topics": ["globalization", "refactoring", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "affine-cipher",
+      "uuid": "02bf6783-fc74-47e9-854f-44d22eb1b6f8",
+      "prerequisites": [],
+      "topics": ["algorithms", "cryptography", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "dnd-character",
+      "uuid": "58625685-b5cf-4e8a-b3aa-bff54da0689d",
+      "prerequisites": [],
+      "topics": ["integers", "randomness"],
+      "difficulty": 1
+    },
+    {
+      "slug": "satellite",
+      "uuid": "18467e72-e3b0-403c-896a-ce337f96e6f7",
+      "prerequisites": [],
+      "topics": ["pattern_recognition", "recursion", "transforming", "trees"],
+      "difficulty": 7
+    },
+    {
+      "slug": "darts",
+      "uuid": "cb581e2c-66ab-4221-9884-44bacb7c4ebe",
+      "prerequisites": [],
+      "topics": ["conditionals", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "resistor-color",
+      "uuid": "d17bee9c-e803-4745-85ea-864f255fb04e",
+      "prerequisites": [],
+      "topics": ["arrays"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color-duo",
+      "uuid": "089f06a6-0759-479c-8c00-d699525a1e22",
+      "prerequisites": [],
+      "topics": ["arrays"],
+      "difficulty": 1
+    },
+    {
+      "slug": "knapsack",
+      "uuid": "b0301d0b-d97a-4043-bd82-ba1edf8c1b16",
+      "prerequisites": [],
+      "topics": ["algorithms", "lists", "loops"],
+      "difficulty": 5
+    },
+    {
+      "slug": "paasio",
+      "uuid": "ec36f9ed-f376-43d9-90ee-be0bea0cfc98",
+      "prerequisites": [],
+      "topics": ["classes", "interfaces", "networking"],
+      "difficulty": 5
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "e7351e8e-d3ff-4621-b818-cd55cf05bffd",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "105f25ec-7ce2-4797-893e-05e3792ebd91",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "octal",
+      "uuid": "4094d27f-4d03-4308-9fd7-9f3de312afec",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "e1e1c7d7-c1d9-4027-b90d-fad573182419",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "point-mutations",
+      "uuid": "d85ec4f2-c201-4eff-9f3a-831a0cc38e8d",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "proverb",
+      "uuid": "9fd94229-f974-45bb-97ea-8bfe484f6eb3",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "strain",
+      "uuid": "b50b29a1-782d-4277-a4d4-23f635fbdaa6",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "trinary",
+      "uuid": "061a6543-d51d-4619-891b-16f92c6435ca",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "binary",
+      "uuid": "49127efa-1124-4f27-bee4-99992e3433de",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "6b7f7b1f-c388-4f4c-b924-84535cc5e1a0",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "parallel-letter-frequency",
+      "uuid": "da03fca4-4606-48d8-9137-6e40396f7759",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    }
   ]
 }

--- a/languages/ruby/config.json
+++ b/languages/ruby/config.json
@@ -129,5 +129,818 @@
       "name": "Strings",
       "blurb": "TODO: add blurb for strings concept"
     }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "4fe19484-4414-471b-a106-73c776c61388",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "1304b188-6d08-4361-be40-c6b1b88e5e54",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color-duo",
+      "uuid": "57b0c57e-26a5-4ccf-aaf2-2fefddd918c1",
+      "prerequisites": [],
+      "topics": ["array", "loops"],
+      "difficulty": 1
+    },
+    {
+      "slug": "acronym",
+      "uuid": "74468206-68a2-4efb-8caa-782634674c7f",
+      "prerequisites": [],
+      "topics": ["regular_expressions", "strings", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "high-scores",
+      "uuid": "9124339c-94fb-46eb-aad2-25944214799d",
+      "prerequisites": [],
+      "topics": ["arrays"],
+      "difficulty": 2
+    },
+    {
+      "slug": "matrix",
+      "uuid": "3de21c18-a533-4150-8a73-49df8fcb8c61",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "exception_handling",
+        "matrices",
+        "strings",
+        "type_conversion"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "series",
+      "uuid": "2de036e4-576d-47fc-bb03-4ed1612e79da",
+      "prerequisites": [],
+      "topics": ["arrays", "enumerable", "loops"],
+      "difficulty": 3
+    },
+    {
+      "slug": "word-count",
+      "uuid": "e9d29769-8d4d-4159-8d6f-762db5339707",
+      "prerequisites": [],
+      "topics": ["enumerable", "hash", "loops"],
+      "difficulty": 3
+    },
+    {
+      "slug": "hamming",
+      "uuid": "d33dec8a-e2b4-40bc-8be9-3f49de084d43",
+      "prerequisites": [],
+      "topics": ["equality", "loops", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "efad2cea-1e0b-4fb8-a452-a8e91be73638",
+      "prerequisites": [],
+      "topics": ["conditionals", "filtering", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "isogram",
+      "uuid": "a79eb8cd-d2db-48f5-a7dc-055039dcee62",
+      "prerequisites": [],
+      "topics": ["regular_expressions", "sequences", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "d934ebce-9ac3-4a41-bcb8-d70480170438",
+      "prerequisites": [],
+      "topics": ["loops", "maps", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "luhn",
+      "uuid": "bee97539-b8c1-460e-aa14-9336008df2b6",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "clock",
+      "uuid": "f95ebf09-0f32-4e60-867d-60cb81dd9a62",
+      "prerequisites": [],
+      "topics": ["equality", "text_formatting", "time"],
+      "difficulty": 3
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "eeb64dda-b79f-4920-8fa3-04810e8d37ab",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "pattern_recognition",
+        "sequences",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "tournament",
+      "uuid": "486becee-9d85-4139-ab89-db254d385ade",
+      "prerequisites": [],
+      "topics": [
+        "integers",
+        "parsing",
+        "records",
+        "sorting",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "77c5c7e6-265a-4f1a-9bc4-851f8f825420",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "f1e4ee0c-8718-43f2-90a5-fb1e915288da",
+      "prerequisites": [],
+      "topics": ["algorithms", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "0fb594a1-193b-4ccf-8de2-eb6a81708b29",
+      "prerequisites": [],
+      "topics": ["time"],
+      "difficulty": 1
+    },
+    {
+      "slug": "grains",
+      "uuid": "22519f53-4516-43bc-915e-07d58e48f617",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "41f66d2a-1883-4a2c-875f-663c46fa88aa",
+      "prerequisites": [],
+      "topics": ["maps", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "76a0fd0a-cc65-4be3-acc8-7348bb67ad5a",
+      "prerequisites": [],
+      "topics": ["randomness"],
+      "difficulty": 3
+    },
+    {
+      "slug": "pangram",
+      "uuid": "fcf07149-b2cb-4042-90e6-fb3350e0fdf6",
+      "prerequisites": [],
+      "topics": ["loops", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "sieve",
+      "uuid": "80f9af5a-ea29-4937-9333-b4494aaf2446",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "loops", "math", "sorting"],
+      "difficulty": 3
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "b7ca9519-c33b-418b-a4ef-858a3d4d6855",
+      "prerequisites": [],
+      "topics": ["numbers", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "16baef71-6234-4928-a2d4-a19eb8e110b8",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "leap",
+      "uuid": "06eaa2dd-dc80-4d38-b10d-11174183b0b6",
+      "prerequisites": [],
+      "topics": ["booleans", "conditionals", "integers", "logic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "bob",
+      "uuid": "70fec82e-3038-468f-96ef-bfb48ce03ef3",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "9d6a8c89-41c1-4c4e-b24c-476ba0dfa5f9",
+      "prerequisites": [],
+      "topics": ["parsing", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "binary",
+      "uuid": "43bc27ed-d2fa-4173-8665-4459b71c9a3a",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "2c71fc3a-2c93-402b-b091-697b795ce3ba",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "4fc25295-5d6a-4d13-9b87-064167d8980e",
+      "prerequisites": [],
+      "topics": ["loops", "math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "4460742c-2beb-48d7-94e6-72ff13c68c71",
+      "prerequisites": [],
+      "topics": ["lists", "sorting", "structs"],
+      "difficulty": 5
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "b68665d5-14ef-4351-ac4a-c28a80c27b3d",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "regular_expressions",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "a18daa31-88d3-45ba-84ca-f1d52fe23a79",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "strain",
+      "uuid": "ac0966a9-822b-45be-91d9-36f6706ea76f",
+      "prerequisites": [],
+      "topics": ["arrays", "filtering", "loops"],
+      "difficulty": 2
+    },
+    {
+      "slug": "etl",
+      "uuid": "0d66f3db-69a4-44b9-80be-9366f8b189ec",
+      "prerequisites": [],
+      "topics": ["loops", "maps", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "trinary",
+      "uuid": "f6735416-4be6-4eb8-b6b9-cb61671ce25e",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "50c34698-7767-42b3-962f-21c735e49787",
+      "prerequisites": [],
+      "topics": ["loops", "strings", "text_formatting"],
+      "difficulty": 3
+    },
+    {
+      "slug": "bowling",
+      "uuid": "051f0825-8357-4ca6-b24f-40a373deac19",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "conditionals"],
+      "difficulty": 5
+    },
+    {
+      "slug": "space-age",
+      "uuid": "c971a2b5-ccd4-4e55-9fc7-33e991bc0676",
+      "prerequisites": [],
+      "topics": ["floating_point_numbers", "if_else_statements"],
+      "difficulty": 2
+    },
+    {
+      "slug": "anagram",
+      "uuid": "36df18ba-580d-4982-984e-ba50eb1f8c0b",
+      "prerequisites": [],
+      "topics": ["filtering", "parsing", "sorting", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "0e05bfcf-17ae-4884-803a-fa1428bc1702",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "recursion",
+        "searching",
+        "sorting",
+        "structs",
+        "trees"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "86f8e33d-31b7-43e3-8ea3-2e391133704a",
+      "prerequisites": [],
+      "topics": [
+        "cryptography",
+        "filtering",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "2323a2a5-c181-4c1e-9c5f-f6b92b2de511",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "searching"],
+      "difficulty": 5
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "64196fe5-2270-4113-a614-fbfbb6d00f2b",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "cryptography",
+        "loops",
+        "sorting",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "8ad2bffd-1d79-4e1f-8ef3-ece0214d2804",
+      "prerequisites": [],
+      "topics": ["maps", "parsing", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "2df8ed82-2a04-4112-a17b-7813bcdc0e84",
+      "prerequisites": [],
+      "topics": ["arrays", "recursion"],
+      "difficulty": 3
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "6984cc14-91f8-47a7-b7e2-4b210a5dbc5c",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "say",
+      "uuid": "2a410923-6445-41fc-9cf3-a60209e1c1c2",
+      "prerequisites": [],
+      "topics": ["numbers", "strings", "text_formatting", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "meetup",
+      "uuid": "8120e133-9561-4f82-8081-10c19f7f6ba3",
+      "prerequisites": [],
+      "topics": ["dates", "time", "transforming", "type_conversion"],
+      "difficulty": 3
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "2ce9b158-e730-4c86-8639-bd08af9f80f4",
+      "prerequisites": [],
+      "topics": ["booleans", "errors", "games", "logic"],
+      "difficulty": 5
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "abd68340-91b9-48c1-8567-79822bb2165c",
+      "prerequisites": [],
+      "topics": ["algorithms", "math"],
+      "difficulty": 6
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "26f6e297-7980-4472-8ce7-157b62b0ff40",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 7
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "6f0919eb-2160-4cca-8504-286acc2ae9c8",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "loops",
+        "recursion",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "38bb4ac6-a5ec-4448-8b86-cdaff13a8be3",
+      "prerequisites": [],
+      "topics": ["arrays", "integers", "matrices", "searching"],
+      "difficulty": 5
+    },
+    {
+      "slug": "triangle",
+      "uuid": "5c797eb2-155d-47ca-8f85-2ba5803f9713",
+      "prerequisites": [],
+      "topics": ["booleans", "conditionals", "logic"],
+      "difficulty": 3
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "1e737640-9785-4a47-866a-46298104d891",
+      "prerequisites": [],
+      "topics": ["algorithms", "cryptography", "strings", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "house",
+      "uuid": "df5d771a-e57b-4a96-8a29-9bd4ce7f88d2",
+      "prerequisites": [],
+      "topics": ["recursion", "strings", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "c1ebad1b-d5aa-465a-b5ef-9e717ab5db9e",
+      "prerequisites": [],
+      "topics": ["arrays", "bitwise_operations", "integers"],
+      "difficulty": 5
+    },
+    {
+      "slug": "proverb",
+      "uuid": "3c5193ab-6471-4be2-9d24-1d2b51ad822a",
+      "prerequisites": [],
+      "topics": ["arrays", "loops", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "dd13bb29-589c-497d-9580-3f288f353fb2",
+      "prerequisites": [],
+      "topics": ["parsing", "pattern_recognition"],
+      "difficulty": 7
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "efc0e498-891a-4e91-a6aa-fae635573a83",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "fa7b91c2-842c-42c8-bdf9-00bb3e71a7f5",
+      "prerequisites": [],
+      "topics": ["arrays", "loops"],
+      "difficulty": 4
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "29c66e8a-b1b0-4bbd-be7b-9979ff51ba8f",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "cryptography",
+        "interfaces",
+        "strings",
+        "transforming"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "wordy",
+      "uuid": "cb58e4cf-e3af-469c-9f2d-02557b9f61ed",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "integers",
+        "parsing",
+        "strings",
+        "type_conversion"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "allergies",
+      "uuid": "b306bdaa-438e-46a2-ba54-82cb2c0be882",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "enumeration"],
+      "difficulty": 4
+    },
+    {
+      "slug": "poker",
+      "uuid": "9a59ba44-34f5-410b-a1e6-9a5c47c52d9e",
+      "prerequisites": [],
+      "topics": [
+        "equality",
+        "games",
+        "parsing",
+        "pattern_matching",
+        "sequences",
+        "strings"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "04bde625-e363-4d8b-880f-db7bf86286eb",
+      "prerequisites": [],
+      "topics": ["parsing", "records", "searching", "strings", "structs"],
+      "difficulty": 3
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "7cb55328-1b11-4544-94c0-945444d9a6a4",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "math", "sequences"],
+      "difficulty": 3
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "43aad536-0e24-464c-9554-cbc2699d0543",
+      "prerequisites": [],
+      "topics": ["algorithms", "math"],
+      "difficulty": 5
+    },
+    {
+      "slug": "scale-generator",
+      "uuid": "4134d491-8ec5-480b-aa61-37a02689db1f",
+      "prerequisites": [],
+      "topics": ["pattern_matching", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "00c6f623-2e54-4f90-ae3f-07e493f93c7c",
+      "prerequisites": [],
+      "topics": ["filtering", "maps", "sequences"],
+      "difficulty": 3
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "76ad732a-6e58-403b-ac65-9091d355241f",
+      "prerequisites": [],
+      "topics": ["algorithms", "filtering", "integers", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "f3419fe3-a5f5-4bc9-bc40-49f450b8981e",
+      "prerequisites": [],
+      "topics": ["queues", "structs"],
+      "difficulty": 5
+    },
+    {
+      "slug": "diamond",
+      "uuid": "c55c75fb-6140-4042-967a-39c75b7781bd",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "conditionals",
+        "loops",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "4f74b3cd-f995-4b8c-9b57-23f073261d0e",
+      "prerequisites": [],
+      "topics": ["filtering", "loops", "sets"],
+      "difficulty": 4
+    },
+    {
+      "slug": "transpose",
+      "uuid": "4a6bc7d3-5d3b-4ad8-96ae-783e17af7c32",
+      "prerequisites": [],
+      "topics": ["loops", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "4ff8b056-f27d-4bdf-b7af-214448db4260",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "math", "recursion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "92c9aafc-791d-4aaf-a136-9bee14f6ff95",
+      "prerequisites": [],
+      "topics": ["data_structure", "pointer"],
+      "difficulty": 4
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "b1ba445d-4908-4922-acc0-de3a0ec92c53",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "searching", "sorting"],
+      "difficulty": 5
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "9d6808fb-d367-4df9-a1f0-47ff83b75544",
+      "prerequisites": [],
+      "topics": ["arrays", "games", "loops", "matrices", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "724e6a6e-2e6e-45a9-ab0e-0d8d50a06085",
+      "prerequisites": [],
+      "topics": ["concurrency", "loops", "sequences", "strings", "structs"],
+      "difficulty": 6
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "3ce4bd3e-0380-498a-8d0a-b79cf3fedc10",
+      "prerequisites": [],
+      "topics": ["integers", "math", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "connect",
+      "uuid": "538a6768-bae5-437c-9cdf-765d73a79643",
+      "prerequisites": [],
+      "topics": ["arrays", "games", "graphs", "loops", "searching"],
+      "difficulty": 9
+    },
+    {
+      "slug": "change",
+      "uuid": "dc6c3e44-1027-4d53-9653-ba06824f8bcf",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "loops", "searching"],
+      "difficulty": 5
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "af961c87-341c-4dd3-a1eb-272501b9b0e4",
+      "prerequisites": [],
+      "topics": ["conditionals", "control_flow_loops", "integers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "book-store",
+      "uuid": "0ec96460-08be-49a0-973a-4336f21b763c",
+      "prerequisites": [],
+      "topics": ["algorithms", "floating_point_numbers", "integers", "lists"],
+      "difficulty": 8
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "af5ccf14-eff2-4dc6-b1db-e209cddca62a",
+      "prerequisites": [],
+      "topics": ["cryptography", "integers", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "a0aac827-8f7a-4065-9d05-a57009f5668d",
+      "prerequisites": [],
+      "topics": ["arrays"],
+      "difficulty": 2
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "705f3eb6-55a9-476c-b3f2-e9f3cb0bbe37",
+      "prerequisites": [],
+      "topics": ["algorithms", "arrays", "searching"],
+      "difficulty": 4
+    },
+    {
+      "slug": "two-bucket",
+      "uuid": "e5a2d445-437d-46a8-889b-fbcd62c70fa9",
+      "prerequisites": [],
+      "topics": ["algorithms", "conditionals", "searching"],
+      "difficulty": 5
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "f62e8acb-8370-46e1-ad7f-a6a2644f8602",
+      "prerequisites": [],
+      "topics": [
+        "functional_programming",
+        "lists",
+        "recursion",
+        "type_conversion"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "octal",
+      "uuid": "cae4e000-3aac-41f7-b727-f9cce12d058d",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "affine-cipher",
+      "uuid": "d1267415-aff5-411d-b267-49a4a2c8fda2",
+      "prerequisites": [],
+      "topics": ["cryptography", "math", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "d75bd7c0-52c5-44f2-a046-f63cb332425f",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "point-mutations",
+      "uuid": "89bd3d71-000f-4cd9-9a84-ad1b22ddbd33",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "zipper",
+      "uuid": "239b8e79-2983-4ce0-9dda-9bb999e79d11",
+      "prerequisites": [],
+      "topics": ["data_structures"],
+      "difficulty": 7
+    },
+    {
+      "slug": "grep",
+      "uuid": "99485900-5d16-4848-af1c-2f1a62ad35ab",
+      "prerequisites": [],
+      "topics": [
+        "files",
+        "parsing",
+        "pattern_matching",
+        "regular_expressions",
+        "strings",
+        "text_formatting"
+      ],
+      "difficulty": 8
+    },
+    {
+      "slug": "resistor-color",
+      "uuid": "685634dd-0b38-40bc-b0ad-e8aa2904035f",
+      "prerequisites": [],
+      "topics": ["arrays"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color-trio",
+      "uuid": "2df14b68-75c8-4984-8ae2-ecd2cb7ed1d4",
+      "prerequisites": [],
+      "topics": ["loops"],
+      "difficulty": 5
+    },
+    {
+      "slug": "darts",
+      "uuid": "15b73808-78a4-4854-b7cf-82a478107024",
+      "prerequisites": [],
+      "topics": ["math", "geometry"],
+      "difficulty": 3
+    },
+    {
+      "slug": "microwave",
+      "uuid": "b960d0fe-a07f-11ea-bb37-0242ac130002",
+      "prerequisites": [],
+      "topics": ["math", "strings", "interpolation"],
+      "difficulty": 2
+    }
   ]
 }

--- a/languages/rust/config.json
+++ b/languages/rust/config.json
@@ -140,5 +140,754 @@
       "name": "Structs",
       "blurb": "TODO: add blurb for structs concept"
     }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "13ec1ebe-d71b-436f-ab12-25305e814171",
+      "prerequisites": [],
+      "topics": ["strings", "test_driven_development"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "ef52f576-9c33-4cc1-a018-803ace8897f6",
+      "prerequisites": [],
+      "topics": ["booleans", "conditionals"],
+      "difficulty": 1
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "2c12be9b-3a02-4161-8eac-050642ad791f",
+      "prerequisites": [],
+      "topics": ["conditionals", "strings", "type_conversion", "variables"],
+      "difficulty": 1
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "ee5048a7-c625-434d-a0a2-4fd54757ee02",
+      "prerequisites": [],
+      "topics": ["loops", "math", "primes"],
+      "difficulty": 1
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "bb42bc3a-139d-4cab-8b3a-2eac2e1b77b6",
+      "prerequisites": [],
+      "topics": ["case", "loops", "strings", "vectors"],
+      "difficulty": 1
+    },
+    {
+      "slug": "proverb",
+      "uuid": "504f9033-6433-4508-aebb-60ee77b800b9",
+      "prerequisites": [],
+      "topics": ["format"],
+      "difficulty": 1
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "aee49878-f727-400b-8fb5-eaf83447cf87",
+      "prerequisites": [],
+      "topics": ["fold", "map", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "be90fe16-9947-45ef-ab8e-eeca4ce3a8c8",
+      "prerequisites": [],
+      "topics": ["algorithms", "borrowing", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "grains",
+      "uuid": "9e69dd5d-472d-43d7-a8bb-60e4a7bed175",
+      "prerequisites": [],
+      "topics": ["panic"],
+      "difficulty": 1
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "9f649818-0c82-4b79-b912-4d65b9f60e10",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "e652139e-ff3f-4e03-9810-d21f8b0c9e60",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "ecf8d1e3-9400-4d1a-8326-2e2820bce024",
+      "prerequisites": [],
+      "topics": ["iterators", "str_vs_string", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "f880b1ef-8f66-41f3-bb89-f39a4ed592a2",
+      "prerequisites": [],
+      "topics": ["crates"],
+      "difficulty": 1
+    },
+    {
+      "slug": "high-scores",
+      "uuid": "7e0f5d25-e1f2-4a25-b150-1c8b24f328d7",
+      "prerequisites": [],
+      "topics": ["iterators", "lifetimes", "vectors"],
+      "difficulty": 1
+    },
+    {
+      "slug": "bob",
+      "uuid": "38ef1802-2730-4f94-bafe-d2cd6b3e7f95",
+      "prerequisites": [],
+      "topics": ["chars", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "40729822-4265-4c14-b03f-a00bff5f24bb",
+      "prerequisites": [],
+      "topics": ["stack_or_recursion"],
+      "difficulty": 1
+    },
+    {
+      "slug": "clock",
+      "uuid": "543a3ca2-fb9b-4f20-a873-ff23595d41df",
+      "prerequisites": [],
+      "topics": ["derive", "structs", "traits"],
+      "difficulty": 4
+    },
+    {
+      "slug": "dot-dsl",
+      "uuid": "7bc60899-3b12-4c51-b23b-8dced5845e4c",
+      "prerequisites": [],
+      "topics": ["builder_pattern", "derive", "modules", "structs"],
+      "difficulty": 4
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "10923b0b-c726-44a7-9e02-b775e7b8b237",
+      "prerequisites": [],
+      "topics": ["lists", "structs", "type_conversion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "ddc0c1da-6b65-4ed1-8bdc-5e71cd05f720",
+      "prerequisites": [],
+      "topics": ["index", "math", "vectors"],
+      "difficulty": 4
+    },
+    {
+      "slug": "paasio",
+      "uuid": "8c24c151-d22a-4818-83b5-4fe0f919e3fd",
+      "prerequisites": [],
+      "topics": ["io", "traits"],
+      "difficulty": 4
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "3f54853b-cc65-4282-ab25-8dc3fdf43c03",
+      "prerequisites": [],
+      "topics": ["entry_api", "filter", "match", "mutability", "result_type"],
+      "difficulty": 4
+    },
+    {
+      "slug": "etl",
+      "uuid": "0c8eeef7-4bab-4cf9-9047-c208b5618312",
+      "prerequisites": [],
+      "topics": ["btree"],
+      "difficulty": 4
+    },
+    {
+      "slug": "acronym",
+      "uuid": "26a9102f-26f6-4238-858e-ba20db66f1a9",
+      "prerequisites": [],
+      "topics": ["filter", "flat_map", "loops", "map", "vectors"],
+      "difficulty": 4
+    },
+    {
+      "slug": "sieve",
+      "uuid": "da784b42-1cec-469e-8e48-0be232b17003",
+      "prerequisites": [],
+      "topics": ["map", "math", "vectors", "while_let"],
+      "difficulty": 4
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "9a219d87-cd32-4e12-a879-bfb5747c2369",
+      "prerequisites": [],
+      "topics": ["match", "result_type", "str_vs_string", "strings", "structs"],
+      "difficulty": 4
+    },
+    {
+      "slug": "triangle",
+      "uuid": "c0bc2af6-d7af-401f-9ed8-bbe31977666c",
+      "prerequisites": [],
+      "topics": ["structs"],
+      "difficulty": 4
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "5ca03812-c229-48db-b7fd-0889b22f8d1d",
+      "prerequisites": [],
+      "topics": ["entry_api", "option_type", "structs", "vectors"],
+      "difficulty": 4
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "dd74b65c-0d26-4821-9add-064e32e3a5bd",
+      "prerequisites": [],
+      "topics": ["option_type", "slices", "traits"],
+      "difficulty": 4
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "1beb8b0c-d06d-4569-80e5-866ed01a7a66",
+      "prerequisites": [],
+      "topics": ["enums", "immutability"],
+      "difficulty": 7
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "30c33e3d-8034-4618-8346-2ae906961579",
+      "prerequisites": [],
+      "topics": ["result_type", "structs", "traits"],
+      "difficulty": 4
+    },
+    {
+      "slug": "bowling",
+      "uuid": "fec447a5-cf11-4ddd-b0fd-63bcc4e245cd",
+      "prerequisites": [],
+      "topics": ["goofy_bowling_logic", "result_type", "structs"],
+      "difficulty": 4
+    },
+    {
+      "slug": "tournament",
+      "uuid": "9a2406cc-5037-4761-b820-bb25b1d397c8",
+      "prerequisites": [],
+      "topics": ["enums", "hashmaps", "sorting", "structs"],
+      "difficulty": 4
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "7450bd80-2388-42ac-a61f-097e82581475",
+      "prerequisites": [],
+      "topics": ["combinations", "external_crates", "parsing", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "two-bucket",
+      "uuid": "1850fb3f-9dad-449a-90b6-9d90038cf34d",
+      "prerequisites": [],
+      "topics": ["algorithms", "loops"],
+      "difficulty": 4
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "8dea3473-36f4-4228-b24b-bee8d9389167",
+      "prerequisites": [],
+      "topics": ["matrix", "nested_structures"],
+      "difficulty": 4
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "8cdc3424-51da-4cae-a065-9982859d5b55",
+      "prerequisites": [],
+      "topics": ["calculation", "math", "strings", "structs"],
+      "difficulty": 4
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "ccebfa12-d224-11e7-8941-cec278b6b50a",
+      "prerequisites": [],
+      "topics": ["iterators", "vectors"],
+      "difficulty": 4
+    },
+    {
+      "slug": "isogram",
+      "uuid": "79613fd8-b7da-11e7-abc4-cec278b6b50a",
+      "prerequisites": [],
+      "topics": ["chars", "iterators", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "say",
+      "uuid": "4ba35adb-230b-49a6-adc9-2d3cd9a4c538",
+      "prerequisites": [],
+      "topics": ["modulus", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "4dc9b165-792a-4438-be80-df9aab6f6a9c",
+      "prerequisites": [],
+      "topics": ["chars", "int_string_conversion", "loops", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "c986c240-46de-419c-8ed6-700eb68f8db6",
+      "prerequisites": [],
+      "topics": ["int_string_conversion", "loops"],
+      "difficulty": 4
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "20e7d347-b80a-4656-ac34-0825126939ff",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "hamming",
+      "uuid": "2874216a-0822-4ec2-892e-d451fd89646a",
+      "prerequisites": [],
+      "topics": ["option_type"],
+      "difficulty": 4
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "561cc4ff-5e74-4701-a7c2-c4edefa0d068",
+      "prerequisites": [],
+      "topics": ["hashmaps", "higher_order_functions"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pangram",
+      "uuid": "a24cb7bf-3aac-4051-bcd1-952c2a806187",
+      "prerequisites": [],
+      "topics": ["ascii", "filter"],
+      "difficulty": 4
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "54c11dae-3878-4bec-b8d6-775b7d4f317b",
+      "prerequisites": [],
+      "topics": ["enumerate", "fold", "map", "math", "result_type"],
+      "difficulty": 4
+    },
+    {
+      "slug": "allergies",
+      "uuid": "94f040d6-3f41-4950-8fe6-acf0945ac83d",
+      "prerequisites": [],
+      "topics": ["bitwise", "enums", "filter", "structs", "vectors"],
+      "difficulty": 4
+    },
+    {
+      "slug": "affine-cipher",
+      "uuid": "2a1dcf38-ec05-4b24-a2e2-2e5b3595f3f0",
+      "prerequisites": [],
+      "topics": [
+        "ascii",
+        "chars",
+        "iterators",
+        "primitive_types",
+        "str_vs_string",
+        "strings"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "variable-length-quantity",
+      "uuid": "f1371a9c-c2a4-4fc6-a5fd-3a57c4af16fa",
+      "prerequisites": [],
+      "topics": ["bitwise", "encodings", "result_type", "slices"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "c21c379b-fb23-449b-809a-3c6ef1c31221",
+      "prerequisites": [],
+      "topics": ["ascii", "regular_expressions", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "53298a14-76a9-4bb9-943a-57c5e79d9cf7",
+      "prerequisites": [],
+      "topics": [
+        "ascii",
+        "chars",
+        "iterators",
+        "primitive_types",
+        "str_vs_string",
+        "strings"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "0cc485e9-43ba-4d97-a622-ee4cb8b9f1f7",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "ascii",
+        "chars",
+        "iterators",
+        "primitive_types",
+        "str_vs_string",
+        "strings",
+        "transforming"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "5dbecc83-2c8d-467d-be05-f28a08f7abcf",
+      "prerequisites": [],
+      "topics": [
+        "ascii",
+        "chars",
+        "iterators",
+        "primitive_types",
+        "str_vs_string",
+        "strings"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "f424a350-50bd-11e8-9c2d-fa7ae01bbebc",
+      "prerequisites": [],
+      "topics": ["ascii", "chars", "str_vs_string", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "9a8bae4f-2c0b-4e9e-aab2-b92f82dd3b87",
+      "prerequisites": [],
+      "topics": ["chars", "cipher", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "anagram",
+      "uuid": "f3172997-91f5-4941-a76e-91c4b8eed401",
+      "prerequisites": [],
+      "topics": [
+        "iterators",
+        "lifetimes",
+        "loops",
+        "str_vs_string",
+        "strings",
+        "vectors"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "4e01efbc-51ce-4d20-b093-b3d44c4be5e8",
+      "prerequisites": [],
+      "topics": ["hashmaps", "lifetimes", "result_type", "structs"],
+      "difficulty": 7
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "ec7f66c2-749e-4d00-9c11-fa9d106632e4",
+      "prerequisites": [],
+      "topics": ["lifetimes", "mutability", "randomness", "slices", "structs"],
+      "difficulty": 4
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "704aab91-b83a-4e64-8c21-fb0be5076289",
+      "prerequisites": [],
+      "topics": ["chunks", "lines", "slices"],
+      "difficulty": 10
+    },
+    {
+      "slug": "react",
+      "uuid": "8708ccc7-711a-4862-b5a4-ff59fde2241c",
+      "prerequisites": [],
+      "topics": ["closures", "generics", "lifetimes"],
+      "difficulty": 10
+    },
+    {
+      "slug": "space-age",
+      "uuid": "fa94645d-14e1-422d-a832-d24efbb493d8",
+      "prerequisites": [],
+      "topics": ["from_trait", "trait_implementation", "traits"],
+      "difficulty": 7
+    },
+    {
+      "slug": "wordy",
+      "uuid": "620b55bb-058e-4c6f-a966-ced3b41736db",
+      "prerequisites": [],
+      "topics": ["operators", "parsing", "result_type", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "sublist",
+      "uuid": "644ffd17-548e-4405-bfd5-a58df74cc19d",
+      "prerequisites": [],
+      "topics": ["enums", "generic_over_type"],
+      "difficulty": 7
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "9d652e63-6654-4dec-a99f-97e6bc8cf772",
+      "prerequisites": [],
+      "topics": ["equality", "generic_over_type", "structs", "vectors"],
+      "difficulty": 4
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "e0037ac4-ae5f-4622-b3ad-915648263495",
+      "prerequisites": [],
+      "topics": ["board_state"],
+      "difficulty": 7
+    },
+    {
+      "slug": "rectangles",
+      "uuid": "cc4ccd99-1c97-4ee7-890c-d629b4e1e46d",
+      "prerequisites": [],
+      "topics": ["algorithms", "enums", "structs", "traits"],
+      "difficulty": 10
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "6ff1a539-251b-49d4-81b5-a6b1e9ba66a4",
+      "prerequisites": [],
+      "topics": ["buffers", "generics"],
+      "difficulty": 10
+    },
+    {
+      "slug": "luhn",
+      "uuid": "8d64bfc3-fc4b-45c4-85f0-e74dc2ea6812",
+      "prerequisites": [],
+      "topics": ["higher_order_functions", "iterators", "str_to_digits"],
+      "difficulty": 7
+    },
+    {
+      "slug": "luhn-from",
+      "uuid": "f9131b5d-91dd-4514-983d-4abc22bb5d5c",
+      "prerequisites": [],
+      "topics": [
+        "from_trait",
+        "higher_order_functions",
+        "iterators",
+        "str_to_digits"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "luhn-trait",
+      "uuid": "c32c0124-873d-45f4-9287-402aea29f129",
+      "prerequisites": [],
+      "topics": [
+        "higher_order_functions",
+        "iterators",
+        "str_to_digits",
+        "traits"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "8679c221-d150-4230-b1cd-5ea78ae69db7",
+      "prerequisites": [],
+      "topics": [
+        "chars",
+        "higher_order_functions",
+        "math",
+        "result_type",
+        "windows"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "word-count",
+      "uuid": "6c5c0dc3-4f5b-4f83-bf67-a45bf4ea6be4",
+      "prerequisites": [],
+      "topics": ["chars", "entry_api", "hashmaps", "str_vs_string", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "6abac1d1-0d85-4b51-8001-97a07990630d",
+      "prerequisites": [],
+      "topics": ["format", "iterators", "match", "option_type", "unwrap_or"],
+      "difficulty": 4
+    },
+    {
+      "slug": "diamond",
+      "uuid": "c6878b91-70dd-49a0-b7c1-06364fa3d80b",
+      "prerequisites": [],
+      "topics": ["parsing", "str_vs_string", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "ddc45979-8a92-4313-a4f8-878562d5a483",
+      "prerequisites": [],
+      "topics": ["generics", "higher_order_functions", "move_semantics"],
+      "difficulty": 4
+    },
+    {
+      "slug": "fizzy",
+      "uuid": "6b209749-d4af-45c2-bbdc-27603ce6979f",
+      "prerequisites": [],
+      "topics": ["generics", "impl_trait", "iterators"],
+      "difficulty": 7
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "498be645-734a-49b7-aba7-aae1e051e1f0",
+      "prerequisites": [],
+      "topics": ["loops", "mutability", "result_type", "structs", "traits"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "6e7cac84-99d1-4f9f-b7d6-48ea43024bc0",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 7
+    },
+    {
+      "slug": "series",
+      "uuid": "9de405e1-3a05-43cb-8eb3-00b81a2968e9",
+      "prerequisites": [],
+      "topics": ["strings", "vectors"],
+      "difficulty": 1
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "f9afd650-8103-4373-a284-fa4ecfee7207",
+      "prerequisites": [],
+      "topics": ["math", "option_type"],
+      "difficulty": 1
+    },
+    {
+      "slug": "diffie-hellman",
+      "uuid": "23d82e48-d074-11e7-8fab-cec278b6b50a",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "parallel-letter-frequency",
+      "uuid": "e114b19f-9a9a-402d-a5cb-1cad8de5088e",
+      "prerequisites": [],
+      "topics": ["multi_threading"],
+      "difficulty": 10
+    },
+    {
+      "slug": "macros",
+      "uuid": "29583cc6-d56d-4bee-847d-93d74e5a30e7",
+      "prerequisites": [],
+      "topics": ["hashmaps", "macros", "macros_by_example"],
+      "difficulty": 10
+    },
+    {
+      "slug": "poker",
+      "uuid": "0a33f3ac-cedd-4a40-a132-9d044b0e9977",
+      "prerequisites": [],
+      "topics": [
+        "enums",
+        "lifetimes",
+        "parsing",
+        "strings",
+        "structs",
+        "traits"
+      ],
+      "difficulty": 10
+    },
+    {
+      "slug": "grep",
+      "uuid": "1bce70ca-db1a-46c8-a314-07d3fda921c2",
+      "prerequisites": [],
+      "topics": [
+        "anyhow_crate",
+        "conditionals",
+        "file_io",
+        "parsing",
+        "result_type",
+        "strings",
+        "utf"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "scale-generator",
+      "uuid": "b9436a89-90cb-4fb7-95b0-758f17c309ff",
+      "prerequisites": [],
+      "topics": [
+        "enums",
+        "from_primitive",
+        "music_theory",
+        "to_primitive",
+        "traits"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "decimal",
+      "uuid": "7cefed7c-37f4-46c5-9a45-68fe4d0fb326",
+      "prerequisites": [],
+      "topics": [
+        "bigint",
+        "external_crates",
+        "parsing",
+        "strings",
+        "structs",
+        "traits"
+      ],
+      "difficulty": 7
+    },
+    {
+      "slug": "book-store",
+      "uuid": "a78ed17a-b2c0-485c-814b-e13ccd1f4153",
+      "prerequisites": [],
+      "topics": ["algorithms", "groups", "set_theory"],
+      "difficulty": 7
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "5e6f6986-5011-427b-a992-d6d0c81f5101",
+      "prerequisites": [],
+      "topics": ["graph_theory", "searching"],
+      "difficulty": 10
+    },
+    {
+      "slug": "forth",
+      "uuid": "55976c49-1be5-4170-8aa3-056c2223abbb",
+      "prerequisites": [],
+      "topics": ["parsing"],
+      "difficulty": 10
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "c6631a2c-4632-11e8-842f-0ed5f89f718b",
+      "prerequisites": [],
+      "topics": ["match", "strings"],
+      "difficulty": 1,
+      "deprecated": true
+    },
+    {
+      "slug": "nucleotide-codons",
+      "uuid": "8dae8f4d-368d-477d-907e-bf746921bfbf",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "doubly-linked-list",
+      "uuid": "34738b66-28bb-41bc-85c6-68fcf4a09bc2",
+      "prerequisites": [],
+      "topics": ["generics", "lists", "unsafe"],
+      "difficulty": 10
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "496fd79f-1678-4aa2-8110-c32c6aaf545e",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    }
   ]
 }

--- a/languages/scala/config.json
+++ b/languages/scala/config.json
@@ -12,5 +12,729 @@
     "concept": [],
     "practice": []
   },
-  "concepts": []
+  "concepts": [],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "1fadd9c3-a7c9-4355-aef9-82e0df3d45b9",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "9d56454b-410a-435f-94e9-043db8c8b790",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "b600cda0-f5b8-45b3-bfd0-7e0c19a0b073",
+      "prerequisites": [],
+      "topics": ["integers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "space-age",
+      "uuid": "f147966d-97ec-4479-8679-8cad942b499a",
+      "prerequisites": [],
+      "topics": ["dates", "domain_specific_languages", "enumerations"],
+      "difficulty": 1
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "b469a197-adf4-4d02-b129-07f993104054",
+      "prerequisites": [],
+      "topics": ["maps", "sequences", "sorting"],
+      "difficulty": 2
+    },
+    {
+      "slug": "bob",
+      "uuid": "57b76aba-a485-464d-84ba-e9a445b25be6",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_else_statements",
+        "pattern_matching",
+        "strings"
+      ],
+      "difficulty": 1
+    },
+    {
+      "slug": "hamming",
+      "uuid": "5a31217f-02fd-4be4-b64f-7a93f36f5140",
+      "prerequisites": [],
+      "topics": ["filtering", "optional_values", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "etl",
+      "uuid": "d21f16ce-8e6e-436e-918b-e973cfc7c2a0",
+      "prerequisites": [],
+      "topics": ["lists", "maps", "sequences", "strings", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "261f75c1-df67-4c62-a2e9-ce13550f5de3",
+      "prerequisites": [],
+      "topics": ["enumerations", "tuples"],
+      "difficulty": 3
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "e810d2eb-5c90-4135-8db8-0bda54a33d2e",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "lists", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "7221946d-6321-4cec-8e64-050abae3ccd7",
+      "prerequisites": [],
+      "topics": ["filtering", "math", "sets"],
+      "difficulty": 1
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "6d136d51-390a-46a7-b42b-fdecff7b622a",
+      "prerequisites": [],
+      "topics": ["generics", "lists", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "825e94e5-6fc8-4dce-befe-74e1516fae14",
+      "prerequisites": [],
+      "topics": ["lists", "pattern_matching", "recursion"],
+      "difficulty": 2
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "65a76aba-a485-222d-84ba-e9a445b25be6",
+      "prerequisites": [],
+      "topics": ["math", "recursion"],
+      "difficulty": 2
+    },
+    {
+      "slug": "armstrong-numbers",
+      "uuid": "2bd9ab9e-ecc4-4331-984d-8e5f15f775b4",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 2
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "612b8880-1dd1-410d-b530-c66ec9edc1b3",
+      "prerequisites": [],
+      "topics": ["discriminated_unions", "enumerations", "integers", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "matrix",
+      "uuid": "c6c37479-a030-44ba-9da5-97eb77233ac6",
+      "prerequisites": [],
+      "topics": ["matrices", "parsing", "strings", "vectors"],
+      "difficulty": 4
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "4c3710dc-fac2-4056-b4ac-945b67c08068",
+      "prerequisites": [],
+      "topics": ["dates", "function_overloading", "time"],
+      "difficulty": 1
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "1fe9f43a-7774-4fbd-864b-eff7749ebbc6",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "pangram",
+      "uuid": "e6f96ae1-6736-42f4-b74d-14a4aa8aa5fc",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "54ff0017-7c53-4e83-a3bd-aff2953185b7",
+      "prerequisites": [],
+      "topics": ["logic", "strings", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "d7f7b64e-1dba-400e-a9c1-acd521d21753",
+      "prerequisites": [],
+      "topics": ["optional_values", "parsing", "strings", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "strain",
+      "uuid": "d3a10b82-ae65-4a99-968d-4f1bec62b88a",
+      "prerequisites": [],
+      "topics": ["filtering", "generics", "sequences"],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "d06505fb-3844-481a-bf7a-4e05545119f0",
+      "prerequisites": [],
+      "topics": ["randomness", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "grains",
+      "uuid": "39b2350c-60b5-4da0-9fb9-26f75a4bad6d",
+      "prerequisites": [],
+      "topics": ["optional_values"],
+      "difficulty": 3
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "a4797d24-9293-41b2-b630-3ac9e3840d47",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "fc58b128-24a8-48e7-90db-b4843fbdf40a",
+      "prerequisites": [],
+      "topics": ["optional_values", "strings", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "triangle",
+      "uuid": "2be75924-fce4-49fa-b52e-6cdcf222b283",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 3
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "f653decb-f7fa-47ff-81a6-2b3981261ea7",
+      "prerequisites": [],
+      "topics": ["arrays", "optional_values", "searching"],
+      "difficulty": 3
+    },
+    {
+      "slug": "sieve",
+      "uuid": "9f5ee7aa-943b-4151-8530-def1428fc00f",
+      "prerequisites": [],
+      "topics": ["filtering", "lists", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "isogram",
+      "uuid": "f6d61a0e-068b-4519-8d4d-563713be6168",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "clock",
+      "uuid": "a6a06d7f-af28-4c42-a870-0de2c9e896c2",
+      "prerequisites": [],
+      "topics": ["structural_equality", "time"],
+      "difficulty": 3
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "e6a3354e-dd32-413f-856d-53c81bd0d728",
+      "prerequisites": [],
+      "topics": ["sequences", "strings", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "15047d95-671b-4163-96b2-834ec54ea3d5",
+      "prerequisites": [],
+      "topics": ["algorithms", "control_flow", "strings", "text_formatting"],
+      "difficulty": 3
+    },
+    {
+      "slug": "house",
+      "uuid": "73770426-74a8-498f-a37c-1b12aaf71281",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "series",
+      "uuid": "35a0ff51-6c85-4a39-8017-62e8eabd1c21",
+      "prerequisites": [],
+      "topics": ["sequences", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "word-count",
+      "uuid": "10c53e9d-8fa6-486c-b68a-be821dec5010",
+      "prerequisites": [],
+      "topics": ["maps", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "anagram",
+      "uuid": "54633841-b60f-49a0-9f95-aeda09de6232",
+      "prerequisites": [],
+      "topics": ["filtering", "sequences", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "c03319c6-1a2b-4f26-a943-242ccc6a295e",
+      "prerequisites": [],
+      "topics": ["maps", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "meetup",
+      "uuid": "50a7cf00-7f5e-4f38-9a13-c8ff5c895723",
+      "prerequisites": [],
+      "topics": ["dates"],
+      "difficulty": 4
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "49d45a39-c8de-4b25-9ee2-5e08de8721c0",
+      "prerequisites": [],
+      "topics": ["algorithms", "integers", "lists", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "allergies",
+      "uuid": "8e311809-1de4-44c3-923a-ffd863843e6b",
+      "prerequisites": [],
+      "topics": ["enumerations", "filtering", "lists"],
+      "difficulty": 4
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "adcf2a9b-2f6c-490f-b441-ad413a03fee7",
+      "prerequisites": [],
+      "topics": [
+        "integers",
+        "lists",
+        "math",
+        "optional_values",
+        "transforming"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "1218f854-ebb9-40dd-9487-ccc4d09c9a43",
+      "prerequisites": [],
+      "topics": ["enumerations", "lists", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "7e81f24e-c892-4e45-b0bb-6c6420ba1f0e",
+      "prerequisites": [],
+      "topics": [
+        "integers",
+        "math",
+        "optional_values",
+        "strings",
+        "transforming"
+      ],
+      "difficulty": 4
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "34a134c4-f9f5-46c4-97db-2f6c8c1e97f5",
+      "prerequisites": [],
+      "topics": ["control_flow_loops", "lists", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "0e858f22-401b-44ad-b972-766e2f38e5d5",
+      "prerequisites": [],
+      "topics": ["integers", "math", "sequences", "tuples"],
+      "difficulty": 4
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "aa135256-28c8-4e3e-a942-8ae5ae996ab5",
+      "prerequisites": [],
+      "topics": ["lists", "matrices", "sets", "tuples"],
+      "difficulty": 4
+    },
+    {
+      "slug": "acronym",
+      "uuid": "876a07ce-0ee4-4ded-bab3-c9b3f8746d57",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "163d247a-1763-4876-870a-63deb3a3daa8",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "4c08ec90-4c5a-4dae-812c-52899b1a29cf",
+      "prerequisites": [],
+      "topics": ["algorithms", "sequences", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "168823e4-de57-40c0-ac8d-bec6ccf9c96d",
+      "prerequisites": [],
+      "topics": ["classes", "generics", "lists", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "842f0674-fcf3-48c3-80ae-c6d43c65f270",
+      "prerequisites": [],
+      "topics": ["security", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "6e379741-8337-41f3-9790-dc93cacdc9b6",
+      "prerequisites": [],
+      "topics": ["algorithms", "optional_values", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "bank-account",
+      "uuid": "ec0334d9-df30-4e61-bea6-bd3f7c8d13e6",
+      "prerequisites": [],
+      "topics": ["parallellism"],
+      "difficulty": 5
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "b047cdd2-5afa-47a0-b48d-5c235c1099dc",
+      "prerequisites": [],
+      "topics": ["lists", "security", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "9d25bf46-52d6-435e-a384-38c25517f8ee",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "1af833c7-2e0d-4c96-a3a9-d4812df5d1a1",
+      "prerequisites": [],
+      "topics": ["games", "logic", "optional_values", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "luhn",
+      "uuid": "8956383c-bea2-4bcc-b7af-df19f94e15e6",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "60deb77c-45f2-48a1-bff8-b0cef3b07500",
+      "prerequisites": [],
+      "topics": ["algorithms", "text_formatting"],
+      "difficulty": 5
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "bec1be3e-2d1c-4cb7-9398-dd0249e79d2e",
+      "prerequisites": [],
+      "topics": ["generics", "lists", "optional_values"],
+      "difficulty": 5
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "e0810022-d3ea-463a-97da-dfdac08e3c63",
+      "prerequisites": [],
+      "topics": ["matrices"],
+      "difficulty": 5
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "0605da19-048e-4a1f-b508-5d77d1e384a5",
+      "prerequisites": [],
+      "topics": ["generics", "lists", "sets"],
+      "difficulty": 5
+    },
+    {
+      "slug": "parallel-letter-frequency",
+      "uuid": "a557f7e3-9fc0-4cd8-bab1-b4d8fc88402d",
+      "prerequisites": [],
+      "topics": [
+        "dictionaries",
+        "maps",
+        "parallellism",
+        "sequences",
+        "strings",
+        "transforming"
+      ],
+      "difficulty": 5
+    },
+    {
+      "slug": "book-store",
+      "uuid": "5ce09233-9ec1-4422-aa97-2d90ea67146b",
+      "prerequisites": [],
+      "topics": ["recursion"],
+      "difficulty": 5
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "c7838d98-35db-4a84-914e-c05cafda2bed",
+      "prerequisites": [],
+      "topics": ["algorithms", "math", "optional_values"],
+      "difficulty": 6
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "fc57c00f-ca56-499d-bb46-0ce006b60923",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "math",
+        "optional_values",
+        "sets",
+        "strings",
+        "tuples"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "221be13e-da2a-4f0a-9702-84744cbcaca6",
+      "prerequisites": [],
+      "topics": [
+        "lists",
+        "parsing",
+        "pattern_recognition",
+        "strings",
+        "transforming"
+      ],
+      "difficulty": 6
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "088e1441-a648-4dc4-ad13-c5fdd8e8a104",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "f70d2b0c-9660-4538-9897-2f233b93d0c3",
+      "prerequisites": [],
+      "topics": ["generics", "lists", "searching", "trees"],
+      "difficulty": 6
+    },
+    {
+      "slug": "rail-fence-cipher",
+      "uuid": "755b5cf5-97f2-41c1-9b0b-24e6db68b7eb",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "bowling",
+      "uuid": "9ea2b27f-4c3a-463d-8869-4e930808ce93",
+      "prerequisites": [],
+      "topics": ["algorithms", "control_flow_if_else_statements", "lists"],
+      "difficulty": 6
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "d619cdc2-b8b7-442d-a2b2-41383c33d219",
+      "prerequisites": [],
+      "topics": ["games", "lists", "optional_values", "tuples"],
+      "difficulty": 7
+    },
+    {
+      "slug": "sublist",
+      "uuid": "00a09826-f63b-4558-8ad0-6cdb7836dfea",
+      "prerequisites": [],
+      "topics": ["enumerations", "generics", "lists"],
+      "difficulty": 7
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "04c3197c-cd3d-4853-af3f-50c189af80c7",
+      "prerequisites": [],
+      "topics": ["lists", "parsing", "strings", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "wordy",
+      "uuid": "ded3ae4c-43a7-46df-b43b-42aab419c2d8",
+      "prerequisites": [],
+      "topics": ["optional_values", "parsing", "strings", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "change",
+      "uuid": "62dd342a-591c-497f-8f3a-64748952b1af",
+      "prerequisites": [],
+      "topics": ["integers", "lists", "optional_values"],
+      "difficulty": 7
+    },
+    {
+      "slug": "connect",
+      "uuid": "5ea6b0e1-513e-462f-9741-46f060638a92",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "games",
+        "graphs",
+        "optional_values",
+        "recursion",
+        "searching"
+      ],
+      "difficulty": 8
+    },
+    {
+      "slug": "zebra-puzzle",
+      "uuid": "eb9387d6-3fac-460b-ad14-657c0f4d2d88",
+      "prerequisites": [],
+      "topics": ["logic"],
+      "difficulty": 8
+    },
+    {
+      "slug": "say",
+      "uuid": "e0e0ef68-6759-42e3-8542-3d165f8900d7",
+      "prerequisites": [],
+      "topics": [
+        "optional_values",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ],
+      "difficulty": 8
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "64002f5b-e373-4850-92bf-88461d49376e",
+      "prerequisites": [],
+      "topics": ["maps", "optional_values", "parsing", "strings"],
+      "difficulty": 9
+    },
+    {
+      "slug": "sgf-parsing",
+      "uuid": "8b4c7142-6790-4d89-a5cb-fa094e2c969a",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 9
+    },
+    {
+      "slug": "lens-person",
+      "uuid": "e6e88c52-b984-479d-8b9c-047d25f2aa47",
+      "prerequisites": [],
+      "topics": [],
+      "difficulty": 9
+    },
+    {
+      "slug": "variable-length-quantity",
+      "uuid": "12dbe514-848b-4fd2-868d-7f6195092e23",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "bitwise_operations",
+        "discriminated_unions",
+        "lists"
+      ],
+      "difficulty": 9
+    },
+    {
+      "slug": "zipper",
+      "uuid": "bc5b07e2-f641-4fda-818d-12502cdbb066",
+      "prerequisites": [],
+      "topics": ["generics", "optional_values", "trees"],
+      "difficulty": 10
+    },
+    {
+      "slug": "forth",
+      "uuid": "2c85199f-4d09-485b-9925-3b21f81ee054",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 10
+    },
+    {
+      "slug": "binary",
+      "uuid": "6cc53fdc-4423-47fe-abac-7688259b0ac5",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "7c949a14-70dc-4034-874f-0c9e3217fcf8",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "octal",
+      "uuid": "403063a8-9f29-409a-8bf4-a2400521e19b",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "trinary",
+      "uuid": "616e49fe-b6eb-4384-9af4-b8413d4d0eab",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "diamond",
+      "uuid": "e45f95de-8688-46ba-80d1-470c4072c740",
+      "prerequisites": [],
+      "topics": ["lists", "strings", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "48131b13-2548-4d31-9c5e-af1dac2fc94d",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 6
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "67b5c1cd-7c46-4939-851d-7c10d2e908b1",
+      "prerequisites": [],
+      "topics": ["math", "security", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "high-scores",
+      "uuid": "3b161610-5b60-4661-aa24-dc026b741586",
+      "prerequisites": [],
+      "topics": ["lists", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "darts",
+      "uuid": "939bfbf2-55c9-4c54-b2ef-3247bb6fc67c",
+      "prerequisites": [],
+      "topics": [
+        "control_flow_if_else_statements",
+        "floating_point_numbers",
+        "math"
+      ],
+      "difficulty": 1
+    }
+  ]
 }

--- a/languages/swift/config.json
+++ b/languages/swift/config.json
@@ -4,7 +4,10 @@
   "active": true,
   "blurb": "Swift is a general-purpose programming language built using a modern approach to safety, performance, and software design patterns. Although Swift is great for iOS, iPadOS, and macOS programming, it also offers great programming capabilities for servr-side applications, Linux programming, and will soon be officially supported on Windows as well.",
   "version": 3,
-  "online_editor": { "indent_style": "space", "indent_size": 2 },
+  "online_editor": {
+    "indent_style": "space",
+    "indent_size": 2
+  },
   "exercises": {
     "concept": [
       {
@@ -348,6 +351,637 @@
       "slug": "variadic-parameters",
       "name": "Variadic Parameters",
       "blurb": "TODO: add blurb for variadic-parameters concept"
+    }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "63906530-1e13-491a-ab17-aee66d619fd8",
+      "prerequisites": [],
+      "topics": ["optional_values", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "ed859c29-fae0-4a32-9074-ac3c3cf324c2",
+      "prerequisites": [],
+      "topics": ["optional_values", "text_formatting"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "53ca7b6a-cdba-4d6d-a564-06e59700a6e4",
+      "prerequisites": [],
+      "topics": ["integers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "gigasecond",
+      "uuid": "0a1ae85a-1d89-453a-8b97-303181d7874d",
+      "prerequisites": [],
+      "topics": ["dates"],
+      "difficulty": 1
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "ef114733-886b-4d4b-a713-3ba169a85025",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "537f8ccd-31ac-41d3-a5fa-39359340d1cb",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "sum-of-multiples",
+      "uuid": "b9736756-7022-4a82-b0ea-47b738b1b607",
+      "prerequisites": [],
+      "topics": ["lists", "math", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "space-age",
+      "uuid": "aaa19946-ab8b-4035-815a-a1f8218ea38b",
+      "prerequisites": [],
+      "topics": ["discriminated_unions", "floating_point_numbers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "bob",
+      "uuid": "49051b88-063a-4fa1-b920-6ca9a6f9bc60",
+      "prerequisites": [],
+      "topics": ["control_flow_if_else_statements", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "grains",
+      "uuid": "b7d90715-b241-4c59-8457-f637efd14bda",
+      "prerequisites": [],
+      "topics": ["integers"],
+      "difficulty": 2
+    },
+    {
+      "slug": "hamming",
+      "uuid": "b3cd804f-4ac2-44c7-997b-066779a1b5e6",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "nucleotide-count",
+      "uuid": "82fe74be-1589-41fc-966c-10c7b756a2f2",
+      "prerequisites": [],
+      "topics": ["maps", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "cb5bc145-8249-4b3b-bcb3-b8d7805f2a14",
+      "prerequisites": [],
+      "topics": ["recursion", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "60b3b28e-06cb-4a5e-b458-380b6f542ed0",
+      "prerequisites": [],
+      "topics": ["filtering", "text_formatting"],
+      "difficulty": 2
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "d1ab2908-8f95-42cd-b40e-b571287ea744",
+      "prerequisites": [],
+      "topics": ["maps", "sorting"],
+      "difficulty": 2
+    },
+    {
+      "slug": "etl",
+      "uuid": "71eb6dd0-1d0d-4aaa-bb22-604cece45bd7",
+      "prerequisites": [],
+      "topics": ["maps", "transforming"],
+      "difficulty": 2
+    },
+    {
+      "slug": "isogram",
+      "uuid": "066d2666-deeb-4d99-8314-36d72fbf9afd",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "list-ops",
+      "uuid": "cf91efe6-0c6f-4c6f-b3da-e828dff03ad9",
+      "prerequisites": [],
+      "topics": [
+        "conditionals",
+        "filtering",
+        "functional_programming",
+        "lists",
+        "loops",
+        "searching",
+        "variables"
+      ],
+      "difficulty": 2
+    },
+    {
+      "slug": "clock",
+      "uuid": "3ee3ebf1-5cc0-4905-afc4-17e77b9d55a5",
+      "prerequisites": [],
+      "topics": ["structural_equality", "time"],
+      "difficulty": 3
+    },
+    {
+      "slug": "triangle",
+      "uuid": "27671176-d9e4-4060-816c-be6158568269",
+      "prerequisites": [],
+      "topics": ["discriminated_unions", "integers"],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "219f45e1-1475-431e-a087-3c36a557e1a0",
+      "prerequisites": [],
+      "topics": ["randomness", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "scrabble-score",
+      "uuid": "5d215619-65d0-4e0c-b592-3eb0747e43c5",
+      "prerequisites": [],
+      "topics": ["transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "4420075e-e1b2-4790-922e-4a0650d87036",
+      "prerequisites": [],
+      "topics": ["enumerations", "parsing"],
+      "difficulty": 3
+    },
+    {
+      "slug": "queen-attack",
+      "uuid": "5d590847-775c-4b16-9a11-39b208b5c0b2",
+      "prerequisites": [],
+      "topics": ["tuples"],
+      "difficulty": 3
+    },
+    {
+      "slug": "strain",
+      "uuid": "2be64fe9-cc46-437b-ad3f-43ca3ac7a786",
+      "prerequisites": [],
+      "topics": ["filtering", "sequences"],
+      "difficulty": 3
+    },
+    {
+      "slug": "sieve",
+      "uuid": "571de186-7791-4fc3-b6b2-5ab0ed50a2cb",
+      "prerequisites": [],
+      "topics": ["filtering", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "de217063-bb3a-4593-850e-887fe8b74924",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 3
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "3eeb8ae0-c8e6-4388-9e4e-b83b8ad2470e",
+      "prerequisites": [],
+      "topics": ["discriminated_unions", "integers", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "2fb516ce-6b89-4e0a-b240-d6f024ed5ff2",
+      "prerequisites": [],
+      "topics": ["records", "tuples"],
+      "difficulty": 3
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "a4a4e5a0-0226-4082-9a82-3cba2c2d4786",
+      "prerequisites": [],
+      "topics": ["lists", "searching"],
+      "difficulty": 3
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "b113d981-8fc8-4572-b3e0-7ba7a07419de",
+      "prerequisites": [],
+      "topics": ["lists", "looping", "searching"],
+      "difficulty": 3
+    },
+    {
+      "slug": "sublist",
+      "uuid": "5bd37dff-8b10-4e96-8b04-a37a8565338b",
+      "prerequisites": [],
+      "topics": ["lists", "looping"],
+      "difficulty": 3
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "ea9feed8-481a-4bd0-9af8-7ca44433c266",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "lists"],
+      "difficulty": 3
+    },
+    {
+      "slug": "collatz-conjecture",
+      "uuid": "1b068d66-c8de-42a8-a566-03848c9c7941",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 3
+    },
+    {
+      "slug": "diamond",
+      "uuid": "6d70fd81-76a4-4e44-a64a-9a070e07e83d",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "5854447a-ff9f-4321-bd5c-430555b91fc6",
+      "prerequisites": [],
+      "topics": ["conditionals", "loops", "pattern_matching", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "protein-translation",
+      "uuid": "72bd3b46-c3ed-4399-a925-9b616cfa1e9b",
+      "prerequisites": [],
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "strings"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "f5499564-62b9-47ab-9ba2-8be6ba453269",
+      "prerequisites": [],
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "data_structures",
+        "exception_handling",
+        "lists"
+      ],
+      "difficulty": 3
+    },
+    {
+      "slug": "scale-generator",
+      "uuid": "1c9dfe22-de66-4437-862b-8921dc7eb25e",
+      "prerequisites": [],
+      "topics": ["loops", "pattern_matching", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "proverb",
+      "uuid": "9604f1ef-4925-4c28-9c59-b986c1a42c7e",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "word-count",
+      "uuid": "495a61a4-1bef-402e-a50c-b0d9a2abfe19",
+      "prerequisites": [],
+      "topics": ["maps", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "allergies",
+      "uuid": "d9894c7f-afeb-4d34-a967-53285571fdac",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "enumerations", "filtering"],
+      "difficulty": 4
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "53f022ee-903e-4ee1-aabc-2db0a68d4b1c",
+      "prerequisites": [],
+      "topics": ["conditionals", "looping", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "5671c927-5e04-4207-b947-f8e9715aa7ef",
+      "prerequisites": [],
+      "topics": ["algorithms", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "meetup",
+      "uuid": "a306e9d3-5cd0-42c7-99ed-72ad4b5eba24",
+      "prerequisites": [],
+      "topics": ["dates"],
+      "difficulty": 4
+    },
+    {
+      "slug": "anagram",
+      "uuid": "f2742e98-d6fe-4280-b4e6-ba1b2fd325f8",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "series",
+      "uuid": "452cd259-2c71-4c90-a0ff-ac39c23e1f55",
+      "prerequisites": [],
+      "topics": ["lists", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "6a1d09f6-9a1a-4952-8543-d6a07b8158ce",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 4
+    },
+    {
+      "slug": "acronym",
+      "uuid": "7359a818-ffa5-4ce0-be35-cc66654f9af2",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "matrix",
+      "uuid": "84fe8e39-f7e3-4295-be9d-5256b59d800d",
+      "prerequisites": [],
+      "topics": ["matrices", "parsing"],
+      "difficulty": 4
+    },
+    {
+      "slug": "all-your-base",
+      "uuid": "77f7a53c-ef83-4f26-b758-5ded1010a61a",
+      "prerequisites": [],
+      "topics": ["integers", "math", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "471e5cdc-438d-4930-b830-cdd4c144740e",
+      "prerequisites": [],
+      "topics": ["integers", "math", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "house",
+      "uuid": "880a9644-13b3-4c24-9a95-24454804f804",
+      "prerequisites": [],
+      "topics": ["algorithms", "text_formatting"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "24ed2341-31f0-494b-83d0-a9fa74d4f07b",
+      "prerequisites": [],
+      "topics": ["integers", "math", "records"],
+      "difficulty": 4
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "402469d7-5735-46ea-8122-1faf90ae7d6e",
+      "prerequisites": [],
+      "topics": ["lists", "matrices"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "3b13f3f5-2d75-4dc0-8be0-e05694425fe2",
+      "prerequisites": [],
+      "topics": ["lists", "math", "recursion"],
+      "difficulty": 4
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "e651057d-a36f-4c81-a341-f12859ac37a3",
+      "prerequisites": [],
+      "topics": ["integers", "math"],
+      "difficulty": 4
+    },
+    {
+      "slug": "pangram",
+      "uuid": "c4dc447b-80d5-45a0-983d-25edc34cc6cf",
+      "prerequisites": [],
+      "topics": ["searching", "strings"],
+      "difficulty": 4
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "f6b157cb-ddb0-4c40-baa3-9fc6b58de7ff",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "say",
+      "uuid": "0f840c37-a8c0-42da-93f9-d215cb044d53",
+      "prerequisites": [],
+      "topics": ["loops", "parsing", "text_formatting", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "942d0c4b-eaef-4576-b3f8-383757c53768",
+      "prerequisites": [],
+      "topics": ["recursion", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "131206b1-8f1c-4906-9c31-7a077c6125be",
+      "prerequisites": [],
+      "topics": ["searching", "trees"],
+      "difficulty": 5
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "bbe12b06-cc63-46cd-9379-4865bf9171eb",
+      "prerequisites": [],
+      "topics": ["parsing", "pattern_recognition"],
+      "difficulty": 5
+    },
+    {
+      "slug": "linked-list",
+      "uuid": "ecedbfe8-b578-4af7-8e8c-470809adbc42",
+      "prerequisites": [],
+      "topics": ["lists"],
+      "difficulty": 5
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "414351cd-580a-4608-b9ce-9003f3cdb242",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "atbash-cipher",
+      "uuid": "c5adab05-2b19-4544-8abd-159af71196f5",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "49f50818-3574-450e-9d57-6b23e62db5f8",
+      "prerequisites": [],
+      "topics": ["algorithms", "text_formatting"],
+      "difficulty": 5
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "93731f15-38da-4e28-bfa0-6a3006a4f2c6",
+      "prerequisites": [],
+      "topics": ["sets"],
+      "difficulty": 5
+    },
+    {
+      "slug": "crypto-square",
+      "uuid": "68f60053-41dc-4376-a0e2-bcb3b736aab3",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "luhn",
+      "uuid": "a7e26cf2-45b9-4b41-8143-a2b8e2104dec",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "0718397c-b823-4b38-9892-69b667cf895f",
+      "prerequisites": [],
+      "topics": ["algorithms", "transforming"],
+      "difficulty": 5
+    },
+    {
+      "slug": "tournament",
+      "uuid": "3a699a07-f0ab-4db2-bb0e-99aa968f1ad8",
+      "prerequisites": [],
+      "topics": ["parsing", "text_formatting"],
+      "difficulty": 6
+    },
+    {
+      "slug": "bowling",
+      "uuid": "beb0c7dd-69aa-4e9b-a0df-f1d507221b21",
+      "prerequisites": [],
+      "topics": ["algorithms"],
+      "difficulty": 6
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "031f1ab5-5233-4d9b-8f55-0a662014a05c",
+      "prerequisites": [],
+      "topics": ["math"],
+      "difficulty": 6
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "b96cace1-8666-4607-91e7-0203b4f7434f",
+      "prerequisites": [],
+      "topics": ["algorithms", "math", "strings", "tuples"],
+      "difficulty": 6
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "5a9f6db4-7bee-4dda-a1ef-1d0bd1dad24e",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "transpose",
+      "uuid": "a7074b04-3ac5-4437-817e-2dc31d9d8ae0",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 6
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "5a918ed8-e840-46b8-b824-291d872d2224",
+      "prerequisites": [],
+      "topics": ["math", "tuples"],
+      "difficulty": 6
+    },
+    {
+      "slug": "bracket-push",
+      "uuid": "b3924cce-02f7-4962-85a5-e67d8b1ac1fa",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 7
+    },
+    {
+      "slug": "minesweeper",
+      "uuid": "ca6d49c7-e850-4e81-9540-582a1353f604",
+      "prerequisites": [],
+      "topics": ["parsing", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "dominoes",
+      "uuid": "68d71c7f-5259-4030-821f-8449a142b677",
+      "prerequisites": [],
+      "topics": ["lists", "tuples"],
+      "difficulty": 7
+    },
+    {
+      "slug": "wordy",
+      "uuid": "04b9825b-0ae2-4ee4-a444-12573f5d5c66",
+      "prerequisites": [],
+      "topics": ["parsing", "strings", "transforming"],
+      "difficulty": 7
+    },
+    {
+      "slug": "poker",
+      "uuid": "ffd130c2-f816-474c-a989-dc5814e31ea6",
+      "prerequisites": [],
+      "topics": ["discriminated_unions", "games", "parsing", "sorting"],
+      "difficulty": 8
+    },
+    {
+      "slug": "binary",
+      "uuid": "0930d019-2ccb-48f9-9ee7-467b683d9901",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "trinary",
+      "uuid": "8b376ef9-ad94-4623-8d0f-e2d7bb6c364a",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "octal",
+      "uuid": "128bcbc1-18b3-45e7-9590-c71d8f57c5c1",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "3a9f0e4d-a569-40ea-adb8-ded8d240c949",
+      "prerequisites": [],
+      "difficulty": 0,
+      "deprecated": true
     }
   ]
 }

--- a/languages/x86-64-assembly/config.json
+++ b/languages/x86-64-assembly/config.json
@@ -4,7 +4,10 @@
   "active": true,
   "blurb": "x86-64 assembly is a low-level programming language, typically used in boot loaders, device drivers, and operating system kernels.",
   "version": 3,
-  "online_editor": { "indent_style": "space", "indent_size": 4 },
+  "online_editor": {
+    "indent_style": "space",
+    "indent_size": 4
+  },
   "exercises": {
     "concept": [
       {
@@ -22,6 +25,120 @@
       "slug": "basics",
       "name": "Basics",
       "blurb": "TODO: add blurb for basics concept"
+    }
+  ],
+  "practice": [
+    {
+      "slug": "hello-world",
+      "uuid": "edfc05bc-1458-4047-8d64-eea38e155f20",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "leap",
+      "uuid": "669b6523-0dfe-4ccc-b16e-51ee6a8e7e0b",
+      "prerequisites": [],
+      "topics": ["conditionals", "integers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "d0f241d3-4d99-49e3-bf90-2767cfb0c9c3",
+      "prerequisites": [],
+      "topics": ["optional_values", "strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "resistor-color",
+      "uuid": "39e8a36c-bbcb-4b47-ae05-f376f74fa4a8",
+      "prerequisites": [],
+      "topics": ["arrays"],
+      "difficulty": 1
+    },
+    {
+      "slug": "space-age",
+      "uuid": "c6377959-f8fb-4df4-97c0-f48915076144",
+      "prerequisites": [],
+      "topics": ["floating_point_numbers"],
+      "difficulty": 1
+    },
+    {
+      "slug": "hamming",
+      "uuid": "c7177570-056f-4024-9022-9b0fcc37f246",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "allergies",
+      "uuid": "cf6d015d-40f6-4afe-8d0b-ca4c9e32b0cc",
+      "prerequisites": [],
+      "topics": ["bitwise_operations", "filtering"],
+      "difficulty": 3
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "c7cf1766-11e5-47b0-9d01-8eff62218131",
+      "prerequisites": [],
+      "topics": ["algorithms", "strings", "transforming"],
+      "difficulty": 4
+    },
+    {
+      "slug": "matching-brackets",
+      "uuid": "6e3f6c68-e290-4b1d-9ad8-2ed0c66be41a",
+      "prerequisites": [],
+      "topics": ["parsing", "strings"],
+      "difficulty": 5
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "9520ca3d-926a-4cc3-949c-9d99dd9009bf",
+      "prerequisites": [],
+      "topics": ["strings", "transforming"],
+      "difficulty": 1
+    },
+    {
+      "slug": "reverse-string",
+      "uuid": "799bdac9-e905-4fbd-aa55-94dc1154dc5e",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 1
+    },
+    {
+      "slug": "pangram",
+      "uuid": "068f3bc2-48cc-46af-9e1e-5a664cc8025a",
+      "prerequisites": [],
+      "topics": ["strings"],
+      "difficulty": 2
+    },
+    {
+      "slug": "isogram",
+      "uuid": "015bc461-1d31-4d2f-a914-d6294f27592d",
+      "prerequisites": [],
+      "topics": ["filtering", "strings"],
+      "difficulty": 3
+    },
+    {
+      "slug": "grains",
+      "uuid": "a4a24a15-f553-4d98-9fde-7e579897f6d3",
+      "prerequisites": [],
+      "topics": ["integers"],
+      "difficulty": 2
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "d050fbb3-db22-4b1a-9ae6-60bf246b1a6d",
+      "prerequisites": [],
+      "topics": ["integers", "loops", "math"],
+      "difficulty": 1
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "63ea6d20-2a4c-4784-946c-05e582184a10",
+      "prerequisites": [],
+      "topics": ["arrays", "searching"],
+      "difficulty": 3
     }
   ]
 }


### PR DESCRIPTION
This PR adds the existing v2 exercises of all tracks to the v3 tracks' config.json files (see https://github.com/exercism/v3/issues/2293). It does this by copying the original exercise but with some changes:

- The `core`, `auto_approve` and `unlocked_by` keys are removed. They are no longer relevant in v3.
- A `prerequisites` key is added. This key will have the same function as the `prerequisites` key for concept exercise: it determines when the exercise is unlocked.
- The `topics` property is also copied. Its goal is to help with populating the prerequisites property. The `topics` property has no value in v3 and we'll remove it once the prerequisites property has been populated.

I've added a separate commit per language to make reviews easier. It might also be nice to not squash this on merging to retain the commit history.