### PR TITLE
[JavaScript] booleans - replace about.md file with concept files

### DIFF
--- a/languages/javascript/concepts/booleans/about.md
+++ b/languages/javascript/concepts/booleans/about.md
@@ -1,1 +1,7 @@
-TODO: add information on booleans concept
+JavaScript uses `true` and `false` to represent the two truth values of logic.
+
+In JavaScript, for each of the three logical operations (AND, OR and NOT) there is a corresponding operator: `&&`, `||` and `!`. In general, there are rules regarding the order of the operations and, in this case, `!` (negation) is applied first, and then `&&` (conjunction) and then `||` (disjunction).
+
+You can always 'escape' these rules by using an operator with an even higher precedence, namely, `( )` named the 'Grouping operator' or simply said 'parentheses'. As a matter of fact the `( )` operator has the highest precedence of all JavaScript operators. More information about operators precedence [here].
+
+[here]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence

--- a/languages/javascript/concepts/booleans/about.md
+++ b/languages/javascript/concepts/booleans/about.md
@@ -2,6 +2,6 @@ JavaScript uses `true` and `false` to represent the two truth values of logic.
 
 In JavaScript, for each of the three logical operations (AND, OR and NOT) there is a corresponding operator: `&&`, `||` and `!`. In general, there are rules regarding the order of the operations and, in this case, `!` (negation) is applied first, and then `&&` (conjunction) and then `||` (disjunction).
 
-You can always 'escape' these rules by using an operator with an even higher precedence, namely, `( )` named the 'Grouping operator' or simply said 'parentheses'. As a matter of fact the `( )` operator has the highest precedence of all JavaScript operators. More information about operators precedence [here].
+The order of operations between the operators can be overcome by using an operator with an even higher precedence: `( )`, named the 'Grouping operator' or simply said 'parentheses'. As a matter of fact the `( )` operator has the highest precedence of all JavaScript operators. More information about operators precedence [here].
 
 [here]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence

--- a/languages/javascript/concepts/booleans/links.json
+++ b/languages/javascript/concepts/booleans/links.json
@@ -1,1 +1,6 @@
-[]
+[
+  {
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence",
+    "description": "here"
+  }
+]

--- a/languages/javascript/exercises/concept/booleans/.docs/after.md
+++ b/languages/javascript/exercises/concept/booleans/.docs/after.md
@@ -1,7 +1,0 @@
-JavaScript uses `true` and `false` to represent the two truth values of logic.
-
-In JavaScript, for each of the three logical operations (AND, OR and NOT) there is a corresponding operator: `&&`, `||` and `!`. In general, there are rules regarding the order of the operations and, in this case, `!` (negation) is applied first, and then `&&` (conjunction) and then `||` (disjunction).
-
-You can always 'escape' these rules by using an operator with an even higher precedence, namely, `( )` named the 'Grouping operator' or simply said 'parentheses'. As a matter of fact the `( )` operator has the highest precedence of all JavaScript operators. More information about operators precedence [here].
-
-[here]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence


### PR DESCRIPTION
In [this issue](https://github.com/exercism/v3/issues/2293) we're describing an evolution of the specification of this repo.
These changes include, amongst others, replacing the contents of the `after.md` document with individual concept documents. There are two documents per concept:

1. An `about.md` file containing the description of the concept
1. A `links.json` file containing a set of useful links related to the concept. 

This looks as follows in the repo:

```
<track>
├── concepts
│   ├── <concept>
│   │   ├── about.md
│   │   └── links.json
│   └── ...
```

This PR applies this change to this exercise by: 
                    
1. Copying the existing `after.md` file's contents to the `about.md` file of each concept listed in the exercise's `concepts` section in the `config.json` file.
1. Extract the links from the `after.md` file and put them into the `links.json` file

Before merging this PR, please check that the contents of the concept documents makes sense.
This is especially true when the exercise unlocks multiple concepts, as then the concept documents should be updated to only contain the information relevant to that concept.

Note: to make reviewing easier, the PR has been split into three separate commits. Please squash this PR upon merging.
