### PR TITLE
[CI] Enable external link checks

### DIFF
--- a/.github/workflows/valid-links.yml
+++ b/.github/workflows/valid-links.yml
@@ -46,13 +46,13 @@ jobs:
           if [ "$GITHUB_REF" = "refs/heads/master" ] || [[ $deleted_or_renamed -ne 0 ]]
           then
               echo "Searching all files..."
-              markdownlinkchecker -m files -v "$debug_level"
+              markdownlinkchecker -v "$debug_level"
           else
               files=$(git diff --no-commit-id --name-only --diff-filter AM origin/master | grep  -i .md$ | grep -v -i _sidebar.md | grep -v -i ISSUE_TEMPLATE | cat)
               echo "Searching changed files: $files"
 
               if [[ -n $files ]]; then
                 # shellcheck disable=SC2086
-                markdownlinkchecker -m files -v "$debug_level" -f $files
+                markdownlinkchecker -v "$debug_level" -f $files
               fi
           fi


### PR DESCRIPTION
The previous issue was fixed in https://github.com/ErikSchierboom/MarkdownLinkChecker/pull/11 and https://github.com/ErikSchierboom/MarkdownLinkChecker/commit/37d70ea9071d16416a557ef1eb51d494f2f0284f