### PR TITLE
[CI] Update dead links check to check all files

### DIFF
--- a/.github/workflows/valid-links.yml
+++ b/.github/workflows/valid-links.yml
@@ -35,10 +35,15 @@ jobs:
           else
               files=$(git diff --no-commit-id --name-only --diff-filter AM origin/master | grep  -i .md$ | grep -v -i _sidebar.md | grep -v -i ISSUE_TEMPLATE | cat)
           fi
-
+          
+          set +e
+          exitCode=0
+          
           for file in $files; do
             if [ -f "$file" ]
             then
                 markdown-link-check -q -c .github/markdown-link-check-config.json "$file"
+                exitCode=$((exitCode + $?))
             fi
           done
+          exit "$exitCode"


### PR DESCRIPTION
This updates the markdown link checker to check all the files instead of just exiting after the first one that fails

closes #2538