### PR TITLE
[Python] Basics Concept Exercise Reformat - A Re-implementation of PR 2534

### DIFF
--- a/languages/python/concepts/basics/about.md
+++ b/languages/python/concepts/basics/about.md
@@ -1,19 +1,33 @@
-[Python](https://docs.python.org/3/) is a [dynamic and strongly](https://stackoverflow.com/questions/11328920/is-python-strongly-typed) typed [object-oriented](https://en.wikipedia.org/wiki/Object-oriented_programming) programming language. As of version 3.5, it employs both [duck typing](https://en.wikipedia.org/wiki/Duck_typing) and [gradual typing](https://en.wikipedia.org/wiki/Gradual_typing), via [type hints](https://docs.python.org/3/library/typing.html). It supports both imperative (_object-oriented, procedural_) and declarative (_functional, concurrent_) programming paradigms. But do not be fooled: while programming in other paradigms is fully _supported_, [everything in Python is an object](https://docs.python.org/3/reference/datamodel.html).
+## basics
 
-Python was created by Guido van Rossum and first released in 1991. The [Python Software Foundation](https://www.python.org/psf/) manages and directs resources for Python and CPython development and receives proposals for changes to the language from [members](https://www.python.org/psf/membership/) of the community via [Python Enhancement Proposals or PEPs](https://www.python.org/dev/peps/).
+[Python][python docs] is a [dynamic and strongly][dynamic typing in python] typed [object-oriented][object oriented programming] programming language. It employs both [duck typing][duck typing] and [gradual typing][gradual typing], via [type hints][type hints]. It supports multiple programming paradigms including both imperative (_object-oriented, procedural_) and declarative (_functional, concurrent_) flavors. But do not be fooled: while programming across paradigms is fully _supported_, [everything in Python is an object][everythings an object].
 
-Python puts a strong emphasis on code readability and (_similar to Haskell_) uses [significant indentation](https://docs.python.org/3/reference/lexical_analysis.html#indentation) to denote function, method, and class definitions. The [zen of Python (PEP 20)](https://www.python.org/dev/peps/pep-0020/) lays out additional inspiration and philosophy.
+Python was created by Guido van Rossum and first released in 1991. The [Python Software Foundation][psf] manages and directs resources for Python and CPython development and receives proposals for changes to the language from [members][psf membership] of the community via [Python Enhancement Proposals or PEPs][peps].
 
-Objects are [assigned](https://docs.python.org/3/reference/simple_stmts.html#assignment-statements) to [names](https://docs.python.org/3/reference/executionmodel.html#naming-and-binding) in Python via the `=` or _assignment operator_. [Variables](https://realpython.com/python-variables/) are written in [`snake_case`](https://en.wikipedia.org/wiki/Snake_case), and _constants_ usually in `SCREAMING_SNAKE_CASE`. A name (_variable or constant_) is not itself _typed_, and can be attached or re-attached to different objects over its lifetime. For extended naming conventions and advice, see [PEP 8](https://www.python.org/dev/peps/pep-0008/).
+Python puts a strong emphasis on code readability and (_similar to Haskell_) uses [significant indentation][significant indentation] to denote function, method, and class definitions. The [zen of Python (PEP 20)][the zen of python] lays out additional philosophy, as does the essay [What is Pythonic?][what is pythonic].
+
+Complete documentation for the Python programming language can be found at [docs.python.org/3/][python docs]:
+
+- [Python Tutorial][python tutorial]
+- [Python Library Reference][python library reference]
+- [Python Language Reference][python language reference]
+- [Python HOW TOs][python how tos]
+- [Python FAQs][python faqs]
+- [Python Glossary of Terms][python glossary of terms]
+
+### Getting Started
+
+Objects are [assigned][assignment statements] to [names][naming and binding] in Python via the `=` or _assignment operator_. [Variables][variables] are written in [`snake_case`][snake case], and _constants_ usually in `SCREAMING_SNAKE_CASE`. A name (_variable or constant_) is not itself _typed_, and can be attached or re-attached to different objects over its lifetime. For extended naming conventions and advice, see [PEP 8][pep8].
 
 ```python
 >>> my_first_variable = 1
 >>> my_first_variable = "Last one, I promise"
 >>> print(my_first_variable)
+
 "Last one, I promise"
 ```
 
-Constants are usually defined on a [module](https://docs.python.org/3/tutorial/modules.html) or _global_ level, and although they _can_ be changed, they are _intended_ to be named only once. Their `SCREAMING_SNAKE_CASE` is a message to other developers that the assignment should not be altered:
+Constants are usually defined on a [module][module] or _global_ level, and although they _can_ be changed, they are _intended_ to be named only once. Their `SCREAMING_SNAKE_CASE` is a message to other developers that the assignment should not be altered:
 
 ```python
 # All caps signal that this is intended as a constant
@@ -24,36 +38,35 @@ MY_FIRST_CONSTANT = 16
 # Please don't do: MY_FIRST_CONSTANT = "Some other value"
 ```
 
-In Python, units of functionality are encapsulated in [functions](https://docs.python.org/3/reference/compound_stmts.html#function), which are themselves [objects](https://docs.python.org/3/reference/datamodel.html#the-standard-type-hierarchy) (_Its [turtles all the way down](https://en.wikipedia.org/wiki/Turtles_all_the_way_down)_).
+In Python, units of functionality are encapsulated in [_functions._][functions], which are themselves [objects][objects] (_Its [turtles all the way down][turtles all the way down]_). Functions can be executed by themselves, passed as arguments to other functions, nested, or bound to a class. When functions are bound to a [class][classes] name, they're referred to as [methods][method objects]. Related functions and classes (_with their methods_) can be grouped together in the same file or module, and imported in part or in whole for use in other programs.
 
-Functions can be executed by themselves, passed as arguments to other functions, nested, or bound to a class. When functions are bound to a [class](https://docs.python.org/3/reference/datamodel.html#classes) name, they're referred to as [methods](https://docs.python.org/3/c-api/method.html#method-objects). Related functions and classes (_with their methods_) can be grouped together in the same file or [module](https://docs.python.org/3/reference/datamodel.html#modules), and imported in part or in whole for use in other programs.
-
-The keyword `def` begins a [function definition](https://docs.python.org/3/tutorial/controlflow.html#defining-functions). It must be followed by the function name and a parenthesized list of zero or more formal [parameters](https://docs.python.org/3/glossary.html#term-parameter), which can be of several different varieties, and even [vary](https://docs.python.org/3/tutorial/controlflow.html#more-on-defining-functions) in length.
-
-The `def` line is terminated with a colon. Statements for the _body_ of the function begin on the next line, and must be _indented in a block_. There is no strict indentation amount (_either space **OR** [tab] characters are acceptable_), but [indentation](https://docs.python.org/3/reference/lexical_analysis.html#indentation) must be _consistent for all indented statements_. Functions explicitly return a value or object via the [`return`](https://docs.python.org/3/reference/simple_stmts.html#return) keyword. Functions that do not have an explicit `return` expression will return [`None`](https://docs.python.org/3/library/constants.html):
+The keyword `def` begins a [function definition][function definition]. It must be followed by the function name and a parenthesized list of zero or more formal [parameters][parameters], which can be of several different varieties, and even [vary][more on functions] in length. The `def` line is terminated with a colon.
 
 ```python
 #function definition on first line.
 def add_two_numbers(number_one, number_two):
-    return number_one + number_two  #returns the sum of the numbers
+  return number_one + number_two  #returns the sum of the numbers, and is indented by 2 spaces.
 
 >>> add_two_numbers(3, 4)
 7
 
-#this function has no return keyword, and so will return None
-def multiply_two_numbers(number_one, number_two):
-    result = number_one * number_two
-
->>> print(multiply_two_numbers(6, 8))
-None
+#the return statement line does not match the first line indent
+>>> def add_three_numbers_misformatted(number_one, number_two, number_three):
+...     result = number_one + number_two + number_three   #indented by 4 spaces
+...    return result     #this was only indented by 3 spaces
+  File "<stdin>", line 3
+    return result
+                ^
+IndentationError: unindent does not match any outer indentation level
 ```
 
-Functions are [called](https://docs.python.org/3/reference/expressions.html#calls) using their name followed by `()`. The number of arguments passed in the parentheses must match the number of parameters in the original function definition unless [default arguments](https://docs.python.org/3/tutorial/controlflow.html#default-argument-values) have been used:
+Statements for the _body_ of the function begin on the next line down from `def`, and must be _indented in a block_. There is no strict indentation amount (_either space **OR** [tab] characters are acceptable_), but [indentation][indentation] must be _consistent for all indented statements_. Functions explicitly return a value or object via the [`return`][return] keyword. Functions that do not have an explicit `return` expression will return [`None`][none].
+
+Functions are [_called_][calls] using their name followed by `()`. The number of arguments passed in the parentheses must match the number of parameters in the original function definition unless [default arguments][default aruguments] have been used:
 
 ```python
 def number_to_the_power_of(number_one, number_two):
     '''Returns float or int.
-
        Takes number_one and raises it to the power of number_two, returning the result.
     '''
 
@@ -67,11 +80,9 @@ Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 TypeError: number_to_the_power_of() missing 1 required positional argument: 'number_two'
 
-...
 
 def number_to_the_power_of_default(number_one, number_two=2):
     '''Returns float or int.
-
        Takes number_one and raises it to the power of number_two, returning the result.
     '''
 
@@ -81,26 +92,27 @@ def number_to_the_power_of_default(number_one, number_two=2):
 16
 ```
 
-Methods bound to class names are invoked via _dot notation_ (`.`), as are functions, constants, or global names imported as part of a _module_.:
+Methods bound to class names are invoked via dot notation (.), as are functions, constants, or global names imported as part of a module.:
 
 ```python
+
 import string
 
-#this is a constant provided by the *string* module
+# this is a constant provided by the *string* module
 >>> print(string.ascii_lowercase)
 "abcdefghijklmnopqrstuvwxyz"
 
-#this is a method call of the str *class*
+# this is a method call of the str *class*
 >>> start_text = "my silly sentence for examples."
 >>> str.upper(start_text)
 "MY SILLY SENTENCE FOR EXAMPLES."
 
-#this is a method call of an *instance* of the str *class*
+# this is a method call of an *instance* of the str *class*
 >>> start_text.upper()
 "MY SILLY SENTENCE FOR EXAMPLES."
 ```
 
-[Comments](https://realpython.com/python-comments-guide/#python-commenting-basics) in Python start with a `#` that is not part of a string, and end at line termination. Unlike many other programming languages, Python does not support multi-line comment marks. Each line of a comment block must start with the `#` character. Comments are ignored by the interpreter:
+[Comments][comments] in Python start with a `#` that is not part of a string, and end at line termination. Unlike many other programming languages, Python does not support multi-line comment marks. Each line of a comment block must start with the `#` character. Comments are ignored by the interpreter:
 
 ```python
 #this is a single line comment
@@ -112,7 +124,7 @@ x = "foo"  #this is an in-line comment
 #these should be used sparingly
 ```
 
-The first statement of a function body can optionally be a [docstring](https://docs.python.org/3/tutorial/controlflow.html#tut-docstrings), which concisely summarizes the function or object's purpose. These docstrings are read by automated documentation tools, and are returned by calling `__doc__` on the function, method, or class. They are recommended for programs of any size where documentation is needed:
+The first statement of a function body can optionally be a [_docstring_][docstring], which concisely summarizes the function or object's purpose. These docstrings are read by automated documentation tools, and are returned by calling **doc** on the function, method, or class. . They are recommended for programs of any size where documentation is needed:
 
 ```python
 #an example on a user-defined function
@@ -143,4 +155,46 @@ encoding defaults to sys.getdefaultencoding().
 errors defaults to 'strict'.
 ```
 
-Docstrings can also include [doctests](https://docs.python.org/3/library/doctest.html), which are interactive examples of how a method or function should work. Doctests can be read and run by PyTest, or by importing the `doctest` module.
+Docstrings can also include [doctests][doctests], which are interactive examples of how a method or funtion should work. Doctests can be read and run by PyTest, or by importing the `doctest` module.
+
+[assignment statements]: https://docs.python.org/3/reference/simple_stmts.html#assignment-statements
+[calls]: https://docs.python.org/3/reference/expressions.html#calls
+[classes]: https://docs.python.org/3/reference/datamodel.html#classes
+[comments]: https://realpython.com/python-comments-guide/#python-commenting-basics
+[default arguments]: https://docs.python.org/3/tutorial/controlflow.html#default-argument-values
+[docstring]: https://docs.python.org/3/tutorial/controlflow.html#tut-docstrings
+[doctests]: https://docs.python.org/3/library/doctest.html
+[duck typing]: https://en.wikipedia.org/wiki/Duck_typing
+[dynamic typing in python]: https://stackoverflow.com/questions/11328920/is-python-strongly-typed
+[everythings an object]: https://docs.python.org/3/reference/datamodel.html
+[function definition]: https://docs.python.org/3/tutorial/controlflow.html#defining-functions
+[functions]: https://docs.python.org/3/reference/compound_stmts.html#function
+[gradual typing]: https://en.wikipedia.org/wiki/Gradual_typing
+[indentation]: https://docs.python.org/3/reference/lexical_analysis.html#indentation
+[method objects]: https://docs.python.org/3/c-api/method.html#method-objects
+[module]: https://docs.python.org/3/tutorial/modules.html
+[more on functions]: https://docs.python.org/3/tutorial/controlflow.html#more-on-defining-functions
+[naming and binding]: https://docs.python.org/3/reference/executionmodel.html#naming-and-binding
+[none]: https://docs.python.org/3/library/constants.html
+[object oriented programming]: https://en.wikipedia.org/wiki/Object-oriented_programming
+[objects]: https://docs.python.org/3/reference/datamodel.html#the-standard-type-hierarchy
+[parameters]: https://docs.python.org/3/glossary.html#term-parameter
+[pep8]: https://www.python.org/dev/peps/pep-0008/
+[peps]: https://www.python.org/dev/peps/
+[psf membership]: https://www.python.org/psf/membership/
+[psf]: https://www.python.org/psf/
+[python docs]: https://docs.python.org/3/
+[python faqs]: https://docs.python.org/3/faq/index.html
+[python glossary of terms]: https://docs.python.org/3/glossary.html
+[python how tos]: https://docs.python.org/3/howto/index.html
+[python language reference]: https://docs.python.org/3/reference/index.html
+[python library reference]: https://docs.python.org/3/library/index.html
+[python tutorial]: https://docs.python.org/3/tutorial/index.html
+[return]: https://docs.python.org/3/reference/simple_stmts.html#return
+[significant indentation]: https://docs.python.org/3/reference/lexical_analysis.html#indentation
+[snake case]: https://en.wikipedia.org/wiki/Snake_case
+[the zen of python]: https://www.python.org/dev/peps/pep-0020/
+[turtles all the way down]: https://en.wikipedia.org/wiki/Turtles_all_the_way_down
+[type hints]: https://docs.python.org/3/library/typing.html
+[variables]: https://realpython.com/python-variables/
+[what is pythonic]: https://blog.startifact.com/posts/older/what-is-pythonic.html

--- a/languages/python/concepts/basics/links.json
+++ b/languages/python/concepts/basics/links.json
@@ -1,117 +1,75 @@
 [
-  { "url": "https://docs.python.org/3/", "description": "Python" },
-  {
-    "url": "https://stackoverflow.com/questions/11328920/is-python-strongly-typed",
-    "description": "dynamic and strongly"
-  },
-  {
-    "url": "https://en.wikipedia.org/wiki/Object-oriented_programming",
-    "description": "object-oriented"
-  },
-  {
-    "url": "https://en.wikipedia.org/wiki/Duck_typing",
-    "description": "duck typing"
-  },
-  {
-    "url": "https://en.wikipedia.org/wiki/Gradual_typing",
-    "description": "gradual typing"
-  },
-  {
-    "url": "https://docs.python.org/3/library/typing.html",
-    "description": "type hints"
-  },
-  {
-    "url": "https://docs.python.org/3/reference/datamodel.html",
-    "description": "everything in Python is an object"
-  },
   {
     "url": "https://www.python.org/psf/",
     "description": "Python Software Foundation"
   },
-  { "url": "https://www.python.org/psf/membership/", "description": "members" },
+  {
+    "url": "https://docs.python.org/3/",
+    "description": "Python documentation"
+  },
   {
     "url": "https://www.python.org/dev/peps/",
     "description": "Python Enhancement Proposals or PEPs"
   },
   {
-    "url": "https://docs.python.org/3/reference/lexical_analysis.html#indentation",
-    "description": "significant indentation"
-  },
-  {
     "url": "https://www.python.org/dev/peps/pep-0020/",
-    "description": "zen of Python (PEP 20)"
-  },
-  {
-    "url": "https://docs.python.org/3/reference/simple_stmts.html#assignment-statements",
-    "description": "assigned"
-  },
-  {
-    "url": "https://docs.python.org/3/reference/executionmodel.html#naming-and-binding",
-    "description": "names"
-  },
-  {
-    "url": "https://realpython.com/python-variables/",
-    "description": "Variables"
-  },
-  {
-    "url": "https://en.wikipedia.org/wiki/Snake_case",
-    "description": "TODO: add description"
+    "description": "the zen of Python (PEP 20)"
   },
   {
     "url": "https://www.python.org/dev/peps/pep-0008/",
     "description": "PEP 8"
   },
   {
-    "url": "https://docs.python.org/3/tutorial/modules.html",
-    "description": "module"
+    "url": "https://docs.python.org/3/reference/datamodel.html",
+    "description": "everything in Python is an object"
   },
   {
-    "url": "https://docs.python.org/3/reference/compound_stmts.html#function",
-    "description": "functions"
+    "url": "https://stackoverflow.com/questions/11328920/is-python-strongly-typed",
+    "description": "dynamic typing and strong typing"
   },
   {
-    "url": "https://docs.python.org/3/reference/datamodel.html#the-standard-type-hierarchy",
-    "description": "objects"
+    "url": "https://docs.python.org/3/library/typing.html",
+    "description": "type hints"
   },
   {
-    "url": "https://en.wikipedia.org/wiki/Turtles_all_the_way_down",
-    "description": "turtles all the way down"
+    "url": "https://docs.python.org/3/reference/lexical_analysis.html#indentation",
+    "description": "significant indentation"
   },
   {
-    "url": "https://docs.python.org/3/reference/datamodel.html#classes",
-    "description": "class"
+    "url": "https://realpython.com/python-variables/",
+    "description": "variables in Python"
   },
   {
-    "url": "https://docs.python.org/3/c-api/method.html#method-objects",
-    "description": "methods"
+    "url": "https://docs.python.org/3/reference/simple_stmts.html#assignment-statements",
+    "description": "assignment statements in Python"
   },
   {
-    "url": "https://docs.python.org/3/reference/datamodel.html#modules",
-    "description": "module"
+    "url": "https://docs.python.org/3/reference/executionmodel.html#naming-and-binding",
+    "description": "naming and binding in Python"
   },
   {
     "url": "https://docs.python.org/3/tutorial/controlflow.html#defining-functions",
     "description": "function definition"
   },
   {
-    "url": "https://docs.python.org/3/glossary.html#term-parameter",
-    "description": "parameters"
-  },
-  {
     "url": "https://docs.python.org/3/tutorial/controlflow.html#more-on-defining-functions",
-    "description": "vary"
+    "description": "more on defining functions"
   },
   {
-    "url": "https://docs.python.org/3/reference/lexical_analysis.html#indentation",
-    "description": "indentation"
+    "url": "https://docs.python.org/3/reference/compound_stmts.html#function",
+    "description": "functions in Python"
   },
   {
-    "url": "https://docs.python.org/3/reference/simple_stmts.html#return",
-    "description": "TODO: add description"
+    "url": "https://docs.python.org/3/reference/datamodel.html#classes",
+    "description": "class in Python"
   },
   {
-    "url": "https://docs.python.org/3/library/constants.html",
-    "description": "TODO: add description"
+    "url": "https://docs.python.org/3/c-api/method.html#method-objects",
+    "description": "methods in Python"
+  },
+  {
+    "url": "https://docs.python.org/3/reference/datamodel.html#the-standard-type-hierarchy",
+    "description": "Pythons standard type hierarchy"
   },
   {
     "url": "https://docs.python.org/3/reference/expressions.html#calls",

--- a/languages/python/exercises/concept/guidos-gorgeous-lasagna/.docs/introduction.md
+++ b/languages/python/exercises/concept/guidos-gorgeous-lasagna/.docs/introduction.md
@@ -2,8 +2,6 @@
 
 [Python][python docs] is a [dynamic and strongly][dynamic typing in python] typed [object-oriented][object oriented programming] programming language. It employs both [duck typing][duck typing] and [gradual typing][gradual typing], via [type hints][type hints]. It supports multiple programming paradigms including both imperative (_object-oriented, procedural_) and declarative (_functional, concurrent_) flavors. But do not be fooled: while programming across paradigms is fully _supported_, [everything in Python is an object][everythings an object].
 
-Python was created by Guido van Rossum and first released in 1991. The [Python Software Foundation][psf] manages and directs resources for Python and CPython development and receives proposals for changes to the language from [members][psf membership] of the community via [Python Enhancement Proposals or PEPs][peps].
-
 Python puts a strong emphasis on code readability and (_similar to Haskell_) uses [significant indentation][significant indentation] to denote function, method, and class definitions. The [zen of Python (PEP 20)][the zen of python] lays out additional philosophy, as does the essay [What is Pythonic?][what is pythonic].
 
 ### Getting Started
@@ -28,8 +26,6 @@ MY_FIRST_CONSTANT = 16
 # but is VERY strongly discouraged.
 # Please don't do: MY_FIRST_CONSTANT = "Some other value"
 ```
-
-In Python, units of functionality are encapsulated in [_functions._][functions], which are themselves [objects][objects] (_Its [turtles all the way down][turtles all the way down]_). Functions can be executed by themselves, passed as arguments to other functions, nested, or bound to a class. When functions are bound to a [class][classes] name, they're referred to as [methods][method objects]. Related functions and classes (_with their methods_) can be grouped together in the same file or module, and imported in part or in whole for use in other programs.
 
 The keyword `def` begins a [function definition][function definition]. It must be followed by the function name and a parenthesized list of zero or more formal [parameters][parameters], which can be of several different varieties, and even [vary][more on functions] in length. The `def` line is terminated with a colon.
 
@@ -147,15 +143,6 @@ errors defaults to 'strict'.
 ```
 
 Docstrings can also include [doctests][doctests], which are interactive examples of how a method or funtion should work. Doctests can be read and run by PyTest, or by importing the `doctest` module.
-
-Complete documentation for the Python programming language can be found at [docs.python.org/3/][python docs]:
-
-- [Python Tutorial][python tutorial]
-- [Python Library Reference][python library reference]
-- [Python Language Reference][python language reference]
-- [Python HOW TOs][python how tos]
-- [Python FAQs][python faqs]
-- [Python Glossary of Terms][python glossary of terms]
 
 [assignment statements]: https://docs.python.org/3/reference/simple_stmts.html#assignment-statements
 [calls]: https://docs.python.org/3/reference/expressions.html#calls

--- a/languages/python/exercises/concept/guidos-gorgeous-lasagna/.docs/introduction.md
+++ b/languages/python/exercises/concept/guidos-gorgeous-lasagna/.docs/introduction.md
@@ -1,17 +1,24 @@
 ## basics
 
-Python is a dynamic and strongly typed object-oriented programming language. It supports both imperative (_object-oriented, procedural_) and declarative (_functional, concurrent_) programming paradigms. Python emphasizes code readability and (similar to Haskell) uses significant whitespace.
+[Python][python docs] is a [dynamic and strongly][dynamic typing in python] typed [object-oriented][object oriented programming] programming language. It employs both [duck typing][duck typing] and [gradual typing][gradual typing], via [type hints][type hints]. It supports multiple programming paradigms including both imperative (_object-oriented, procedural_) and declarative (_functional, concurrent_) flavors. But do not be fooled: while programming across paradigms is fully _supported_, [everything in Python is an object][everythings an object].
 
-Objects are assigned to names in Python via the `=` or _assignment operator_. _Variables_ are written in [`snake_case`](https://en.wikipedia.org/wiki/Snake_case), and _constants_ (usually) in `SCREAMING_SNAKE_CASE`. A name (_variable or constant_) is not itself _typed_, and can be attached or re-attached to different objects over its lifetime:
+Python was created by Guido van Rossum and first released in 1991. The [Python Software Foundation][psf] manages and directs resources for Python and CPython development and receives proposals for changes to the language from [members][psf membership] of the community via [Python Enhancement Proposals or PEPs][peps].
+
+Python puts a strong emphasis on code readability and (_similar to Haskell_) uses [significant indentation][significant indentation] to denote function, method, and class definitions. The [zen of Python (PEP 20)][the zen of python] lays out additional philosophy, as does the essay [What is Pythonic?][what is pythonic].
+
+### Getting Started
+
+Objects are [assigned][assignment statements] to [names][naming and binding] in Python via the `=` or _assignment operator_. [Variables][variables] are written in [`snake_case`][snake case], and _constants_ usually in `SCREAMING_SNAKE_CASE`. A name (_variable or constant_) is not itself _typed_, and can be attached or re-attached to different objects over its lifetime. For extended naming conventions and advice, see [PEP 8][pep8].
 
 ```python
 >>> my_first_variable = 1
 >>> my_first_variable = "Last one, I promise"
 >>> print(my_first_variable)
+
 "Last one, I promise"
 ```
 
-Constants are usually defined at the top of a script or file, and although they _can_ be changed, they are _intended_ to be named only once. Their `SCREAMING_SNAKE_CASE` is a message to other developers that the assignment should not be altered:
+Constants are usually defined on a [module][module] or _global_ level, and although they _can_ be changed, they are _intended_ to be named only once. Their `SCREAMING_SNAKE_CASE` is a message to other developers that the assignment should not be altered:
 
 ```python
 # All caps signal that this is intended as a constant
@@ -22,9 +29,9 @@ MY_FIRST_CONSTANT = 16
 # Please don't do: MY_FIRST_CONSTANT = "Some other value"
 ```
 
-In Python, units of functionality are encapsulated in _functions._
+In Python, units of functionality are encapsulated in [_functions._][functions], which are themselves [objects][objects] (_Its [turtles all the way down][turtles all the way down]_). Functions can be executed by themselves, passed as arguments to other functions, nested, or bound to a class. When functions are bound to a [class][classes] name, they're referred to as [methods][method objects]. Related functions and classes (_with their methods_) can be grouped together in the same file or module, and imported in part or in whole for use in other programs.
 
-The keyword `def` begins a _function definition_, and must be followed by the _function name_ and a parenthesized list of zero or more formal _parameters_. The `def` line is terminated with a colon. Statements for the _body_ of the function begin on the next line, and must be _indented in a block_. There is no strict indentation amount (_either space **OR** [tab] characters are acceptable_), but indentation must be _consistent for all indented statements_. Functions explicitly return a value or object via the `return` keyword:
+The keyword `def` begins a [function definition][function definition]. It must be followed by the function name and a parenthesized list of zero or more formal [parameters][parameters], which can be of several different varieties, and even [vary][more on functions] in length. The `def` line is terminated with a colon.
 
 ```python
 #function definition on first line.
@@ -44,10 +51,16 @@ def add_two_numbers(number_one, number_two):
 IndentationError: unindent does not match any outer indentation level
 ```
 
-Functions are _called_ using their name followed by `()`. The number of arguments passed in the parentheses must match the number of parameters in the original function definition:
+Statements for the _body_ of the function begin on the next line down from `def`, and must be _indented in a block_. There is no strict indentation amount (_either space **OR** [tab] characters are acceptable_), but [indentation][indentation] must be _consistent for all indented statements_. Functions explicitly return a value or object via the [`return`][return] keyword. Functions that do not have an explicit `return` expression will return [`None`][none].
+
+Functions are [_called_][calls] using their name followed by `()`. The number of arguments passed in the parentheses must match the number of parameters in the original function definition unless [default arguments][default aruguments] have been used:
 
 ```python
 def number_to_the_power_of(number_one, number_two):
+    '''Returns float or int.
+       Takes number_one and raises it to the power of number_two, returning the result.
+    '''
+
     return number_one ** number_two
 
 >>> number_to_the_power_of(3,3)
@@ -57,9 +70,40 @@ def number_to_the_power_of(number_one, number_two):
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 TypeError: number_to_the_power_of() missing 1 required positional argument: 'number_two'
+
+
+def number_to_the_power_of_default(number_one, number_two=2):
+    '''Returns float or int.
+       Takes number_one and raises it to the power of number_two, returning the result.
+    '''
+
+    return number_one ** number_two
+
+>>> number_to_the_power_of_default(4)
+16
 ```
 
-Comments in Python start with a `#` that is not part of a string, and end at line termination. Unlike many other programming languages, Python does not support multi-line comment marks. Each line of a comment block must start with the `#` character. Comments are ignored by the interpreter:
+Methods bound to class names are invoked via dot notation (.), as are functions, constants, or global names imported as part of a module.:
+
+```python
+
+import string
+
+# this is a constant provided by the *string* module
+>>> print(string.ascii_lowercase)
+"abcdefghijklmnopqrstuvwxyz"
+
+# this is a method call of the str *class*
+>>> start_text = "my silly sentence for examples."
+>>> str.upper(start_text)
+"MY SILLY SENTENCE FOR EXAMPLES."
+
+# this is a method call of an *instance* of the str *class*
+>>> start_text.upper()
+"MY SILLY SENTENCE FOR EXAMPLES."
+```
+
+[Comments][comments] in Python start with a `#` that is not part of a string, and end at line termination. Unlike many other programming languages, Python does not support multi-line comment marks. Each line of a comment block must start with the `#` character. Comments are ignored by the interpreter:
 
 ```python
 #this is a single line comment
@@ -71,18 +115,86 @@ x = "foo"  #this is an in-line comment
 #these should be used sparingly
 ```
 
-The first statement of a function body can optionally be a _docstring_, which concisely summarizes the function or object's purpose. These docstrings are read by automated documentation tools and can be accessed from code. They are recommended for programs of any size where documentation is needed.
+The first statement of a function body can optionally be a [_docstring_][docstring], which concisely summarizes the function or object's purpose. These docstrings are read by automated documentation tools, and are returned by calling **doc** on the function, method, or class. . They are recommended for programs of any size where documentation is needed:
 
 ```python
+#an example on a user-defined function
 def number_to_the_power_of(number_one, number_two):
     '''Returns float or int.
 
        Takes number_one and raises it to the power of number_two, returning the result.
     '''
+
     return number_one ** number_two
 
 >>> print(number_to_the_power_of.__doc__)
 Returns float or int.
 
        Takes number_one and raises it to the power of number_two, returning the result.
+
+#an example for a built-in type: str
+>>> print(str.__doc__)
+str(object='') -> str
+str(bytes_or_buffer[, encoding[, errors]]) -> str
+
+Create a new string object from the given object. If encoding or
+errors is specified, then the object must expose a data buffer
+that will be decoded using the given encoding and error handler.
+Otherwise, returns the result of object.__str__() (if defined)
+or repr(object).
+encoding defaults to sys.getdefaultencoding().
+errors defaults to 'strict'.
 ```
+
+Docstrings can also include [doctests][doctests], which are interactive examples of how a method or funtion should work. Doctests can be read and run by PyTest, or by importing the `doctest` module.
+
+Complete documentation for the Python programming language can be found at [docs.python.org/3/][python docs]:
+
+- [Python Tutorial][python tutorial]
+- [Python Library Reference][python library reference]
+- [Python Language Reference][python language reference]
+- [Python HOW TOs][python how tos]
+- [Python FAQs][python faqs]
+- [Python Glossary of Terms][python glossary of terms]
+
+[assignment statements]: https://docs.python.org/3/reference/simple_stmts.html#assignment-statements
+[calls]: https://docs.python.org/3/reference/expressions.html#calls
+[classes]: https://docs.python.org/3/reference/datamodel.html#classes
+[comments]: https://realpython.com/python-comments-guide/#python-commenting-basics
+[default arguments]: https://docs.python.org/3/tutorial/controlflow.html#default-argument-values
+[docstring]: https://docs.python.org/3/tutorial/controlflow.html#tut-docstrings
+[doctests]: https://docs.python.org/3/library/doctest.html
+[duck typing]: https://en.wikipedia.org/wiki/Duck_typing
+[dynamic typing in python]: https://stackoverflow.com/questions/11328920/is-python-strongly-typed
+[everythings an object]: https://docs.python.org/3/reference/datamodel.html
+[function definition]: https://docs.python.org/3/tutorial/controlflow.html#defining-functions
+[functions]: https://docs.python.org/3/reference/compound_stmts.html#function
+[gradual typing]: https://en.wikipedia.org/wiki/Gradual_typing
+[indentation]: https://docs.python.org/3/reference/lexical_analysis.html#indentation
+[method objects]: https://docs.python.org/3/c-api/method.html#method-objects
+[module]: https://docs.python.org/3/tutorial/modules.html
+[more on functions]: https://docs.python.org/3/tutorial/controlflow.html#more-on-defining-functions
+[naming and binding]: https://docs.python.org/3/reference/executionmodel.html#naming-and-binding
+[none]: https://docs.python.org/3/library/constants.html
+[object oriented programming]: https://en.wikipedia.org/wiki/Object-oriented_programming
+[objects]: https://docs.python.org/3/reference/datamodel.html#the-standard-type-hierarchy
+[parameters]: https://docs.python.org/3/glossary.html#term-parameter
+[pep8]: https://www.python.org/dev/peps/pep-0008/
+[peps]: https://www.python.org/dev/peps/
+[psf membership]: https://www.python.org/psf/membership/
+[psf]: https://www.python.org/psf/
+[python docs]: https://docs.python.org/3/
+[python faqs]: https://docs.python.org/3/faq/index.html
+[python glossary of terms]: https://docs.python.org/3/glossary.html
+[python how tos]: https://docs.python.org/3/howto/index.html
+[python language reference]: https://docs.python.org/3/reference/index.html
+[python library reference]: https://docs.python.org/3/library/index.html
+[python tutorial]: https://docs.python.org/3/tutorial/index.html
+[return]: https://docs.python.org/3/reference/simple_stmts.html#return
+[significant indentation]: https://docs.python.org/3/reference/lexical_analysis.html#indentation
+[snake case]: https://en.wikipedia.org/wiki/Snake_case
+[the zen of python]: https://www.python.org/dev/peps/pep-0020/
+[turtles all the way down]: https://en.wikipedia.org/wiki/Turtles_all_the_way_down
+[type hints]: https://docs.python.org/3/library/typing.html
+[variables]: https://realpython.com/python-variables/
+[what is pythonic]: https://blog.startifact.com/posts/older/what-is-pythonic.html

--- a/languages/python/exercises/concept/guidos-gorgeous-lasagna/.docs/introduction.md
+++ b/languages/python/exercises/concept/guidos-gorgeous-lasagna/.docs/introduction.md
@@ -29,6 +29,8 @@ MY_FIRST_CONSTANT = 16
 
 The keyword `def` begins a [function definition][function definition]. It must be followed by the function name and a parenthesized list of zero or more formal [parameters][parameters], which can be of several different varieties, and even [vary][more on functions] in length. The `def` line is terminated with a colon.
 
+Statements for the _body_ of the function begin on the next line down from `def`, and must be _indented in a block_. There is no strict indentation amount (_either space **OR** [tab] characters are acceptable_), but [indentation][indentation] must be _consistent for all indented statements_. Functions explicitly return a value or object via the [`return`][return] keyword. Functions that do not have an explicit `return` expression will return [`None`][none].
+
 ```python
 #function definition on first line.
 def add_two_numbers(number_one, number_two):
@@ -46,8 +48,6 @@ def add_two_numbers(number_one, number_two):
                 ^
 IndentationError: unindent does not match any outer indentation level
 ```
-
-Statements for the _body_ of the function begin on the next line down from `def`, and must be _indented in a block_. There is no strict indentation amount (_either space **OR** [tab] characters are acceptable_), but [indentation][indentation] must be _consistent for all indented statements_. Functions explicitly return a value or object via the [`return`][return] keyword. Functions that do not have an explicit `return` expression will return [`None`][none].
 
 Functions are [_called_][calls] using their name followed by `()`. The number of arguments passed in the parentheses must match the number of parameters in the original function definition unless [default arguments][default aruguments] have been used:
 
@@ -141,8 +141,6 @@ or repr(object).
 encoding defaults to sys.getdefaultencoding().
 errors defaults to 'strict'.
 ```
-
-Docstrings can also include [doctests][doctests], which are interactive examples of how a method or funtion should work. Doctests can be read and run by PyTest, or by importing the `doctest` module.
 
 [assignment statements]: https://docs.python.org/3/reference/simple_stmts.html#assignment-statements
 [calls]: https://docs.python.org/3/reference/expressions.html#calls


### PR DESCRIPTION
- Edited `introduction.md` and `about.md` to contain reference links instead of in-line links
- Edited `introduction.md` down to only include examples needed for exercise.
- Edited `links.json` to shorten it.