### PR TITLE
[CI] Remove unused markdown link check config file

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -1,7 +1,0 @@
-{
-  "ignorePatterns": [
-    {
-      "pattern": "^https?://"
-    }
-  ]
-}


### PR DESCRIPTION
This file belonged to the old markdown link checker which we no longer use.