### PR TITLE
[Python] Further Adjustments to config.json for Concept tree and Prerequisites

### DIFF
--- a/languages/python/config.json
+++ b/languages/python/config.json
@@ -77,7 +77,6 @@
           "basics",
           "comparisons",
           "conditionals",
-          "lists",
           "strings"
         ]
       },

--- a/languages/python/config.json
+++ b/languages/python/config.json
@@ -22,7 +22,7 @@
         "name": "Tisbury Treasure Hunt",
         "uuid": "7ecd42c1-2ed5-487a-bc89-71c9cbad9b05",
         "concepts": ["tuples"],
-        "prerequisites": ["basics", "bools", "loops", "conditionals", "numbers"]
+        "prerequisites": ["bools", "loops", "conditionals", "numbers"]
       },
       {
         "slug": "guidos-gorgeous-lasagna",
@@ -43,7 +43,7 @@
         "name": "Inventory Management",
         "uuid": null,
         "concepts": ["dicts"],
-        "prerequisites": ["basics", "bools", "loops", "numbers", "lists"]
+        "prerequisites": ["bools", "loops", "numbers", "lists"]
       },
       {
         "slug": "log-levels",
@@ -51,17 +51,13 @@
         "uuid": null,
         "concepts": ["enums"],
         "prerequisites": [
-          "basics",
           "classes",
           "conditionals",
           "enumeration",
-          "indexing",
           "iteration",
           "list-comprehensions",
-          "loops",
           "methods",
           "sequences",
-          "slicing",
           "strings",
           "string-formatting",
           "string-methods",
@@ -73,25 +69,14 @@
         "name": "Elyse's Enchantments",
         "uuid": null,
         "concepts": ["lists"],
-        "prerequisites": [
-          "basics",
-          "comparisons",
-          "conditionals",
-          "strings"
-        ]
+        "prerequisites": ["comparisons", "conditionals", "strings"]
       },
       {
         "slug": "chaitanas-colossal-coaster",
         "name": "Chaitana's Colossal Coaster",
         "uuid": null,
         "concepts": ["list-methods"],
-        "prerequisites": [
-          "basics",
-          "comparisons",
-          "conditionals",
-          "lists",
-          "strings"
-        ]
+        "prerequisites": ["comparisons", "conditionals", "lists"]
       },
       {
         "slug": "restaurant-rozalynn",
@@ -99,13 +84,10 @@
         "uuid": null,
         "concepts": ["none"],
         "prerequisites": [
-          "basics",
           "bools",
           "conditionals",
           "default-arguments",
-          "dicts",
           "dict-methods",
-          "lists",
           "list-methods",
           "loops"
         ]
@@ -115,13 +97,7 @@
         "name": "Making the Grade",
         "uuid": null,
         "concepts": ["loops"],
-        "prerequisites": [
-          "basics",
-          "comparisons",
-          "conditionals",
-          "lists",
-          "strings"
-        ]
+        "prerequisites": ["comparisons", "conditionals", "lists", "strings"]
       }
     ],
     "practice": []

--- a/languages/python/config.json
+++ b/languages/python/config.json
@@ -57,14 +57,14 @@
         "name": "Elyse's Enchantments",
         "uuid": null,
         "concepts": ["lists"],
-        "prerequisites": ["comparisons", "conditionals", "strings"]
+        "prerequisites": ["basics"]
       },
       {
         "slug": "chaitanas-colossal-coaster",
         "name": "Chaitana's Colossal Coaster",
         "uuid": null,
         "concepts": ["list-methods"],
-        "prerequisites": ["comparisons", "conditionals", "lists"]
+        "prerequisites": ["basics"]
       },
       {
         "slug": "restaurant-rozalynn",
@@ -78,7 +78,7 @@
         "name": "Making the Grade",
         "uuid": null,
         "concepts": ["loops"],
-        "prerequisites": ["comparisons", "conditionals"]
+        "prerequisites": ["basics"]
       }
     ],
     "practice": []

--- a/languages/python/config.json
+++ b/languages/python/config.json
@@ -22,7 +22,7 @@
         "name": "Tisbury Treasure Hunt",
         "uuid": "7ecd42c1-2ed5-487a-bc89-71c9cbad9b05",
         "concepts": ["tuples"],
-        "prerequisites": ["bools", "loops", "conditionals", "numbers"]
+        "prerequisites": ["basics"]
       },
       {
         "slug": "guidos-gorgeous-lasagna",
@@ -43,26 +43,14 @@
         "name": "Inventory Management",
         "uuid": null,
         "concepts": ["dicts"],
-        "prerequisites": ["bools", "loops", "numbers", "lists"]
+        "prerequisites": ["basics"]
       },
       {
         "slug": "log-levels",
         "name": "Log Levels",
         "uuid": null,
         "concepts": ["enums"],
-        "prerequisites": [
-          "classes",
-          "conditionals",
-          "enumeration",
-          "iteration",
-          "list-comprehensions",
-          "methods",
-          "sequences",
-          "strings",
-          "string-formatting",
-          "string-methods",
-          "tuples"
-        ]
+        "prerequisites": ["basics"]
       },
       {
         "slug": "elyses-enchantments",
@@ -83,21 +71,14 @@
         "name": "Restaurant Rozalynn",
         "uuid": null,
         "concepts": ["none"],
-        "prerequisites": [
-          "bools",
-          "conditionals",
-          "default-arguments",
-          "dict-methods",
-          "list-methods",
-          "loops"
-        ]
+        "prerequisites": ["basics"]
       },
       {
         "slug": "making-the-grade",
         "name": "Making the Grade",
         "uuid": null,
         "concepts": ["loops"],
-        "prerequisites": ["comparisons", "conditionals", "lists", "strings"]
+        "prerequisites": ["comparisons", "conditionals"]
       }
     ],
     "practice": []


### PR DESCRIPTION
1.  Fixed cycle in concept tree where `lists` required `lists`.  

2.  Edited concepts that depended on _other_ concepts that had `basics` as a prerequisite to **not** also require `basics`.  _For example:_  `tuples` had `basics` & `strings` as prerequisites, but since `strings` already required `basics`, the `basics` prerequisite was omitted from `tuples`.

I probably missed some of these tho - so work is ongoing.