### PR TITLE
[Common Lisp] Using gender neutral pronouns for Lisp Aliens.

### DIFF
--- a/languages/common-lisp/exercises/concept/leslies-lists/.docs/instructions.md
+++ b/languages/common-lisp/exercises/concept/leslies-lists/.docs/instructions.md
@@ -12,7 +12,7 @@ First thing is that Leslie needs to create a new empty list. A function called `
 (empty-list) ; => ()
 ```
 
-Oh no... Leslie actually has a few things in mind already so she needs a function that takes a three items (luckily Leslie never creates a list if she has less or more than three items) and creates a new shopping list with those things. Write a function called `list-of-things` which will take three items and makes a list of them.
+Oh no... Leslie actually has a few things in mind already so they need a function that takes a three items (luckily Leslie never creates a list if they have less or more than three items) and creates a new shopping list with those things. Write a function called `list-of-things` which will take three items and makes a list of them.
 
 ```lisp
 (list-of-things 'bread 'milk 'butter) ; => '(bread milk butter)

--- a/languages/common-lisp/exercises/concept/pal-picker/.docs/instructions.md
+++ b/languages/common-lisp/exercises/concept/pal-picker/.docs/instructions.md
@@ -3,17 +3,17 @@ wonderful things, but one of their favorite discoveries was that of
 "pets". Let's be honest, what sort of alien wouldn't gush over a puppy or
 kitten?
 
-Ludwig, after his recent holiday to Earth, has decided he wants a pet of his
+Ludwig, after their recent holiday to Earth, has decided they want a pet of their
 own! The only issue? Far too many choices! Perhaps you could write a program to
-help Ludwig find and care for his next cuddly friend?
+help Ludwig find and care for their next cuddly friend?
 
 ## 1. Picking a Pal
 
-Though Ludwig is set on getting a pet, that's about as far as he's gotten in
+Though Ludwig is set on getting a pet, that's about as far as they've gotten in
 thinking things through. The first step, then, is deciding what sort of pet to
 get!
 
-Ludwig wants to find a pal with a personality that complements his own. Could
+Ludwig wants to find a pal with a personality that complements their own. Could
 you write Ludwig a function called `pal-picker` that takes some personality
 trait (a keyword) and returns the type of pet (a string) with the given trait?
 
@@ -34,10 +34,10 @@ For other, unknown personalities, your function should evaluate to: `"I don't kn
 ## 2. In Their Natural Habitat
 
 Now that Ludwig has a new friend, they'll need a place to stay! Can you help
-Ludwig select the right size bed / tank / cage for his pet?
+Ludwig select the right size bed / tank / cage for their pet?
 
 Here, Ludwig needs a function called `habitat-fitter` for selecting the proper
-habitat size (a keyword) from his pet's weight in kilograms (a integer).
+habitat size (a keyword) from their pet's weight in kilograms (a integer).
 
 The habitats needed by each size pet are:
 
@@ -54,10 +54,10 @@ The habitats needed by each size pet are:
 ## 3. And Now, We Feast
 
 One thing all earthling pets have in common is their need for food! This concept
-is somewhat alien to Ludwig, however, as he is prone to forgetting to refill his
+is somewhat alien to Ludwig, however, as they are prone to forgetting to refill their
 pet's food-bowl.
 
-Ludwig could use a simple function called `feeding-time-p` to alert him when the
+Ludwig could use a simple function called `feeding-time-p` to alert them when the
 bowl needs refilling. The function would take a percent fullness (an integer)
 and return a message in the form of a string.
 

--- a/languages/common-lisp/exercises/concept/pizza-pi/.docs/instructions.md
+++ b/languages/common-lisp/exercises/concept/pizza-pi/.docs/instructions.md
@@ -1,6 +1,6 @@
 Lilly, a culinarily-inclined Lisp Alien, wants to throw a pizza party for
-herself and some friends but, wanting to make the most of her ingredients, would
-like to know exactly how much of each component she'll need before starting.
+themselves and some friends but, wanting to make the most of their ingredients, would
+like to know exactly how much of each component they'll need before starting.
 
 To solve this problem, Lilly has drafted a program to automate some of the
 planning but needs your help finishing it. Will you help Lilly throw the
@@ -16,7 +16,7 @@ requires 45g of dough.
 
 Lilly is looking to write a function that takes the number of pizzas to make and
 their diameters then returns the exact amount of dough (to the nearest gram)
