### PR TITLE
[Rust] options - replace about.md file with concept files

### DIFF
--- a/languages/rust/concepts/option/about.md
+++ b/languages/rust/concepts/option/about.md
@@ -1,1 +1,0 @@
-TODO: add information on option concept


### PR DESCRIPTION
In [this issue](https://github.com/exercism/v3/issues/2293) we're describing an evolution of the specification of this repo.
These changes include, amongst others, replacing the contents of the `after.md` document with individual concept documents. There are two documents per concept:

1. An `about.md` file containing the description of the concept
1. A `links.json` file containing a set of useful links related to the concept. 

This looks as follows in the repo:

```
<track>
├── concepts
│   ├── <concept>
│   │   ├── about.md
│   │   └── links.json
│   └── ...
```

This PR applies this change to this exercise by: 
                
1. Copying the existing `after.md` file's contents to the `about.md` file of each concept listed in the exercise's `concepts` section in the `config.json` file.
1. Extract the links from the `after.md` file and put them into the `links.json` file

Before merging this PR, please check that the contents of the concept documents makes sense.
This is especially true when the exercise unlocks multiple concepts, as then the concept documents should be updated to only contain the information relevant to that concept.

Note: to make reviewing easier, the PR has been split into three separate commits. Please squash this PR upon merging.
