### PR TITLE
[Elixir] Add concepts missing in the config

### DIFF
--- a/languages/elixir/config.json
+++ b/languages/elixir/config.json
@@ -975,6 +975,12 @@
       "blurb": "TODO: add blurb for default-arguments concept"
     },
     {
+      "uuid": "c809ee97-03d1-42a9-ae72-af1c4042b974",
+      "slug": "dynamic-dispatch",
+      "name": "Dynamic Dispatch",
+      "blurb": "TODO: add blurb for dynamic-dispatch concept"
+    },
+    {
       "uuid": "34f0a21f-1ec5-4042-9efe-0c3ae7e35fbb",
       "slug": "enum",
       "name": "Enum",
@@ -1087,6 +1093,12 @@
       "slug": "processes",
       "name": "Processes",
       "blurb": "TODO: add blurb for processes concept"
+    },
+    {
+      "uuid": "39a458dd-287f-482c-8fee-111beb4945e4",
+      "slug": "protocols",
+      "name": "Protocols",
+      "blurb": "TODO: add blurb for protocols concept"
     },
     {
       "uuid": "b2165ae4-a742-4230-8297-11e65882ce2c",


### PR DESCRIPTION
A quick comparison of the concepts in the config and the directories inside `elixir/concepts` revealed two missing concepts.