-that she'll need. For example, to make 4 pizzas 30cm in diameter:
+that they'll need. For example, to make 4 pizzas 30cm in diameter:
 
 ```lisp
 (dough-calculator 4 30) ; => 1648
@@ -29,9 +29,9 @@ $$g = n \cdot \left(\dfrac{45 \pi d}{20} + 200\right)$$
 
 ## 2. A Splash of Sauce
 
-Lilly is astonishingly meticulous when it comes to her sauce application and
+Lilly is astonishingly meticulous when it comes to their sauce application and
 always applies exactly 3ml of sauce to every 10 square centimeters of
-pizza. Ironically, the size of her pizzas can be incredibly inconsistent. Lilly
+pizza. Ironically, the size of their pizzas can be incredibly inconsistent. Lilly
 needs your help defining a function that calculates the pizza size (the
 diameter) from the amount of sauce applied. For example, given Lilly has used
 250ml of sauce:
@@ -49,7 +49,7 @@ $$d = \sqrt{\dfrac{40s}{3\pi}}$$
 
 On Lilly's planet, all cheese comes in perfect cubes and is sold by size. (What
 were you expecting? This is an alien planet after all...) Your task is to help
-Lilly calculate how many pizzas she can make using any given cheese
+Lilly calculate how many pizzas they can make using any given cheese
 cube. Mozzarella cheese has a density of 0.5 grams per cubic centimeter and
 every pizza needs 3 grams of cheese per square centimeter. Given the side-length
 of some cheese cube and the pizzas' diameter, calculate the number of pizzas
@@ -68,8 +68,8 @@ $$n = \dfrac{2l^3}{3 \pi d^2}$$
 
 ## 4. A Fair Share
 
-Finally, Lilly wants to be sure that her pizzas (each made up of 8 slices) can
-be evenly divided between her friends. Your task is to define a function
+Finally, Lilly wants to be sure that their pizzas (each made up of 8 slices) can
+be evenly divided between their friends. Your task is to define a function
 that takes a number of pizzas and number of friends then returns `T` if the
 pizza can be evenly divided between friends and `NIL` otherwise. For example:
 

--- a/languages/common-lisp/exercises/concept/socks-and-sexprs/.docs/hints.md
+++ b/languages/common-lisp/exercises/concept/socks-and-sexprs/.docs/hints.md
@@ -14,7 +14,7 @@ functions with "atom" or "cons" in the name.
 Note: in general predicate functions end with `p` or `-p`. The naming of the
 atom predicate is an unfortunate inconsistency.
 
-## 3. Help Lenny split up his conses
+## 3. Help Lenny split up their conses
 
 When it comes to getting the first element and the rest of an sexpr, there are a
 couple of options [here][clhs-conses]. Look specifically for _Accessors_ as

--- a/languages/common-lisp/exercises/concept/socks-and-sexprs/.docs/instructions.md
+++ b/languages/common-lisp/exercises/concept/socks-and-sexprs/.docs/instructions.md
@@ -1,17 +1,17 @@
-You! Yes you, brave lisper! [Lenny the lisp alien][alien] needs your help! He
-wants to go hang out with all the other lisp aliens, but his parents have told him
-that he's not going anywhere until his room is clean.
+You! Yes you, brave lisper! [Lenny the lisp alien][alien] needs your help! Lenny
+wants to go hang out with all the other lisp aliens, but their parents have told Lenny
+that they're not going anywhere until their room is clean.
 
-The issue is, Lenny can hardly see the floor! He can't tell his atoms from his
-conses, his symbols from his keywords, his `car`s from his `cdr`s!
+The issue is, Lenny can hardly see the floor! Lenny can't tell their atoms from their
+conses, their symbols from their keywords, their `car`s from their `cdr`s!
 
 Can you help Lenny sort this mess out? Don't forget [your parentheses][xkcd],
 you'll be needing them!
 
 ## 1. Refresh Lenny on symbols
 
-Before Lenny can get started, he needs a refresher on what symbols and keywords
-look like – it's been a while since he last tidied up... Help Lenny out by
+Before Lenny can get started, they need a refresher on what symbols and keywords
+look like – it's been a while since they last tidied up... Help Lenny out by
 defining two functions: `lennys-favorite-food` which evaluates to some symbol,
 and `lennys-secret-keyword` which evaluates to some keyword. For example:
 
@@ -29,7 +29,7 @@ of lasagna or aren't a believer in aliens).
 ## 2. Help Lenny distinguish between atoms and conses
 
 Once Lenny has had a refresher on symbols and keywords, it's time to get
-cleaning! To sort through all of the S-Expressions laying around his room, Lenny
+cleaning! To sort through all of the S-Expressions laying around their room, Lenny
 needs help determining what is a cons and what is an atom. You can help by
 implementing two functions, `is-an-atom-p` and `is-a-cons-p`:
 
@@ -47,11 +47,11 @@ For this section, there are a number of built-in lisp functions that you may
 find useful. Additionally, for now, you can simply consider `T` as true and
 `NIL` as false.
 
-## 3. Help Lenny split up his conses
+## 3. Help Lenny split up their conses
 
-Finally, Lenny's conses are too bulky to put away neatly, so he needs to split
+Finally, Lenny's conses are too bulky to put away neatly, so they need to split
 them up into smaller parts. Can you help by defining two more functions to break
-up his conses (`first-thing` and `rest-of-it`)?
+up their conses (`first-thing` and `rest-of-it`)?
 
 ```lisp
 (first-thing '(first second third)) ; => FIRST


### PR DESCRIPTION
Given our lack of understanding of Lisp Alien biology and societal norms it is best to use gender neutral pronouns for them for the time being until we get to know them better.

----

Fixes #2855