### PR TITLE
[Ruby] strings - replace about.md file with concept files

### DIFF
--- a/languages/ruby/concepts/strings/about.md
+++ b/languages/ruby/concepts/strings/about.md
@@ -1,1 +1,9 @@
-TODO: add information on strings concept
+The key thing to remember about Ruby strings is that they are objects that you call methods on. You can find all the methods in the [Ruby docs][ruby-doc.org-string]
+
+It's also worth knowing that strings can be created using single quotes (`'`) or double quotes (`"`). Single-quoted strings don't process ASCII escape codes(\n, \t etc.), and they don't do [string interpolation][ruby-for-beginners.rubymonstas.org-interpolation] while double-quoted does both.
+
+You can also create strings using the [heredoc syntax][ruby-heredoc] or using the `%q` and `%Q` helpers.
+
+[ruby-for-beginners.rubymonstas.org-interpolation]: http://ruby-for-beginners.rubymonstas.org/bonus/string_interpolation.html
+[ruby-doc.org-string]: https://ruby-doc.org/core-2.7.0/String.html
+[ruby-heredoc]: https://www.rubyguides.com/2018/11/ruby-heredoc/

--- a/languages/ruby/concepts/strings/links.json
+++ b/languages/ruby/concepts/strings/links.json
@@ -1,1 +1,14 @@
-[]
+[
+  {
+    "url": "https://ruby-doc.org/core-2.7.0/String.html",
+    "description": "ruby-doc.org-string"
+  },
+  {
+    "url": "http://ruby-for-beginners.rubymonstas.org/bonus/string_interpolation.html",
+    "description": "ruby-for-beginners.rubymonstas.org-interpolation"
+  },
+  {
+    "url": "https://www.rubyguides.com/2018/11/ruby-heredoc/",
+    "description": "ruby-heredoc"
+  }
+]

--- a/languages/ruby/exercises/concept/strings/.docs/after.md
+++ b/languages/ruby/exercises/concept/strings/.docs/after.md
@@ -1,9 +1,0 @@
-The key thing to remember about Ruby strings is that they are objects that you call methods on. You can find all the methods in the [Ruby docs][ruby-doc.org-string]
-
-It's also worth knowing that strings can be created using single quotes (`'`) or double quotes (`"`). Single-quoted strings don't process ASCII escape codes(\n, \t etc.), and they don't do [string interpolation][ruby-for-beginners.rubymonstas.org-interpolation] while double-quoted does both.
-
-You can also create strings using the [heredoc syntax][ruby-heredoc] or using the `%q` and `%Q` helpers.
-
-[ruby-for-beginners.rubymonstas.org-interpolation]: http://ruby-for-beginners.rubymonstas.org/bonus/string_interpolation.html
-[ruby-doc.org-string]: https://ruby-doc.org/core-2.7.0/String.html
-[ruby-heredoc]: https://www.rubyguides.com/2018/11/ruby-heredoc/


### PR DESCRIPTION
In [this issue](https://github.com/exercism/v3/issues/2293) we're describing an evolution of the specification of this repo.
These changes include, amongst others, replacing the contents of the `after.md` document with individual concept documents. There are two documents per concept:

1. An `about.md` file containing the description of the concept
1. A `links.json` file containing a set of useful links related to the concept. 

This looks as follows in the repo:

```
<track>
├── concepts
│   ├── <concept>
│   │   ├── about.md
│   │   └── links.json
│   └── ...
```

This PR applies this change to this exercise by: 
                    
1. Copying the existing `after.md` file's contents to the `about.md` file of each concept listed in the exercise's `concepts` section in the `config.json` file.
1. Extract the links from the `after.md` file and put them into the `links.json` file

Before merging this PR, please check that the contents of the concept documents makes sense.
This is especially true when the exercise unlocks multiple concepts, as then the concept documents should be updated to only contain the information relevant to that concept.

Note: to make reviewing easier, the PR has been split into three separate commits. Please squash this PR upon merging.
