### PR TITLE
Update prettier version used in format scripts.

### DIFF
--- a/bin/format.cmd
+++ b/bin/format.cmd
@@ -1,2 +1,2 @@
 if "%~1"=="" (set PATTERN="**/*.{md,json}") else (set PATTERN="%1")
-npx prettier@2.0.4 --write %PATTERN%
+npx prettier@2.1.2 --write %PATTERN%

--- a/bin/format.sh
+++ b/bin/format.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 DEFAULT_PATTERN='**/*.{md,json}'
-npx prettier@2.0.4 --write "${1:-$DEFAULT_PATTERN}"
+npx prettier@2.1.2 --write "${1:-$DEFAULT_PATTERN}"


### PR DESCRIPTION
Looks like when #2619 was merged it updated only the versions of
prettier in use by the GitHub Actions not that of those used by
`./bin/format.{sh,cmd}`.

This commit sets the version of prettier used by the latter to be equal of

Without this change the scripts will produce a lot of copies of the
following message:

`[warn] Ignored unknown option { embeddedLanguageFormatting: "auto" }.`


----

#