### PR TITLE
[Common Lisp] lists - replace about.md file with concept files

### DIFF
--- a/languages/common-lisp/concepts/cons/about.md
+++ b/languages/common-lisp/concepts/cons/about.md
@@ -1,1 +1,11 @@
-TODO: add information on cons concept
+[Conses][hyper-conses] are a basic data type in Common Lisp. They are composed of a head and a tail (called for
+historical reason[1] the `car` and the `cdr`). There is no restriction on the data types of the head and tail of a cons.
+
+Conses are created with the [`cons`][hyper-cons] function which takes two objects and evaluates to a cons (also sometimes termed a 'cons cell').
+
+The parts of a cons may be accessed with the functions [`car`][hyper-car] and [`cdr`][hyper-cdr].
+
+[hyper-conses]: http://l1sp.org/cl/14
+[hyper-cons]: http://l1sp.org/cl/cons
+[hyper-car]: http://l1sp.org/cl/car
+[hyper-cdr]: http://l1sp.org/cl/cdr

--- a/languages/common-lisp/concepts/cons/links.json
+++ b/languages/common-lisp/concepts/cons/links.json
@@ -1,1 +1,30 @@
-[]
+[
+  {
+    "url": "http://l1sp.org/cl/14",
+    "description": "Hyperspec Chapter on Conses"
+  },
+  {
+    "url": "http://l1sp.org/cl/cons",
+    "description": "Hyperspec reference for `cons`"
+  },
+  {
+    "url": "http://l1sp.org/cl/car",
+    "description": "Hyperpsec reference for `car`"
+  },
+  {
+    "url": "http://l1sp.org/cl/cdr",
+    "description": "Hyperspec reference for `cdr`"
+  },
+  {
+    "url": "https://www.tutorialspoint.com/lisp/lisp_lists.htm",
+    "description": "Summary of functions pertaining to lists and conses"
+  },
+  {
+    "url": "http://www.gigamonkeys.com/book/they-called-it-lisp-for-a-reason-list-processing.html",
+    "description": "Practical Common Lisp chapter on lists and conses."
+  },
+  {
+    "url": "http://l1sp.org/cl/14.1.2",
+    "description": "Hyperspec reference on conses as lists."
+  }
+]

--- a/languages/common-lisp/concepts/lists/about.md
+++ b/languages/common-lisp/concepts/lists/about.md
@@ -1,1 +1,48 @@
-TODO: add information on lists concept
+## Summary
+
+Lists are a very common datatype in Common Lisp. They can be constructed via `list` or `cons` or even just quoting `'(a b c)`.
+
+```lisp
+'(1 2 3) ; => (1 2 3)
+(cons 1 (const 2 3)) ; => (1 2 3)
+(list 1 2 3) ; => (1 2 3)
+```
+
+The first element and rest of a list (called the `car` and the `cdr` respectively) can be accessed with the `car` and `cdr` functions or their aliases `first` and `rest`. The elements of a list can also be accessed by index via `nth`, or the helper functions `first` through `tenth`.
+
+```lisp
+(car '(1 2 3)) ; => 1
+(cdr '(1 2 3)) ; => (2 3)
+(nth 1 '(1 2 3)) ; => 2
+```
+
+While lists can be though of as simply sequences of values they are also a recursive data structure in that each element of a list may itself be a list.
+
+## Diving Deeper
+
+### `car` and `cdr` concatenation
+
+Back before more specialized data structures were added to the Lisp family of languages lists were used for everything. By creating abstractions (such as getter and setter functions) around list structures (and their nested values) one can uses lists to implement complex data structures. To simplify the accessing of data in nested lists the language can parse the use of "composed" `car` and `cdr` calls.
+
+The language defines helper functions for the arbitrary composition of up to 4 `car` or `cdr` calls. These functions have names which begin with `c` and end with `r` and between which are up to 4 `a` or `d` characters. The language interprets those functions as if they were a functional composition of the respective `car` or `cdr` calls. For example:
+
+```lisp
+(caar '((a b) (c d))) ; => A
+(cdar '((a b) (c d))) ; => B
+(cadr '((a b) (c d))) ; => (C D)
+(caadr '((a b) (c d))) ; => C
+(cdadr '((a b) (c d))) ; => (D)
+(cadadr '((a b) (c d))) ; => D
+```
+
+## Reference
+
+[Tutorialspoint][tutorialspoint] has a good summary of list functions and [Practical Common Lisp][pcl] is a good reference with more details.
+
+The [Hyperspec][hyperspec] is the ultimate reference to the language. Its section on [conses][hyper-conses] describes all functions which can be used on lists. Its section on [sequences][hyper-sequences] describes those functions which can be used on sequences (which lists are).
+
+[hyper-conses]: http://www.lispworks.com/documentation/HyperSpec/Body/14_.htm
+[hyper-seqs]: http://www.lispworks.com/documentation/HyperSpec/Body/17_.htm
+[hyperspec]: http://www.lispworks.com/documentation/HyperSpec/Front/index.htm
+[pcl]: http://www.gigamonkeys.com/book/they-called-it-lisp-for-a-reason-list-processing.html
+[tutorialspoint]: https://www.tutorialspoint.com/lisp/lisp_lists.htm

