### PR TITLE
[C#] Fix Struct Tests to build out of the box.

### DIFF
--- a/languages/csharp/exercises/concept/structs/StructsTests.cs
+++ b/languages/csharp/exercises/concept/structs/StructsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using Xunit;
 
 public class StructsTests
@@ -7,8 +8,8 @@ public class StructsTests
     public void IsClaimed_yes()
     {
         var ch = new ClaimsHandler();
-        ch.StakeClaim(new Plot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
-        var claimed = ch.IsClaimStaked(new Plot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
+        ch.StakeClaim(CreatePlot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
+        var claimed = ch.IsClaimStaked(CreatePlot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
         Assert.True(claimed);
     }
 
@@ -16,8 +17,8 @@ public class StructsTests
     public void IsClaimed_no()
     {
         var ch = new ClaimsHandler();
-        ch.StakeClaim(new Plot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
-        var claimed = ch.IsClaimStaked(new Plot(new Coord(1,0), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
+        ch.StakeClaim(CreatePlot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
+        var claimed = ch.IsClaimStaked(CreatePlot(new Coord(1,0), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
         Assert.False(claimed);
     }
 
@@ -25,9 +26,9 @@ public class StructsTests
     public void IsLastClaim_yes()
     {
         var ch = new ClaimsHandler();
-        ch.StakeClaim(new Plot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
-        ch.StakeClaim(new Plot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2)));
-        var lastClaim = ch.IsLastClaim(new Plot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2)));
+        ch.StakeClaim(CreatePlot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
+        ch.StakeClaim(CreatePlot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2)));
+        var lastClaim = ch.IsLastClaim(CreatePlot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2)));
         Assert.True(lastClaim);
     }
 
@@ -35,9 +36,9 @@ public class StructsTests
     public void IsLastClaim_no()
     {
         var ch = new ClaimsHandler();
-        ch.StakeClaim(new Plot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2)));
-        ch.StakeClaim(new Plot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
-        var lastClaim = ch.IsLastClaim(new Plot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2)));
+        ch.StakeClaim(CreatePlot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2)));
+        ch.StakeClaim(CreatePlot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
+        var lastClaim = ch.IsLastClaim(CreatePlot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2)));
         Assert.False(lastClaim);
     }
 
@@ -45,10 +46,26 @@ public class StructsTests
     public void GetLongestSide()
     {
         var ch = new ClaimsHandler();
-        var longer = new Plot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2));
-        var shorter = new Plot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2));
+        var longer = CreatePlot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2));
+        var shorter = CreatePlot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2));
         ch.StakeClaim(longer);
         ch.StakeClaim(shorter);
         Assert.Equal(longer, ch.GetClaimWithLongestSide());
+    }
+
+    private Plot CreatePlot(Coord coord1, Coord coord2, Coord coord3, Coord coord4)
+    {
+        Type plotType = typeof(Plot);
+        Type[] types = new Type[] { typeof(Coord), typeof(Coord), typeof(Coord), typeof(Coord) };
+        ConstructorInfo constructorInfoObj = plotType.GetConstructor(types);
+        if (constructorInfoObj != null)
+        {
+           return (Plot) constructorInfoObj.Invoke(new object[] { coord1, coord2, coord3, coord4 });
+        }
+
+        else
+        {
+            throw new InvalidOperationException("Cannot find constructor that takes 4 coordinates");
+        }
     }
 }

--- a/languages/csharp/exercises/concept/structs/StructsTests.cs
+++ b/languages/csharp/exercises/concept/structs/StructsTests.cs
@@ -8,8 +8,8 @@ public class StructsTests
     public void IsClaimed_yes()
     {
         var ch = new ClaimsHandler();
-        ch.StakeClaim(CreatePlot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
-        var claimed = ch.IsClaimStaked(CreatePlot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
+        ch.StakeClaim(CreatePlot(new Coord(1, 1), new Coord(2, 1), new Coord(1, 2), new Coord(2, 2)));
+        var claimed = ch.IsClaimStaked(CreatePlot(new Coord(1, 1), new Coord(2, 1), new Coord(1, 2), new Coord(2, 2)));
         Assert.True(claimed);
     }
 
@@ -17,8 +17,8 @@ public class StructsTests
     public void IsClaimed_no()
     {
         var ch = new ClaimsHandler();
-        ch.StakeClaim(CreatePlot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
-        var claimed = ch.IsClaimStaked(CreatePlot(new Coord(1,0), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
+        ch.StakeClaim(CreatePlot(new Coord(1, 1), new Coord(2, 1), new Coord(1, 2), new Coord(2, 2)));
+        var claimed = ch.IsClaimStaked(CreatePlot(new Coord(1, 0), new Coord(2, 1), new Coord(1, 2), new Coord(2, 2)));
         Assert.False(claimed);
     }
 
@@ -26,9 +26,9 @@ public class StructsTests
     public void IsLastClaim_yes()
     {
         var ch = new ClaimsHandler();
-        ch.StakeClaim(CreatePlot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
-        ch.StakeClaim(CreatePlot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2)));
-        var lastClaim = ch.IsLastClaim(CreatePlot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2)));
+        ch.StakeClaim(CreatePlot(new Coord(1, 1), new Coord(2, 1), new Coord(1, 2), new Coord(2, 2)));
+        ch.StakeClaim(CreatePlot(new Coord(10, 1), new Coord(20, 1), new Coord(10, 2), new Coord(20, 2)));
+        var lastClaim = ch.IsLastClaim(CreatePlot(new Coord(10, 1), new Coord(20, 1), new Coord(10, 2), new Coord(20, 2)));
         Assert.True(lastClaim);
     }
 
@@ -36,9 +36,9 @@ public class StructsTests
     public void IsLastClaim_no()
     {
         var ch = new ClaimsHandler();
-        ch.StakeClaim(CreatePlot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2)));
-        ch.StakeClaim(CreatePlot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2)));
-        var lastClaim = ch.IsLastClaim(CreatePlot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2)));
+        ch.StakeClaim(CreatePlot(new Coord(10, 1), new Coord(20, 1), new Coord(10, 2), new Coord(20, 2)));
+        ch.StakeClaim(CreatePlot(new Coord(1, 1), new Coord(2, 1), new Coord(1, 2), new Coord(2, 2)));
+        var lastClaim = ch.IsLastClaim(CreatePlot(new Coord(10, 1), new Coord(20, 1), new Coord(10, 2), new Coord(20, 2)));
         Assert.False(lastClaim);
     }
 
