### PR TITLE
[Go] numbers - replace about.md file with concept files

### DIFF
--- a/languages/go/concepts/conditionals/about.md
+++ b/languages/go/concepts/conditionals/about.md
@@ -1,1 +1,6 @@
-TODO: add information on conditionals concept
+### Type Conversion
+
+For more information on Type Conversion please see
+[A Tour of Go: Type Conversions][type-conversion]
+
+[type-conversion]: https://tour.golang.org/basics/13

--- a/languages/go/concepts/conditionals/links.json
+++ b/languages/go/concepts/conditionals/links.json
@@ -1,1 +1,6 @@
-[]
+[
+  {
+    "url": "https://tour.golang.org/basics/13",
+    "description": "type-conversion"
+  }
+]

--- a/languages/go/concepts/numbers/about.md
+++ b/languages/go/concepts/numbers/about.md
@@ -1,1 +1,6 @@
-TODO: add information on numbers concept
+### Type Conversion
+
+For more information on Type Conversion please see
+[A Tour of Go: Type Conversions][type-conversion]
+
+[type-conversion]: https://tour.golang.org/basics/13

--- a/languages/go/concepts/numbers/links.json
+++ b/languages/go/concepts/numbers/links.json
@@ -1,1 +1,6 @@
-[]
+[
+  {
+    "url": "https://tour.golang.org/basics/13",
+    "description": "type-conversion"
+  }
+]

--- a/languages/go/exercises/concept/numbers/.docs/after.md
+++ b/languages/go/exercises/concept/numbers/.docs/after.md
@@ -1,6 +1,0 @@
-### Type Conversion
-
-For more information on Type Conversion please see
-[A Tour of Go: Type Conversions][type-conversion]
-
-[type-conversion]: https://tour.golang.org/basics/13


### PR DESCRIPTION
In [this issue](https://github.com/exercism/v3/issues/2293) we're describing an evolution of the specification of this repo.
These changes include, amongst others, replacing the contents of the `after.md` document with individual concept documents. There are two documents per concept:

1. An `about.md` file containing the description of the concept
1. A `links.json` file containing a set of useful links related to the concept. 

This looks as follows in the repo:

```
<track>
├── concepts
│   ├── <concept>
│   │   ├── about.md
│   │   └── links.json
│   └── ...
```

This PR applies this change to this exercise by: 
                    
1. Copying the existing `after.md` file's contents to the `about.md` file of each concept listed in the exercise's `concepts` section in the `config.json` file.
1. Extract the links from the `after.md` file and put them into the `links.json` file

Before merging this PR, please check that the contents of the concept documents makes sense.
This is especially true when the exercise unlocks multiple concepts, as then the concept documents should be updated to only contain the information relevant to that concept.

Note: to make reviewing easier, the PR has been split into three separate commits. Please squash this PR upon merging.
