### PR TITLE
[C#] exceptions - replace about.md file with concept files

### DIFF
--- a/languages/csharp/concepts/exceptions/about.md
+++ b/languages/csharp/concepts/exceptions/about.md
@@ -1,1 +1,9 @@
-TODO: add information on exceptions concept
+It is important to note that `exceptions` should be used in cases where something exceptional happens, an error that needs special handeling. It should not be used for control-flow of a program, as that is considered bad design, which often leads to bad performance and maintainability.
+
+Some of the more common exceptions include `IndexOutOfRangeException`, `ArgumentOutOfRangeException`, `NullReferenceException`, `StackOverflowException`, `ArgumentException`, `InvalidOperationException` and `DivideByZeroException`.
+
+Some of the cases when exceptions should be thrown include:
+
+- if the method cannot complete its defined functionality
+- an inappropriate call to an object is made, based on the object state
+- when an argument to a method causes an exception

--- a/languages/csharp/exercises/concept/exceptions/.docs/after.md
+++ b/languages/csharp/exercises/concept/exceptions/.docs/after.md
@@ -1,9 +1,0 @@
-It is important to note that `exceptions` should be used in cases where something exceptional happens, an error that needs special handeling. It should not be used for control-flow of a program, as that is considered bad design, which often leads to bad performance and maintainability.
-
-Some of the more common exceptions include `IndexOutOfRangeException`, `ArgumentOutOfRangeException`, `NullReferenceException`, `StackOverflowException`, `ArgumentException`, `InvalidOperationException` and `DivideByZeroException`.
-
-Some of the cases when exceptions should be thrown include:
-
-- if the method cannot complete its defined functionality
-- an inappropriate call to an object is made, based on the object state
-- when an argument to a method causes an exception


### PR DESCRIPTION
In [this issue](https://github.com/exercism/v3/issues/2293) we're describing an evolution of the specification of this repo.
These changes include, amongst others, replacing the contents of the `after.md` document with individual concept documents. There are two documents per concept:

1. An `about.md` file containing the description of the concept
1. A `links.json` file containing a set of useful links related to the concept. 

This looks as follows in the repo:

```
<track>
├── concepts
│   ├── <concept>
│   │   ├── about.md
│   │   └── links.json
│   └── ...
```

This PR applies this change to this exercise by: 
                    
1. Copying the existing `after.md` file's contents to the `about.md` file of each concept listed in the exercise's `concepts` section in the `config.json` file.
1. Extract the links from the `after.md` file and put them into the `links.json` file

Before merging this PR, please check that the contents of the concept documents makes sense.
This is especially true when the exercise unlocks multiple concepts, as then the concept documents should be updated to only contain the information relevant to that concept.

Note: to make reviewing easier, the PR has been split into three separate commits. Please squash this PR upon merging.
