### PR TITLE
[Python] str-methods. Fix https prefix and typo

### DIFF
--- a/languages/python/concepts/string-methods/about.md
+++ b/languages/python/concepts/string-methods/about.md
@@ -2,10 +2,10 @@
 
 A string (`str`) in Python is a sequence of Unicode code points which
 include letters, numbers, symbols, punctuation, etc. Strings
-implement all of the [common sequence operations](https:/docs.python.org/3/library/stdtypes.html#typesseq-common),
+implement all of the [common sequence operations][types seq common],
 along with iteration using the `for item in <string>` syntax.
 
-Python provides a number of useful methods that you can use to manipulate
+Python provides several useful methods that you can use to manipulate
 strings. These string methods can be used for cleaning, splitting, translating,
 or otherwise working with the `str` type. New strings can be created based
 on method arguments, and/or additional information can be returned. Strings
@@ -13,7 +13,7 @@ can be concatenated using the `+` operator or with `str.join()`.
 
 Some of the more commonly used methods include:
 
-- Checking for prefixes/suffixes with `startwith()` and `endswith()`
+- Checking for prefixes/suffixes with `startswith()` and `endswith()`
 - Altering string casing with methods like `upper()`, `lower()`, and `swapcase()`
 - Removing leading or trailing characters from a string using `strip()`, `lstrip()`, or `rstrip()`
 - Replacing substrings with the `replace()` method
@@ -22,5 +22,7 @@ Some of the more commonly used methods include:
 
 The `str` type is _immutable_, so all of these methods will return a new `str` instead of modifying the existing one.
 
-For more information, you can check out the
-[official documentation](https://docs.python.org/3/library/stdtypes.html#string-methods).
+For more information, you can check out the [official documentation][official documentation].
+
+[types seq common]: https://docs.python.org/3/library/stdtypes.html#typesseq-common
+[official documentation]: https://docs.python.org/3/library/stdtypes.html#string-methods


### PR DESCRIPTION
- Fix `https:/` to `https://`
- startswith typo