--- a/languages/common-lisp/concepts/lists/about.md
+++ b/languages/common-lisp/concepts/lists/about.md
@@ -1,48 +1,9 @@
-## Summary
+[Lists][hyper-cons-as-list] are a very common data type in Common Lisp. They are made up of a sequence of [cons][../cons/about.md] cells. Each `car` is an element of the list and every `cdr` is a either the next cons cell or a terminating atom.
 
-Lists are a very common datatype in Common Lisp. They can be constructed via `list` or `cons` or even just quoting `'(a b c)`.
+A list which terminates with the empty list is called a "proper list".
 
-```lisp
-'(1 2 3) ; => (1 2 3)
-(cons 1 (const 2 3)) ; => (1 2 3)
-(list 1 2 3) ; => (1 2 3)
-```
+A list which terminates with an atom that is not th empty list is called a "dotted list" (based upon how it is printed: `(cons 'a 'b) ;=> (a . b)`).
 
-The first element and rest of a list (called the `car` and the `cdr` respectively) can be accessed with the `car` and `cdr` functions or their aliases `first` and `rest`. The elements of a list can also be accessed by index via `nth`, or the helper functions `first` through `tenth`.
+A list can also be circular if some cons cell in the list `cdr` of a later cons cell.
 
-```lisp
-(car '(1 2 3)) ; => 1
-(cdr '(1 2 3)) ; => (2 3)
-(nth 1 '(1 2 3)) ; => 2
-```
-
-While lists can be though of as simply sequences of values they are also a recursive data structure in that each element of a list may itself be a list.
-
-## Diving Deeper
-
-### `car` and `cdr` concatenation
-
-Back before more specialized data structures were added to the Lisp family of languages lists were used for everything. By creating abstractions (such as getter and setter functions) around list structures (and their nested values) one can uses lists to implement complex data structures. To simplify the accessing of data in nested lists the language can parse the use of "composed" `car` and `cdr` calls.
-
-The language defines helper functions for the arbitrary composition of up to 4 `car` or `cdr` calls. These functions have names which begin with `c` and end with `r` and between which are up to 4 `a` or `d` characters. The language interprets those functions as if they were a functional composition of the respective `car` or `cdr` calls. For example:
-
-```lisp
-(caar '((a b) (c d))) ; => A
-(cdar '((a b) (c d))) ; => B
-(cadr '((a b) (c d))) ; => (C D)
-(caadr '((a b) (c d))) ; => C
-(cdadr '((a b) (c d))) ; => (D)
-(cadadr '((a b) (c d))) ; => D
-```
-
-## Reference
-
-[Tutorialspoint][tutorialspoint] has a good summary of list functions and [Practical Common Lisp][pcl] is a good reference with more details.
-
-The [Hyperspec][hyperspec] is the ultimate reference to the language. Its section on [conses][hyper-conses] describes all functions which can be used on lists. Its section on [sequences][hyper-sequences] describes those functions which can be used on sequences (which lists are).
-
-[hyper-conses]: http://www.lispworks.com/documentation/HyperSpec/Body/14_.htm
-[hyper-seqs]: http://www.lispworks.com/documentation/HyperSpec/Body/17_.htm
-[hyperspec]: http://www.lispworks.com/documentation/HyperSpec/Front/index.htm
-[pcl]: http://www.gigamonkeys.com/book/they-called-it-lisp-for-a-reason-list-processing.html
-[tutorialspoint]: https://www.tutorialspoint.com/lisp/lisp_lists.htm
+[hyper-cons-as-list]: http://l1sp.org/cl/14.1.2