@@ -46,8 +46,8 @@ public class StructsTests
     public void GetLongestSide()
     {
         var ch = new ClaimsHandler();
-        var longer = CreatePlot(new Coord(10,1), new Coord(20,1), new Coord(10,2), new Coord(20,2));
-        var shorter = CreatePlot(new Coord(1,1), new Coord(2,1), new Coord(1,2), new Coord(2,2));
+        var longer = CreatePlot(new Coord(10, 1), new Coord(20, 1), new Coord(10, 2), new Coord(20, 2));
+        var shorter = CreatePlot(new Coord(1, 1), new Coord(2, 1), new Coord(1, 2), new Coord(2, 2));
         ch.StakeClaim(longer);
         ch.StakeClaim(shorter);
         Assert.Equal(longer, ch.GetClaimWithLongestSide());

--- a/languages/csharp/exercises/concept/structs/StructsTests.cs
+++ b/languages/csharp/exercises/concept/structs/StructsTests.cs
@@ -60,7 +60,7 @@ public class StructsTests
         ConstructorInfo constructorInfoObj = plotType.GetConstructor(types);
         if (constructorInfoObj != null)
         {
-           return (Plot)constructorInfoObj.Invoke(new object[]{coord1, coord2, coord3, coord4});
+            return (Plot)constructorInfoObj.Invoke(new object[] { coord1, coord2, coord3, coord4 });
         }
 
         else

--- a/languages/csharp/exercises/concept/structs/StructsTests.cs
+++ b/languages/csharp/exercises/concept/structs/StructsTests.cs
@@ -60,7 +60,7 @@ public class StructsTests
         ConstructorInfo constructorInfoObj = plotType.GetConstructor(types);
         if (constructorInfoObj != null)
         {
-           return (Plot)constructorInfoObj.Invoke(new object[] { coord1, coord2, coord3, coord4 });
+           return (Plot)constructorInfoObj.Invoke(new object[]{ coord1, coord2, coord3, coord4 });
         }
 
         else

--- a/languages/csharp/exercises/concept/structs/StructsTests.cs
+++ b/languages/csharp/exercises/concept/structs/StructsTests.cs
@@ -60,7 +60,7 @@ public class StructsTests
         ConstructorInfo constructorInfoObj = plotType.GetConstructor(types);
         if (constructorInfoObj != null)
         {
-           return (Plot)constructorInfoObj.Invoke(new object[]{ coord1, coord2, coord3, coord4 });
+           return (Plot)constructorInfoObj.Invoke(new object[]{coord1, coord2, coord3, coord4});
         }
 
         else

--- a/languages/csharp/exercises/concept/structs/StructsTests.cs
+++ b/languages/csharp/exercises/concept/structs/StructsTests.cs
@@ -60,7 +60,7 @@ public class StructsTests
         ConstructorInfo constructorInfoObj = plotType.GetConstructor(types);
         if (constructorInfoObj != null)
         {
-           return (Plot) constructorInfoObj.Invoke(new object[] { coord1, coord2, coord3, coord4 });
+           return (Plot)constructorInfoObj.Invoke(new object[] { coord1, coord2, coord3, coord4 });
         }
 
         else

--- a/languages/csharp/exercises/concept/structs/StructsTests.cs
+++ b/languages/csharp/exercises/concept/structs/StructsTests.cs
@@ -65,7 +65,7 @@ public class StructsTests
 
         else
         {
-            throw new InvalidOperationException("Cannot find constructor that takes 4 coordinates");
+            throw new InvalidOperationException("You need to implement a constructor for the struct Plot.  The constructor must take 4 co-ordinates.  No such constructor can be found.");
         }
     }
 }


### PR DESCRIPTION
Used reflection to invoke plot constructor or throw error if not found.  This allows the code to build out of the box instead of having build errors

Fixes #1846 

Maintainers - can you add the hacktoberfest-accepted label to my PR?  Thank you