### PR TITLE
[CI] Rename workflows/builds to tidy up check view

### DIFF
--- a/.github/workflows/csharp-exercise-report.yml
+++ b/.github/workflows/csharp-exercise-report.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   update-csharp-exercises:
-    name: Update csharp exercise report
+    name: Update exercise report
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/csharp-exercise-report.yml
+++ b/.github/workflows/csharp-exercise-report.yml
@@ -1,4 +1,4 @@
-name: Update csharp exercise report
+name: C#
 
 on:
   push:
@@ -11,6 +11,7 @@ on:
 
 jobs:
   update-csharp-exercises:
+    name: Update csharp exercise report
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/julia-exercise-ci.yml
+++ b/.github/workflows/julia-exercise-ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    name: Exercise CI - ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Exercise CI - ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/julia-exercise-ci.yml
+++ b/.github/workflows/julia-exercise-ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    name: Exercise CI - ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Exercise CI - ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/julia-exercise-ci.yml
+++ b/.github/workflows/julia-exercise-ci.yml
@@ -1,4 +1,4 @@
-name: Julia Exercise CI
+name: Julia
 
 on:
   push:
@@ -12,6 +12,7 @@ on:
 
 jobs:
   test:
+    name: Exercise CI - ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,10 +1,11 @@
-name: "Pull Request Labeler"
+name: Tools
 
 on:
 - pull_request_target
 
 jobs:
   triage:
+    name: Pull Request Labeler
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@5f867a63be70efff62b767459b009290364495eb # 2.2.0

--- a/.github/workflows/nim-ci.yml
+++ b/.github/workflows/nim-ci.yml
@@ -1,4 +1,4 @@
-name: Nim Compilability CI
+name: Nim
 
 on:
   push:
@@ -12,6 +12,7 @@ on:
 
 jobs:
   check-compilation-pr:
+    name: Compilability CI - ${{ github.event_name }}
     runs-on: ubuntu-latest
     container: nimlang/nim:1.2.6
     if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/nim-ci.yml
+++ b/.github/workflows/nim-ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check-compilation-pr:
-    name: Compilability CI - ${{ github.event_name }}
+    name: Compilability CI
     runs-on: ubuntu-latest
     container: nimlang/nim:1.2.6
     if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/update-summary-concepts.yml
+++ b/.github/workflows/update-summary-concepts.yml
@@ -1,4 +1,4 @@
-name: Update concepts summary
+name: Tools
 
 on:
   push:
@@ -10,6 +10,7 @@ on:
 
 jobs:
   update-stories-summary:
+    name: Update concepts summary
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update-summary-languages.yml
+++ b/.github/workflows/update-summary-languages.yml
@@ -1,4 +1,4 @@
-name: Update languages summary
+name: Tools
 
 on:
   push:
@@ -10,6 +10,7 @@ on:
 
 jobs:
   update-languages-summary:
+    name: Update languages summary
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update-summary-stories.yml
+++ b/.github/workflows/update-summary-stories.yml
@@ -1,4 +1,4 @@
-name: Update stories summary
+name: Tools
 
 on:
   push:
@@ -9,6 +9,7 @@ on:
 
 jobs:
   update-stories-summary:
+    name: Update stories summary
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/valid-files.yml
+++ b/.github/workflows/valid-files.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   max-file-size:
-    name: Check file sizes - ${{ github.event_name }}
+    name: Check file sizes
     runs-on: ubuntu-latest
 
     steps:
@@ -40,7 +40,7 @@ jobs:
           done
 
   valid-filenames:
-    name: Check file names - ${{ github.event_name }}
+    name: Check file names
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/valid-files.yml
+++ b/.github/workflows/valid-files.yml
@@ -1,4 +1,4 @@
-name: Check if files are valid
+name: CI
 
 on:
   push:
@@ -6,6 +6,7 @@ on:
 
 jobs:
   max-file-size:
+    name: Check file sizes - ${{ github.event_name }}
     runs-on: ubuntu-latest
 
     steps:
@@ -39,6 +40,7 @@ jobs:
           done
 
   valid-filenames:
+    name: Check file names - ${{ github.event_name }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/valid-links.yml
+++ b/.github/workflows/valid-links.yml
@@ -1,4 +1,4 @@
-name: Check for dead links
+name: CI
 
 on:
   push:
@@ -8,6 +8,7 @@ on:
 
 jobs:
   verify-links:
+    name: Check for dead links - ${{ github.event_name }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/valid-links.yml
+++ b/.github/workflows/valid-links.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   verify-links:
-    name: Check for dead links - ${{ github.event_name }}
+    name: Check for dead links
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/verify-code-formatting.yml
+++ b/.github/workflows/verify-code-formatting.yml
@@ -1,4 +1,4 @@
-name: 'Verify formatting'
+name: CI
 
 on:
   push:
@@ -6,6 +6,7 @@ on:
 
 jobs:
   verify-code-formatting:
+    name: Verify formatting
     runs-on: [ubuntu-latest]
     steps:
       - name: 'Checkout code'

--- a/.github/workflows/verify-csharp-formatting.yml
+++ b/.github/workflows/verify-csharp-formatting.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   verify-csharp-formatting:
-    name: Verify C# formatting
+    name: Verify formatting
     runs-on: [ubuntu-latest]
     steps:
       - name: 'Checkout code'

--- a/.github/workflows/verify-csharp-formatting.yml
+++ b/.github/workflows/verify-csharp-formatting.yml
@@ -1,4 +1,4 @@
-name: 'Verify C# formatting'
+name: C#
 
 on:
   push:
@@ -10,6 +10,7 @@ on:
 
 jobs:
   verify-csharp-formatting:
+    name: Verify C# formatting
     runs-on: [ubuntu-latest]
     steps:
       - name: 'Checkout code'


### PR DESCRIPTION
Some PRs like #2537 have a lot of checks. The check overview can get quite messy.

This PR renames all workflows/checks to follow the same scheme:

`category / name`

where `category` is currently `CI` (general checks like the file checks), `Tools` (Things like the summary generators, labeler) and track names.

The downside is that the detailed view and Action tab become less readable:

![grafik](https://user-images.githubusercontent.com/20866761/97311654-e011ef00-1864-11eb-98f6-1e9629e4c97e.png)
![grafik](https://user-images.githubusercontent.com/20866761/97311859-1d767c80-1865-11eb-8788-70ccab2d9edd.png)


Personally I think the PR/Commit popup view are more important because they're the main thing one sees, so IMO this trade off is worth it.

---

Note that this will require changing the required checks to the new names (@iHiD)