--- a/languages/common-lisp/concepts/lists/about.md
+++ b/languages/common-lisp/concepts/lists/about.md
@@ -4,6 +4,7 @@ A list which terminates with the empty list is called a "proper list".
 
 A list which terminates with an atom that is not th empty list is called a "dotted list" (based upon how it is printed: `(cons 'a 'b) ;=> (a . b)`).
 
-A list can also be circular if some cons cell in the list `cdr` of a later cons cell.
+A list can also be circular if some cons cell in the list `cdr` of a later cons cell. For example: `(let ((x (list 1))) (setf (cdr x) x) (write x :stream t :circle t) :done)`. Take care when working with circular lists as allowing them to be printed out without binding [`*print-circle*`][hyper-print-circle] to `t` will cause an infinite loop and will lock up the REPL (in this example by specifying `:circle t` to `write`, `*print-circle` will be bound to `t`).
 
 [hyper-cons-as-list]: http://l1sp.org/cl/14.1.2
+[hyper-print-circle]: http://l1sp.org/cl/*print-circle*

--- a/languages/common-lisp/concepts/lists/links.json
+++ b/languages/common-lisp/concepts/lists/links.json
@@ -1,18 +1,14 @@
 [
   {
     "url": "https://www.tutorialspoint.com/lisp/lisp_lists.htm",
-    "description": "tutorialspoint"
+    "description": "Summary of functions pertaining to lists and conses"
   },
   {
     "url": "http://www.gigamonkeys.com/book/they-called-it-lisp-for-a-reason-list-processing.html",
-    "description": "pcl"
+    "description": "Practical Common Lisp chapter on lists and conses."
   },
   {
-    "url": "http://www.lispworks.com/documentation/HyperSpec/Front/index.htm",
-    "description": "hyperspec"
-  },
-  {
-    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/14_.htm",
-    "description": "hyper-conses"
+    "url": "http://l1sp.org/cl/14.1.2",
+    "description": "Hyperspec reference on conses as lists."
   }
 ]

--- a/languages/common-lisp/concepts/lists/links.json
+++ b/languages/common-lisp/concepts/lists/links.json
@@ -1,1 +1,18 @@
-[]
+[
+  {
+    "url": "https://www.tutorialspoint.com/lisp/lisp_lists.htm",
+    "description": "tutorialspoint"
+  },
+  {
+    "url": "http://www.gigamonkeys.com/book/they-called-it-lisp-for-a-reason-list-processing.html",
+    "description": "pcl"
+  },
+  {
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Front/index.htm",
+    "description": "hyperspec"
+  },
+  {
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/14_.htm",
+    "description": "hyper-conses"
+  }
+]

--- a/languages/common-lisp/config.json
+++ b/languages/common-lisp/config.json
@@ -289,7 +289,7 @@
       "uuid": "9afa389a-17e2-4991-ab48-64be5fc955aa",
       "slug": "cons",
       "name": "Cons",
