### PR TITLE
[Common Lisp] Fix package declarations in exercise example files

### DIFF
--- a/languages/common-lisp/exercises/concept/key-comparison/.meta/example.lisp
+++ b/languages/common-lisp/exercises/concept/key-comparison/.meta/example.lisp
@@ -1,4 +1,4 @@
-(defpackage sameness
+(defpackage key-comparison
   (:use :cl)
   (:export
    :key-object-identity
@@ -16,7 +16,7 @@
    :key-arrays
    :key-arrays-losely))
 
-(in-package :sameness)
+(in-package :key-comparison)
 
 (defun key-object-identity (x y) (eq x y))
 (defun key-numbers (x y) (eql x y))

--- a/languages/common-lisp/exercises/concept/leslies-lists/.meta/example.lisp
+++ b/languages/common-lisp/exercises/concept/leslies-lists/.meta/example.lisp
@@ -1,4 +1,4 @@
-(defpackage lists
+(defpackage leslies-lists
   (:use :cl)
   (:export :new-list
            :list-of-things
@@ -14,7 +14,7 @@
            :part-of-list
            :list-reverse))
 
-(in-package :lists)
+(in-package :leslies-lists)
 
 (defun new-list ()
   (list))

--- a/languages/common-lisp/exercises/concept/pal-picker/.meta/example.lisp
+++ b/languages/common-lisp/exercises/concept/pal-picker/.meta/example.lisp
@@ -1,9 +1,9 @@
-(defpackage conditionals
+(defpackage pal-picker
   (:use :cl)
   (:export :pal-picker :habitat-fitter :feeding-time-p
            :pet :play-fetch))
 
-(in-package :conditionals)
+(in-package :pal-picker)
 
 (defun pal-picker (personality)
   (case personality

--- a/languages/common-lisp/exercises/concept/pizza-pi/.meta/example.lisp
+++ b/languages/common-lisp/exercises/concept/pizza-pi/.meta/example.lisp
@@ -1,9 +1,9 @@
-(defpackage arithmetic
+(defpackage pizza-pi
   (:use :cl)
   (:export :dough-calculator :pizzas-per-cube
            :size-from-sauce :fair-share-p))
 
-(in-package :arithmetic)
+(in-package :pizza-pi)
 
 (defun dough-calculator (pizzas diameter)
   (round (* pizzas (+ (/ (* 45 pi diameter) 20) 200))))

--- a/languages/common-lisp/exercises/concept/socks-and-sexprs/.meta/example.lisp
+++ b/languages/common-lisp/exercises/concept/socks-and-sexprs/.meta/example.lisp
@@ -1,9 +1,9 @@
-(defpackage basics
+(defpackage socks-and-sexprs
   (:use :cl)
   (:export :lennys-favorite-food :lennys-secret-keyword
            :is-an-atom-p :is-a-cons-p :first-thing :rest-of-it))
 
-(in-package :basics)
+(in-package :socks-and-sexprs)
 
 ;; Evaluates to the symbol LASAGNA
 (defun lennys-favorite-food ()


### PR DESCRIPTION
When the exercises were renamed the renaming did not extend to the
`example.lisp` files so they were no longer correct examples of
solutions to the problems.