### PR TITLE
[Go] Remove invisible chars in .meta/config.json

### DIFF
--- a/languages/go/exercises/concept/methods/.meta/config.json
+++ b/languages/go/exercises/concept/methods/.meta/config.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "authors": [
     {
       "github_username": "tehsphinx",

--- a/languages/go/exercises/concept/strings/.meta/config.json
+++ b/languages/go/exercises/concept/strings/.meta/config.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "authors": [
     {
       "github_username": "tehsphinx",

--- a/languages/go/exercises/concept/structs/.meta/config.json
+++ b/languages/go/exercises/concept/structs/.meta/config.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "authors": [
     {
       "github_username": "tehsphinx",


### PR DESCRIPTION
For some reason these three files had `U+FEFF` symbols at the start, which breaks some JSON libraries. This removes those.

You can see the char in the GitHub web editor. Locally checked out files, at least on my machine, didn't seem to have them.


----

The failed check is expected, see #2617 