-      "blurb": "TODO: add blurb for cons concept"
+      "blurb": "An ordered pair of elements."
     },
     {
       "uuid": "b9f5a5fd-57e9-4003-880b-499206e1554f",
@@ -349,7 +349,7 @@
       "uuid": "65c600a7-7f6a-428f-9913-d6f127f35234",
       "slug": "lists",
       "name": "Lists",
-      "blurb": "TODO: add blurb for lists concept"
+      "blurb": "A recursive data structure made from a head and tail."
     },
     {
       "uuid": "5a6598c3-8d92-4eca-b36e-42ba4b435237",

--- a/languages/common-lisp/exercises/concept/leslies-lists/.docs/introduction.md
+++ b/languages/common-lisp/exercises/concept/leslies-lists/.docs/introduction.md
@@ -1,4 +1,4 @@
-### lists
+### Lists
 
 Given that the name of the language is Lisp which stands of _LISt Processing_ one might assume that the language has facilities for handling lists of items, and you'd be correct!
 
@@ -8,7 +8,7 @@ A list in Common Lisp is a sequence of items. The items themselves do not have t
 
 #### Creating Lists
 
-One can simply type in a quoted list like this: `'(1 two "III")` and that will cause a list to be created and evaluated (it evaluates to: `(1 two" "III")`.
+One can simply type in a quoted list like this: `'(1 two "III")` and that will cause a list to be created and evaluated (it evaluates to: `(1 two "III")`.
 
 There are also two main functions used to create lists: `list` and `cons`.
 
@@ -30,7 +30,7 @@ There are also two main functions used to create lists: `list` and `cons`.
 
 (`first` and `rest` are synonyms of `car` and `cdr` and work exactly the same.)
 
-#### Length & random access
+#### Length & Random Access
 
 The length of a list can be determined by the use of `length`. An empty list has length zero.
 

--- a/languages/common-lisp/exercises/concept/leslies-lists/.docs/introduction.md
+++ b/languages/common-lisp/exercises/concept/leslies-lists/.docs/introduction.md
@@ -1,4 +1,4 @@
-### Lists in Common Lisp
+### lists
 
 Given that the name of the language is Lisp which stands of _LISt Processing_ one might assume that the language has facilities for handling lists of items, and you'd be correct!
 
@@ -6,13 +6,7 @@ While Common Lisp has other data structures as well as lists, lists are still he
 
 A list in Common Lisp is a sequence of items. The items themselves do not have to be the same type. For example you can have a list of `1`, `two`, `"III"`.
 
-A list is composed of two parts called (for historical reason[1]) the `car` and the `cdr`. (Those are also the names of the functions used to access those two parts.).
-
-A list is a recursive data structure in that both the `car` and `cdr` may themselves be lists. In fact a list of more a single item will have a `cdr` which itself has a `car` and `cdr` (see below). Typically the final `cdr` of a list will be `nil` but can be any value. Note: an empty list has `nil` for both `car` and `cdr`.
-
-A list is represented by the values delimited with parentheses. (Thus Common Lisp source code can be seen to be a series of lists of things.)
-
-### Creating Lists
+#### Creating Lists
 
 One can simply type in a quoted list like this: `'(1 two "III")` and that will cause a list to be created and evaluated (it evaluates to: `(1 two" "III")`.
 
@@ -36,7 +30,7 @@ There are also two main functions used to create lists: `list` and `cons`.
 
 (`first` and `rest` are synonyms of `car` and `cdr` and work exactly the same.)
 
-### Length & random access
+#### Length & random access
 
 The length of a list can be determined by the use of `length`. An empty list has length zero.
 


### PR DESCRIPTION
In [this issue](https://github.com/exercism/v3/issues/2293) we're describing an evolution of the specification of this repo.
These changes include, amongst others, replacing the contents of the `after.md` document with individual concept documents. There are two documents per concept:

1. An `about.md` file containing the description of the concept
1. A `links.json` file containing a set of useful links related to the concept. 

This looks as follows in the repo:

```
<track>
├── concepts
│   ├── <concept>
│   │   ├── about.md
│   │   └── links.json
│   └── ...
```

This PR applies this change to this exercise by: 
                    
1. Copying the existing `after.md` file's contents to the `about.md` file of each concept listed in the exercise's `concepts` section in the `config.json` file.
1. Extract the links from the `after.md` file and put them into the `links.json` file

Before merging this PR, please check that the contents of the concept documents makes sense.
This is especially true when the exercise unlocks multiple concepts, as then the concept documents should be updated to only contain the information relevant to that concept.

Note: to make reviewing easier, the PR has been split into three separate commits. Please squash this PR upon merging.
