### PR TITLE
[Julia] multiple-dispatch - replace about.md file with concept files

### DIFF
--- a/languages/julia/concepts/multiple-dispatch/about.md
+++ b/languages/julia/concepts/multiple-dispatch/about.md
@@ -1,1 +1,3 @@
-TODO: add information on multiple-dispatch concept
+- ["Rock–paper–scissors game in less than 10 lines of code"](https://giordano.github.io/blog/2017-11-03-rock-paper-scissors/), by Mosè Giordano.
+- "The Unreasonable Effectiveness of Multiple Dispatch", by Stefan Karpinski at JuliaCon 2019, available on [YouTube](https://youtu.be/kc9HwsxE1OY).
+- ["Orthogonalize your [methods] design"](https://docs.julialang.org/en/v1/manual/methods/#man-methods-orthogonalize-1), Julia Manual.

--- a/languages/julia/concepts/multiple-dispatch/links.json
+++ b/languages/julia/concepts/multiple-dispatch/links.json
@@ -1,14 +1,6 @@
 [
     {
-        "url": "https://giordano.github.io/blog/2017-11-03-rock-paper-scissors/",
-        "description": "\"Rock–paper–scissors game in less than 10 lines of code\", by Mosè Giordano."
-    },
-    {
-        "url": "https://youtu.be/kc9HwsxE1OY",
-        "description": "\"The Unreasonable Effectiveness of Multiple Dispatch\", by Stefan Karpinski at JuliaCon 2019."
-    },
-    {
-        "url": "https://docs.julialang.org/en/v1/manual/methods/#man-methods-orthogonalize-1",
-        "description": "\"Orthogonalize your methods design\", Julia Manual."
+        "url": "https://docs.julialang.org/en/v1/manual/methods/",
+        "description": "Julia Manual"
     }
 ]

--- a/languages/julia/concepts/multiple-dispatch/links.json
+++ b/languages/julia/concepts/multiple-dispatch/links.json
@@ -1,11 +1,11 @@
 [
     {
         "url": "https://giordano.github.io/blog/2017-11-03-rock-paper-scissors/",
-        "description": "\u0022Rock\u2013paper\u2013scissors game in less than 10 lines of code\u0022"
+        "description": "\"Rock–paper–scissors game in less than 10 lines of code\", by Mosè Giordano."
     },
-    { "url": "https://youtu.be/kc9HwsxE1OY", "description": "YouTube" },
+    { "url": "https://youtu.be/kc9HwsxE1OY", "description": "\"The Unreasonable Effectiveness of Multiple Dispatch\", by Stefan Karpinski at JuliaCon 2019." },
     {
         "url": "https://docs.julialang.org/en/v1/manual/methods/#man-methods-orthogonalize-1",
-        "description": "\u0022Orthogonalize your  [ methods] design\u0022"
+        "description": "\"Orthogonalize your methods design\", Julia Manual."
     }
 ]

--- a/languages/julia/concepts/multiple-dispatch/links.json
+++ b/languages/julia/concepts/multiple-dispatch/links.json
@@ -1,1 +1,11 @@
-[]
+[
+    {
+        "url": "https://giordano.github.io/blog/2017-11-03-rock-paper-scissors/",
+        "description": "\u0022Rock\u2013paper\u2013scissors game in less than 10 lines of code\u0022"
+    },
+    { "url": "https://youtu.be/kc9HwsxE1OY", "description": "YouTube" },
+    {
+        "url": "https://docs.julialang.org/en/v1/manual/methods/#man-methods-orthogonalize-1",
+        "description": "\u0022Orthogonalize your  [ methods] design\u0022"
+    }
+]

--- a/languages/julia/concepts/multiple-dispatch/links.json
+++ b/languages/julia/concepts/multiple-dispatch/links.json
@@ -3,7 +3,10 @@
         "url": "https://giordano.github.io/blog/2017-11-03-rock-paper-scissors/",
         "description": "\"Rock–paper–scissors game in less than 10 lines of code\", by Mosè Giordano."
     },
-    { "url": "https://youtu.be/kc9HwsxE1OY", "description": "\"The Unreasonable Effectiveness of Multiple Dispatch\", by Stefan Karpinski at JuliaCon 2019." },
+    {
+        "url": "https://youtu.be/kc9HwsxE1OY",
+        "description": "\"The Unreasonable Effectiveness of Multiple Dispatch\", by Stefan Karpinski at JuliaCon 2019."
+    },
     {
         "url": "https://docs.julialang.org/en/v1/manual/methods/#man-methods-orthogonalize-1",
         "description": "\"Orthogonalize your methods design\", Julia Manual."

--- a/languages/julia/exercises/concept/multiple-dispatch/.docs/after.md
+++ b/languages/julia/exercises/concept/multiple-dispatch/.docs/after.md
@@ -1,3 +1,0 @@
-- ["Rock–paper–scissors game in less than 10 lines of code"](https://giordano.github.io/blog/2017-11-03-rock-paper-scissors/), by Mosè Giordano.
-- "The Unreasonable Effectiveness of Multiple Dispatch", by Stefan Karpinski at JuliaCon 2019, available on [YouTube](https://youtu.be/kc9HwsxE1OY).
-- ["Orthogonalize your [methods] design"](https://docs.julialang.org/en/v1/manual/methods/#man-methods-orthogonalize-1), Julia Manual.


### PR DESCRIPTION
In [this issue](https://github.com/exercism/v3/issues/2293) we're describing an evolution of the specification of this repo.
These changes include, amongst others, replacing the contents of the `after.md` document with individual concept documents. There are two documents per concept:

1. An `about.md` file containing the description of the concept
1. A `links.json` file containing a set of useful links related to the concept. 

This looks as follows in the repo:

```
<track>
├── concepts
│   ├── <concept>
│   │   ├── about.md
│   │   └── links.json
│   └── ...
```

This PR applies this change to this exercise by: 
                    
1. Copying the existing `after.md` file's contents to the `about.md` file of each concept listed in the exercise's `concepts` section in the `config.json` file.
1. Extract the links from the `after.md` file and put them into the `links.json` file

Before merging this PR, please check that the contents of the concept documents makes sense.
This is especially true when the exercise unlocks multiple concepts, as then the concept documents should be updated to only contain the information relevant to that concept.

Note: to make reviewing easier, the PR has been split into three separate commits. Please squash this PR upon merging.
