### PR TITLE
Update documentation for Lists.

### DIFF
--- a/languages/elixir/concepts/lists/about.md
+++ b/languages/elixir/concepts/lists/about.md
@@ -1,6 +1,8 @@
 [Lists][list] are a basic data type in Elixir for holding a collection of values. Lists are _immutable_, meaning they cannot be modified; any operation that changes a list returns a new list. Lists implement the [Enumerable protocol][enum-protocol], which allows the use of [Enum][enum] and [Stream][stream] module functions.
 
-Lists can be written in literal form, head-tail notation, or a combination of both:
+Lists in Elixir are implemented as a Linked List, and not as an array of contiguous memory location . Therefore, accessing an element in the list takes linear time depending on the length of the list. 
+
+Lists can be written in literal form, head-tail notation, (which uses the `join` operator `|`), or a combination of both:
 
 ```elixir
 # Literal Form
@@ -17,6 +19,13 @@ Lists can be written in literal form, head-tail notation, or a combination of bo
 [1 | [2, 3]]
 ```
 
+There can also be more than one element before the join operator.
+
+```elixir
+# Multiple prepends
+[1, 2, 3 | [4, 5]]
+```
+
 Head-tail notation can be used to append items to a list.
 
 ```elixir
@@ -25,6 +34,8 @@ list = [2, 1]
 [3, 2, 1] == [3 | list]
 # => true
 ```
+
+Appending an element to a list during iteration is considered an anti-pattern. We can achieve the same result by prepending an element to the reversed list, and then reversing the result.
 
 There are several common functions for lists:
 

--- a/languages/elixir/concepts/lists/about.md
+++ b/languages/elixir/concepts/lists/about.md
@@ -42,7 +42,7 @@ We can achieve the same result by prepending an element to the reversed list, an
 ```elixir
 # [1, 2, 3] ++ [4, 5, 6] is equivalent to the much faster operation:
 Enum.reverse([6 | [5 | 4 | Enum.reverse([1, 2, 3])]])
-````
+```
 
 There are several common functions for lists:
 

--- a/languages/elixir/concepts/lists/about.md
+++ b/languages/elixir/concepts/lists/about.md
@@ -1,6 +1,6 @@
 [Lists][list] are a basic data type in Elixir for holding a collection of values. Lists are _immutable_, meaning they cannot be modified; any operation that changes a list returns a new list. Lists implement the [Enumerable protocol][enum-protocol], which allows the use of [Enum][enum] and [Stream][stream] module functions.
 
-Lists in Elixir are implemented as a Linked List, and not as an array of contiguous memory location . Therefore, accessing an element in the list takes linear time depending on the length of the list. 
+Lists in Elixir are implemented as a Linked List, and not as an array of contiguous memory location. Therefore, accessing an element in the list takes linear time depending on the length of the list.
 
 Lists can be written in literal form, head-tail notation, (which uses the `join` operator `|`), or a combination of both:
 

--- a/languages/elixir/concepts/lists/about.md
+++ b/languages/elixir/concepts/lists/about.md
@@ -43,8 +43,8 @@ We can achieve the same result by prepending an element to the reversed list, an
 # Appending to the end of a list (potentially slow)
 [1, 2, 3] ++ [4] ++ [5] ++ [6]
 
-# Prepend to the start of a list then reverse (faster, due to the nature of linked lists)
-[6 | [5 | [4 | [3, 2, 1]]]] |> reverse()
+# Prepend to the start of a list (faster, due to the nature of linked lists)
+[6 | [5 | [4 | [3, 2, 1]]]] # then reverse!
 ```
 
 There are several common functions for lists:

--- a/languages/elixir/concepts/lists/about.md
+++ b/languages/elixir/concepts/lists/about.md
@@ -41,7 +41,7 @@ We can achieve the same result by prepending an element to the reversed list, an
 
 ```elixir
 # [1, 2, 3] ++ [4, 5, 6] is equivalent to the much faster operation:
-Enum.reverse([6 | [5 | 4 | Enum.reverse([1, 2, 3])]])
+Enum.reverse([6 | [5 | [4 | Enum.reverse([1, 2, 3])]]])
 ```
 
 There are several common functions for lists:

--- a/languages/elixir/concepts/lists/about.md
+++ b/languages/elixir/concepts/lists/about.md
@@ -40,8 +40,11 @@ Appending elements to a list during iteration is considered an anti-pattern. App
 We can achieve the same result by prepending an element to the reversed list, and then reversing the result. Prepending is a fast operation and requires constant time.
 
 ```elixir
-# [1, 2, 3] ++ [4, 5, 6] is equivalent to the much faster operation:
-Enum.reverse([6 | [5 | [4 | Enum.reverse([1, 2, 3])]]])
+# Appending to the end of a list (potentially slow)
+[1, 2, 3] ++ [4] ++ [5] ++ [6]
+
+# Prepend to the start of a list then reverse (faster, due to the nature of linked lists)
+[6 | [5 | [4 | [3, 2, 1]]]] |> reverse()
 ```
 
 There are several common functions for lists:

--- a/languages/elixir/concepts/lists/about.md
+++ b/languages/elixir/concepts/lists/about.md
@@ -35,7 +35,14 @@ list = [2, 1]
 # => true
 ```
 
-Appending an element to a list during iteration is considered an anti-pattern. We can achieve the same result by prepending an element to the reversed list, and then reversing the result.
+Appending elements to a list during iteration is considered an anti-pattern. Appending an element requires walking through the entire list and adding the element at the end, therefore, appending a new element in each iteration would require walking through the entire list in each iteration.
+
+We can achieve the same result by prepending an element to the reversed list, and then reversing the result. Prepending is a fast operation and requires constant time.
+
+```elixir
+# [1, 2, 3] ++ [4, 5, 6] is equivalent to the much faster operation:
+Enum.reverse([6 | [5 | 4 | Enum.reverse([1, 2, 3])]])
+````
 
 There are several common functions for lists:
 


### PR DESCRIPTION
A fix for https://github.com/exercism/v3/issues/2520.

Probably I'm not too sure about `appending to a list in a loop is an anti-pattern, prepend and reverse instead` bit since I've been thinking mostly in terms of list comprehensions. I've still add some explanation around it.

Open to make the changes based on any feedback. 