### PR TITLE
[Rust] enums - replace about.md file with concept files

### DIFF
--- a/languages/rust/concepts/enums-basic/about.md
+++ b/languages/rust/concepts/enums-basic/about.md
@@ -1,1 +1,3 @@
-TODO: add information on enums-basic concept
+Rust enums are also called [algebraic data types](https://en.wikipedia.org/wiki/Algebraic_data_type), or [tagged unions](https://en.wikipedia.org/wiki/Tagged_union). Why does this matter? Enumerations are a popular concept and programming languages implement them differently. Functional programming has influenced Rust's design and the `enum` implementation demonstrates that.
+
+- [introduction to enums in the Rust book](https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html)

--- a/languages/rust/concepts/enums-basic/links.json
+++ b/languages/rust/concepts/enums-basic/links.json
@@ -1,1 +1,14 @@
-[]
+[
+  {
+    "url": "https://en.wikipedia.org/wiki/Algebraic_data_type",
+    "description": "algebraic data types"
+  },
+  {
+    "url": "https://en.wikipedia.org/wiki/Tagged_union",
+    "description": "tagged unions"
+  },
+  {
+    "url": "https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html",
+    "description": "introduction to enums in the Rust book"
+  }
+]

--- a/languages/rust/exercises/concept/enums/.docs/after.md
+++ b/languages/rust/exercises/concept/enums/.docs/after.md
@@ -1,3 +1,0 @@
-Rust enums are also called [algebraic data types](https://en.wikipedia.org/wiki/Algebraic_data_type), or [tagged unions](https://en.wikipedia.org/wiki/Tagged_union). Why does this matter? Enumerations are a popular concept and programming languages implement them differently. Functional programming has influenced Rust's design and the `enum` implementation demonstrates that.
-
-- [introduction to enums in the Rust book](https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html)


### PR DESCRIPTION
In [this issue](https://github.com/exercism/v3/issues/2293) we're describing an evolution of the specification of this repo.
These changes include, amongst others, replacing the contents of the `after.md` document with individual concept documents. There are two documents per concept:

1. An `about.md` file containing the description of the concept
1. A `links.json` file containing a set of useful links related to the concept. 

This looks as follows in the repo:

```
<track>
├── concepts
│   ├── <concept>
│   │   ├── about.md
│   │   └── links.json
│   └── ...
```

This PR applies this change to this exercise by: 
                
1. Copying the existing `after.md` file's contents to the `about.md` file of each concept listed in the exercise's `concepts` section in the `config.json` file.
1. Extract the links from the `after.md` file and put them into the `links.json` file

Before merging this PR, please check that the contents of the concept documents makes sense.
This is especially true when the exercise unlocks multiple concepts, as then the concept documents should be updated to only contain the information relevant to that concept.

Note: to make reviewing easier, the PR has been split into three separate commits. Please squash this PR upon merging.
