### PR TITLE
[Julia] Add doctests for .docs/introduction.md files

### DIFF
--- a/.github/workflows/julia-doctests.yml
+++ b/.github/workflows/julia-doctests.yml
@@ -1,0 +1,50 @@
+name: Julia
+
+on:
+  push:
+    paths:
+      - 'languages/julia/exercises/**/.docs/**'
+  pull_request:
+    paths:
+      - 'languages/julia/exercises/**/.docs/**'
+
+jobs:
+  doctest:
+    name: Doctests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Julia 1.5.2
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.5.2' # Should be the same as the test runner
+
+      - name: Create a fake package
+        run: |
+          cd ..
+          julia -e 'using Pkg; Pkg.generate("JuliaTrack")'
+          mkdir -p JuliaTrack/docs/src
+      
+      - name: Copy .docs files to the fake package
+        run: |
+          for f in languages/julia/exercises/concept/*/.docs/introduction.md; do
+            cp --verbose "$f" "../JuliaTrack/docs/src/${f//\//-}"
+          done
+      
+      - name: Install dependencies
+        run: julia --project=languages/julia/bin/doctests -e 'using Pkg; Pkg.instantiate()'
+      
+      - name: ']dev the fake package'
+        run: julia --project=languages/julia/bin/doctests -e 'using Pkg; Pkg.develop(path=joinpath(ENV["HOME"], "work", "v3", "JuliaTrack"))'
+      
+      - name: Turn ```julia blocks into ```jldoctest
+        run: sed -i 's/```julia/```jldoctest/g' ../JuliaTrack/docs/src/*.md
+      
+      - name: Run doctests with Documenter
+        shell: julia --color=yes --project=languages/julia/bin/doctests {0}
+        run: |
+          using Documenter
+          using JuliaTrack
+
+          doctest(JuliaTrack)

--- a/languages/julia/bin/doctests/Manifest.toml
+++ b/languages/julia/bin/doctests/Manifest.toml
@@ -1,0 +1,99 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocStringExtensions]]
+deps = ["LibGit2", "Markdown", "Pkg", "Test"]
+git-tree-sha1 = "50ddf44c53698f5e784bbebb3f4b21c5807401b1"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.3"
+
+[[Documenter]]
+deps = ["Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "71e35e069daa9969b8af06cef595a1add76e0a11"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.25.3"
+
+[[IOCapture]]
+deps = ["Logging"]
+git-tree-sha1 = "377252859f740c217b936cebcd918a44f9b53b59"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "0.1.1"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.1"
+
+[[LibGit2]]
+deps = ["Printf"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "6fa4202675c05ba0f8268a6ddf07606350eda3ce"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "1.0.11"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/languages/julia/bin/doctests/Project.toml
+++ b/languages/julia/bin/doctests/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/languages/julia/exercises/concept/lasagna/.docs/introduction.md
+++ b/languages/julia/exercises/concept/lasagna/.docs/introduction.md
@@ -1,20 +1,24 @@
 The entire Julia track will require you to treat your solution like small libraries, i.e. you need to define functions, types etc. which will then be run against a test suite.
 For that reason, we will introduce named functions as the very first concept.
 
+<!-- TODO: Add a note that explains the REPL julia block syntax-->
+
 ## Defining functions
 
 There are two common ways to define a named function in Julia:
 
 ```julia
-function muladd(x, y, z)
-    return x * y + z
-end
+julia> function muladd(x, y, z)
+           return x * y + z
+       end
+muladd (generic function with 1 method)
 ```
 
 and
 
 ```julia
-muladd(x, y, z) = x * y + z
+julia> muladd(x, y, z) = x * y + z
+muladd (generic function with 1 method)
 ```
 
 The latter is most commonly used for one-line function definitions or mathematical functions.
@@ -24,11 +28,15 @@ The latter is most commonly used for one-line function definitions or mathematic
 Invoking a function is done by specifying its name and passing arguments for each of the function's parameters:
 
 ```julia
-# invoking a function
-muladd(10, 5, 1)
+julia> muladd(10, 5, 1)
+51
+```
 
-# and of course you can invoke a function within the body of another function:
-square_plus_one(x) = muladd(x, x, 1)
+And of course you can invoke a function within the body of another function:
+
+```julia
+julia> square_plus_one(x) = muladd(x, x, 1)
+square_plus_one (generic function with 1 method)
 ```
 
 ## Types
@@ -42,10 +50,14 @@ Julia supports two kinds of comments.
 Single line comments are preceded by `#` and multiline comments are inserted between `#=` and `=#`.
 
 ```julia
-add(1, 3) # returns 4
+julia> 2 + 2 # returns 4
+4
+```
 
-#= Some random code that's no longer needed but not deleted
-sub(x, y) = x - y
-mulsub(x, y, z) = sub(mul(x, y), z)
-=#
+```julia
+julia> #= Some random code that's no longer needed but not deleted
+       sub(x, y) = x - y
+       mulsub(x, y, z) = sub(mul(x, y), z)
+       =#
+
 ```


### PR DESCRIPTION
This is a dodgy first attempt at ensuring that examples in the `.docs/introduction.md` files are correct.

Basically the script copies all `.docs/introduction.md` into a fake package and then uses Documenter's `doctest` function to test the docs of that "package". Since it's unlikely that the website will support proper rendering of `jldoctest`, at least on launch, the script will replace `julia` triple tick blocks with `jldoctest` triple tick blocks.

For more complex exercises, we will very likely need to add some comment-based annotations to support more features of doctests than just the evaluation of the tests. But for the current ones, this works well enough.

A further extension would be loading `.meta/example.jl` which would allow doctesting the `instructions.md` files