### PR TITLE
[Elixir] Propose a simple chessboard `ranges` exercise

### DIFF
--- a/languages/elixir/concepts/charlists/about.md
+++ b/languages/elixir/concepts/charlists/about.md
@@ -113,7 +113,7 @@ Charlists and strings consisting of the same characters are not considered equal
 false
 ```
 
-Each value in a charlist is the [Unicode code point of a character][unicode-table] whereas in a string, the codepoints are encoded as [UTF-8][utf8].
+Each value in a charlist is the [Unicode code point of a character][unicode-table] whereas in a string, the code points are encoded as [UTF-8][utf8].
 
 ```elixir
 IO.inspect('tschüss', charlists: :as_lists)

--- a/languages/elixir/concepts/ranges/about.md
+++ b/languages/elixir/concepts/ranges/about.md
@@ -1,7 +1,7 @@
 [Ranges][range] represent a sequence of one or many consecutive integers. They:
 
 - Are created using the [`..` operator][range-operator] and can be both ascending or descending.
-- Are inclusive of the last value.
+- Are inclusive of the first and last values.
 - Implement the [_Enumerable protocol_][enumerable].
 - Are represented internally as a struct, but can be pattern matched using `..`.
 - Can be used with integers written in the binary, octal, hexadecimal, and codepoint notation.

--- a/languages/elixir/concepts/ranges/about.md
+++ b/languages/elixir/concepts/ranges/about.md
@@ -5,12 +5,18 @@
 - Implement the [_Enumerable protocol_][enumerable].
 - Are represented internally as a struct, but can be pattern matched using `..`.
 - Can be used with integers written in the binary, octal, hexadecimal, and codepoint notation.
+- Can be turned into lists with functions such as [`Enum.to_list/1`][enum-to-list] or [`Enum.map/2`][enum-map].
 
 ```elixir
-Enum.map(?D..?A, & &1 + 3)
-# => 'GFED'
+Enum.to_list(9..1)
+# => [9, 8, 7, 6, 5, 4, 3, 2, 1]
+
+Enum.map(?A..?F, & <<&1>>)
+["A", "B", "C", "D", "E", "F"]
 ```
 
 [range-operator]: https://hexdocs.pm/elixir/Kernel.html#../2
 [range]: https://hexdocs.pm/elixir/Range.html
 [enumerable]: https://hexdocs.pm/elixir/Enumerable.html
+[enum-to-list]: https://hexdocs.pm/elixir/Enum.html#to_list/1
+[enum-map]: https://hexdocs.pm/elixir/Enum.html#to_list/1

--- a/languages/elixir/concepts/ranges/about.md
+++ b/languages/elixir/concepts/ranges/about.md
@@ -4,7 +4,7 @@
 - Are inclusive of the first and last values.
 - Implement the [_Enumerable protocol_][enumerable].
 - Are represented internally as a struct, but can be pattern matched using `..`.
-- Can be used with integers written in the binary, octal, hexadecimal, and codepoint notation.
+- Can be used with integers written in the binary, octal, hexadecimal, and code point notation.
 - Can be turned into lists with functions such as [`Enum.to_list/1`][enum-to-list] or [`Enum.map/2`][enum-map].
 
 ```elixir

--- a/languages/elixir/config.json
+++ b/languages/elixir/config.json
@@ -188,8 +188,8 @@
         "slug": "mensch-aergere-dich-nicht",
         "name": "Mensch Ärgere Dich Nicht",
         "uuid": "3e2f8bc6-20b4-4e8f-a658-9c270342208e",
-        "concepts": ["streams", "pipe-operator", "ranges"],
-        "prerequisites": ["enum", "tuples", "if"]
+        "concepts": ["streams", "pipe-operator"],
+        "prerequisites": ["enum", "tuples", "if", "ranges", "randomness"]
       },
       {
         "slug": "community-garden",
@@ -234,6 +234,12 @@
           "charlists",
           "atoms"
         ]
+      },
+      {
+        "slug": "chessboard",
+        "uuid": "6ea28f3e-a59a-45b0-83a7-38a2e96bdff7",
+        "concepts": ["ranges"],
+        "prerequisites": ["enum", "integers", "bitstrings", "charlists"]
       }
     ],
     "practice": [

--- a/languages/elixir/config.json
+++ b/languages/elixir/config.json
@@ -237,6 +237,7 @@
       },
       {
         "slug": "chessboard",
+        "name": "Chessboard",
         "uuid": "6ea28f3e-a59a-45b0-83a7-38a2e96bdff7",
         "concepts": ["ranges"],
         "prerequisites": ["enum", "integers", "bitstrings", "charlists"]

--- a/languages/elixir/exercises/concept/chessboard/.docs/hints.md
+++ b/languages/elixir/exercises/concept/chessboard/.docs/hints.md
@@ -9,7 +9,7 @@
 ## 2. Define the file range
 
 - There is a [special operator][range-creation-operator] for creating ranges.
-- There is a [special syntax] to write a character code point without explicitly knowing its value.
+- There is a [special syntax][unicode-code-points] to write a character code point without explicitly knowing its value.
 
 ## 3. Transform the rank range into a list of ranks
 
@@ -19,7 +19,7 @@
 ## 4. Transform the file range into a list of files
 
 - Ranges implement the `Enumerable` protocol.
-- There is a [built-in function] to change an enumerable data structure to a list while modifying its elements.
+- There is a [built-in function][unicode-code-points] to change an enumerable data structure to a list while modifying its elements.
 - The [bitstring special form][bitstring-special-form] can be used to turn a code point into a string.
 
 [range]: https://hexdocs.pm/elixir/Range.html

--- a/languages/elixir/exercises/concept/chessboard/.docs/hints.md
+++ b/languages/elixir/exercises/concept/chessboard/.docs/hints.md
@@ -1,0 +1,30 @@
+## General
+
+- Read the official documentation for [ranges][range].
+
+## 1. Define the rank range
+
+- There is a [special operator][range-creation-operator] for creating ranges.
+
+## 2. Define the file range
+
+- There is a [special operator][range-creation-operator] for creating ranges.
+- There is a [special syntax] to write a character code point without explicitly knowing its value.
+
+## 3. Transform the rank range into a list of ranks
+
+- Ranges implement the `Enumerable` protocol.
+- There is a [built-in function][enum-to-list] to change an enumerable data structure to a list.
+
+## 4. Transform the file range into a list of files
+
+- Ranges implement the `Enumerable` protocol.
+- There is a [built-in function] to change an enumerable data structure to a list while modifying its elements.
+- The [bitstring special form][bitstring-special-form] can be used to turn a code point into a string.
+
+[range]: https://hexdocs.pm/elixir/Range.html
+[range-creation-operator]: https://hexdocs.pm/elixir/Kernel.html#../2
+[unicode-code-points]: https://hexdocs.pm/elixir/syntax-reference.html#integers-in-other-bases-and-unicode-code-points
+[enum-to-list]: https://hexdocs.pm/elixir/Enum.html#to_list/1
+[enum-map]: https://hexdocs.pm/elixir/Enum.html#map/2
+[bitstring-special-form]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%3C%3C%3E%3E/1

--- a/languages/elixir/exercises/concept/chessboard/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/chessboard/.docs/instructions.md
@@ -14,7 +14,7 @@ Chessboard.rank_range()
 
 ## 2. Define the file range
 
-Implement the `file_range/0` function. It should return a range of integers, from the codepoint of the uppercase letter A, to the codepoint of the uppercase letter H.
+Implement the `file_range/0` function. It should return a range of integers, from the code point of the uppercase letter A, to the codepoint of the uppercase letter H.
 
 ```elixir
 Chessboard.file_range()

--- a/languages/elixir/exercises/concept/chessboard/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/chessboard/.docs/instructions.md
@@ -14,7 +14,7 @@ Chessboard.rank_range()
 
 ## 2. Define the file range
 
-Implement the `file_range/0` function. It should return a range of integers, from the code point of the uppercase letter A, to the codepoint of the uppercase letter H.
+Implement the `file_range/0` function. It should return a range of integers, from the code point of the uppercase letter A, to the code point of the uppercase letter H.
 
 ```elixir
 Chessboard.file_range()

--- a/languages/elixir/exercises/concept/chessboard/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/chessboard/.docs/instructions.md
@@ -8,9 +8,17 @@ Each square of the chessboard is identified by a letter-number pair. The vertica
 
 Implement the `rank_range/0` function. It should return a range of integers, from 1 to 8.
 
+```elixir
+Chessboard.rank_range()
+```
+
 ## 2. Define the file range
 
 Implement the `file_range/0` function. It should return a range of integers, from the codepoint of the uppercase letter A, to the codepoint of the uppercase letter H.
+
+```elixir
+Chessboard.file_range()
+```
 
 ## 3. Transform the rank range into a list of ranks
 

--- a/languages/elixir/exercises/concept/chessboard/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/chessboard/.docs/instructions.md
@@ -1,0 +1,31 @@
+As a chess enthusiast, you would like to write your own version of the game. Yes, there maybe plenty of implementations of chess available online already, but yours will be unique!
+
+But before you can let your imagination run wild, you need to take care of the basics. Let's start by generating the board.
+
+Each square of the chessboard is identified by a letter-number pair. The vertical columns of squares, called files, are labeled A through H. The horizontal rows of squares, called ranks, are numbered 1 to 8.
+
+## 1. Define the rank range
+
+Implement the `rank_range/0` function. It should return a range of integers, from 1 to 8.
+
+## 2. Define the file range
+
+Implement the `file_range/0` function. It should return a range of integers, from the codepoint of the uppercase letter A, to the codepoint of the uppercase letter H.
+
+## 3. Transform the rank range into a list of ranks
+
+Implement the `ranks/0` function. It should return a list of integers, from 1 to 8. Do not write the list by hand, generate it from the range returned by the `rank_range/0` function.
+
+```elixir
+Chessboard.ranks()
+# => [1, 2, 3, 4, 5, 6, 7, 8]
+```
+
+## 4. Transform the file range into a list of files
+
+Implement the `files/0` function. It should return a list of letters (string), from "A" to "H". Do not write the list by hand, generate it from the range returned by the `file_range/0` function.
+
+```elixir
+Chessboard.files()
+# => ["A", "B", "C", "D", "E", "F", "G", "H"]
+```

--- a/languages/elixir/exercises/concept/chessboard/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/chessboard/.docs/introduction.md
@@ -6,6 +6,6 @@ Ranges represent a sequence of one or many consecutive integers. They are create
 1..5
 ```
 
-Ranges can be ascending or descending. They are always inclusive of the last value.
+Ranges can be ascending or descending. They are always inclusive of the first and last values.
 
 A range implements the _Enumerable protocol_, which means functions in the `Enum` module can be used to work with ranges.

--- a/languages/elixir/exercises/concept/chessboard/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/chessboard/.docs/introduction.md
@@ -1,0 +1,11 @@
+## ranges
+
+Ranges represent a sequence of one or many consecutive integers. They are created by connecting two integers with `..`.
+
+```elixir
+1..5
+```
+
+Ranges can be ascending or descending. They are always inclusive of the last value.
+
+A range implements the _Enumerable protocol_, which means functions in the `Enum` module can be used to work with ranges.

--- a/languages/elixir/exercises/concept/chessboard/.formatter.exs
+++ b/languages/elixir/exercises/concept/chessboard/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/languages/elixir/exercises/concept/chessboard/.gitignore
+++ b/languages/elixir/exercises/concept/chessboard/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+match_binary-*.tar
+

--- a/languages/elixir/exercises/concept/chessboard/.meta/config.json
+++ b/languages/elixir/exercises/concept/chessboard/.meta/config.json
@@ -5,6 +5,12 @@
       "exercism_username": "angelikatyborska"
     }
   ],
+  "contributors": [
+    {
+      "github_username": "neenjaw",
+      "exercism_username": "neenjaw"
+    }
+  ],
   "editor": {
     "solution_files": ["lib/chessboard.ex"],
     "test_files": ["test/chessboard_test.exs"]

--- a/languages/elixir/exercises/concept/chessboard/.meta/config.json
+++ b/languages/elixir/exercises/concept/chessboard/.meta/config.json
@@ -1,0 +1,13 @@
+{
+  "authors": [
+    {
+      "github_username": "angelikatyborska",
+      "exercism_username": "angelikatyborska"
+    }
+  ],
+  "editor": {
+    "solution_files": ["lib/chessboard.ex"],
+    "test_files": ["test/chessboard_test.exs"]
+  },
+  "language_versions": ">=1.10"
+}

--- a/languages/elixir/exercises/concept/chessboard/.meta/design.md
+++ b/languages/elixir/exercises/concept/chessboard/.meta/design.md
@@ -1,0 +1,27 @@
+## Learning objectives
+
+- Know about ranges.
+  - They are structs.
+  - They are enumerable.
+  - How to transform them to a list.
+  - How to generate a list of letters from a range.
+
+## Out of scope
+
+## Prerequisites
+
+- `integers`
+- `enum`
+- `bitstrings`
+- `charlists`
+
+## Concepts
+
+- `ranges`
+
+## Analyzer
+
+- make sure that `file_range` uses `?A` and `?H` instead of `65` and `72`
+- make sure that `ranks` uses `rank_range`
+- make sure that `files` uses `file_range`
+- make sure that `files` uses `<<>>` to turn a codepoint into a string

--- a/languages/elixir/exercises/concept/chessboard/.meta/design.md
+++ b/languages/elixir/exercises/concept/chessboard/.meta/design.md
@@ -21,7 +21,6 @@
 
 ## Analyzer
 
-- make sure that `file_range` uses `?A` and `?H` instead of `65` and `72`
 - make sure that `ranks` uses `rank_range`
 - make sure that `files` uses `file_range`
-- make sure that `files` uses `<<>>` to turn a codepoint into a string
+- make sure that `files` uses `<<>>` to turn a code point into a string

--- a/languages/elixir/exercises/concept/chessboard/.meta/example.ex
+++ b/languages/elixir/exercises/concept/chessboard/.meta/example.ex
@@ -1,0 +1,17 @@
+defmodule Chessboard do
+  def rank_range do
+    1..8
+  end
+
+  def file_range do
+    ?A..?H
+  end
+
+  def ranks do
+    Enum.to_list(rank_range())
+  end
+
+  def files do
+    Enum.map(file_range(), &<<&1>>)
+  end
+end

--- a/languages/elixir/exercises/concept/chessboard/lib/chessboard.ex
+++ b/languages/elixir/exercises/concept/chessboard/lib/chessboard.ex
@@ -1,0 +1,17 @@
+defmodule Chessboard do
+  def rank_range do
+    raise "Please implement the rank_range/0 function"
+  end
+
+  def file_range do
+    raise "Please implement the file_range/0 function"
+  end
+
+  def ranks do
+    raise "Please implement the ranks/0 function"
+  end
+
+  def files do
+    raise "Please implement the files/0 function"
+  end
+end

--- a/languages/elixir/exercises/concept/chessboard/mix.exs
+++ b/languages/elixir/exercises/concept/chessboard/mix.exs
@@ -1,0 +1,28 @@
+defmodule Chessboard.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :captains_log,
+      version: "0.1.0",
+      # elixir: "~> 1.10",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/languages/elixir/exercises/concept/chessboard/mix.exs
+++ b/languages/elixir/exercises/concept/chessboard/mix.exs
@@ -3,7 +3,7 @@ defmodule Chessboard.MixProject do
 
   def project do
     [
-      app: :captains_log,
+      app: :chessboard,
       version: "0.1.0",
       # elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,

--- a/languages/elixir/exercises/concept/chessboard/test/chessboard_test.exs
+++ b/languages/elixir/exercises/concept/chessboard/test/chessboard_test.exs
@@ -1,0 +1,19 @@
+defmodule ChessboardTest do
+  use ExUnit.Case
+
+  test "rank_range is a range from 1 to 8" do
+    assert Chessboard.rank_range() == 1..8
+  end
+
+  test "file_range is a range from ?A to ?H" do
+    assert Chessboard.file_range() == ?A..?H
+  end
+
+  test "ranks is a list of integers from 1 to 8" do
+    assert Chessboard.ranks() == [1, 2, 3, 4, 5, 6, 7, 8]
+  end
+
+  test "files is a list of letters (strings) from A to H" do
+    assert Chessboard.files() == ["A", "B", "C", "D", "E", "F", "G", "H"]
+  end
+end

--- a/languages/elixir/exercises/concept/chessboard/test/test_helper.exs
+++ b/languages/elixir/exercises/concept/chessboard/test/test_helper.exs
@@ -1,0 +1,2 @@
+ExUnit.start()
+ExUnit.configure(exclude: :pending, trace: true)

--- a/languages/elixir/exercises/concept/date-parser/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/date-parser/.docs/introduction.md
@@ -20,7 +20,7 @@ The `=~/2` operator is useful to perform a regex match on a string to return a `
 > - many different delimiters may be used depending on your requirements rather than `/`
 > - string patterns are already _escaped_, when writing the pattern as a string not using a regex, you will have to _escape_ backslashes (`\`)
 
-Matching a range of characters using square brackets `[]` to denote a _character class_. This will match any one character to the characters in the class. You can also specify a range of characters like `a-z`, as long as the start and end represent a contiguous range of codepoints.
+Matching a range of characters using square brackets `[]` to denote a _character class_. This will match any one character to the characters in the class. You can also specify a range of characters like `a-z`, as long as the start and end represent a contiguous range of code points.
 
 ```elixir
 regex = ~r/[a-z][AZ][0-9][!?]/

--- a/languages/elixir/exercises/concept/dna-encoding/.docs/hints.md
+++ b/languages/elixir/exercises/concept/dna-encoding/.docs/hints.md
@@ -1,6 +1,6 @@
 ## General
 
-- Use `?` to work with the character [codepoints][codepoint].
+- Use `?` to work with the character [code points][codepoint].
 - `\s` can be used to represent a space.
 - Use [integer binary notation][integer-literal] for working with the codes.
 - Try to use the tail call recursion strategy.
@@ -17,9 +17,9 @@
 
 ## 3. Encode a DNA charlist
 
-- Create a recursive function which takes a codepoint from the charlist and recursively builds the bitstring result.
+- Create a recursive function which takes a code point from the charlist and recursively builds the bitstring result.
 
-- Remember, a [charlist][charlist] is a list of [integer codepoints][codepoint].
+- Remember, a [charlist][charlist] is a list of [integer code points][codepoint].
 - You can get the first and remaining items from a list using a build in [`Kernel` module][kernel] function
 - You can also pattern match on a list using the [`[head | tail]`][list] notation.
 - Use multiple clause functions to separate the base case from the recursive cases.

--- a/languages/elixir/exercises/concept/dna-encoding/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/dna-encoding/.docs/instructions.md
@@ -12,7 +12,7 @@ You ponder this, as it will potentially halve the required data storage costs, b
 
 ## 1. Encode nucleic acid to binary value
 
-Implement `encode_nucleotide/1` to accept the codepoint for the nucleic acid and return the integer value of the encoded code.
+Implement `encode_nucleotide/1` to accept the code point for the nucleic acid and return the integer value of the encoded code.
 
 ```elixir
 DNA.encode_nucleotide(?A)
@@ -21,7 +21,7 @@ DNA.encode_nucleotide(?A)
 
 ## 2. Decode the binary value to the nucleic acid
 
-Implement `decode_nucleotide/1` to accept the integer value of the encoded code and return the codepoint for the nucleic acid.
+Implement `decode_nucleotide/1` to accept the integer value of the encoded code and return the code point for the nucleic acid.
 
 ```elixir
 DNA.decode_nucleotide(0b0001)

--- a/languages/elixir/exercises/concept/dna-encoding/lib/dna.ex
+++ b/languages/elixir/exercises/concept/dna-encoding/lib/dna.ex
@@ -1,5 +1,5 @@
 defmodule DNA do
-  def encode_nucleotide(codepoint), do: raise "Please implement encode_nucleotide/1"
+  def encode_nucleotide(code_point), do: raise "Please implement encode_nucleotide/1"
 
   def decode_nucleotide(encoded_code), do: raise "Please implement decode_nucleotide/1"
 

--- a/languages/elixir/exercises/concept/dna-encoding/test/dna_test.exs
+++ b/languages/elixir/exercises/concept/dna-encoding/test/dna_test.exs
@@ -14,7 +14,7 @@ defmodule DNATest do
     test "?T to 0b1000", do: assert DNA.encode_nucleotide(?T) == 0b1000
   end
 
-  describe "decode to codepoint" do
+  describe "decode to code point" do
     @tag :pending
     test "0b0000 to ?\\s", do: assert DNA.decode_nucleotide(0b0000) == ?\s
     @tag :pending

--- a/languages/elixir/exercises/concept/mensch-aergere-dich-nicht/.docs/hints.md
+++ b/languages/elixir/exercises/concept/mensch-aergere-dich-nicht/.docs/hints.md
@@ -1,7 +1,7 @@
 ## General
 
 - Read about enumerables and streams in the [official Getting Started Elixir guide][getting-started-streams].
-- Read the official documentation for [ranges][range] and [streams][stream].
+- Read the official documentation for [streams][stream].
 
 ## 1. Do one 6-sided die roll
 
@@ -17,7 +17,6 @@
 
 - Use the [capture operator][special-forms-capture] to capture the `roll/0` function.
 
-[range]: https://hexdocs.pm/elixir/Range.html
 [stream]: https://hexdocs.pm/elixir/Stream.html
 [getting-started-streams]: https://elixir-lang.org/getting-started/enumerables-and-streams.html
 [enum-random]: https://hexdocs.pm/elixir/Enum.html#random/1

--- a/languages/elixir/exercises/concept/mensch-aergere-dich-nicht/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/mensch-aergere-dich-nicht/.docs/introduction.md
@@ -1,15 +1,3 @@
-## ranges
-
-Ranges represent a sequence of one or many consecutive integers. They are created by connecting two integers with `..`.
-
-```elixir
-1..5
-```
-
-Ranges can be ascending or descending. They are always inclusive of the last value.
-
-A range implements the _Enumerable protocol_, which means functions in the `Enum` module can be used to work with ranges.
-
 ## pipe-operator
 
 The `|>` operator is called the pipe operator. It can be used to chain function calls together in such a way that the value returned by the previous function call is passed as the first argument to the next function call.

--- a/languages/elixir/exercises/concept/mensch-aergere-dich-nicht/.meta/design.md
+++ b/languages/elixir/exercises/concept/mensch-aergere-dich-nicht/.meta/design.md
@@ -1,10 +1,6 @@
 ## Learning objectives
 
 - Know about the `|>` pipe operator for chaining function calls.
-- Know about ranges.
-  - They are structs.
-  - They are enumerable.
-  - How to transform them to a list.
 - Know about streams.
   - `Enum` functions are eager, `Stream` functions are lazy.
   - Potentially infinite.
@@ -15,7 +11,6 @@
 ## Concepts
 
 - `streams`
-- `ranges`
 - `pipe-operator`
 
 ## Prerequisites
@@ -23,6 +18,8 @@
 - `enum`
 - `tuples`
 - `if`
+- `ranges`
+- `randomness`
 
 ## Analyzer
 

--- a/languages/elixir/reference/README.md
+++ b/languages/elixir/reference/README.md
@@ -11,7 +11,7 @@ The initial breakdown of these concepts, including the ordering, is based on the
   - `h/0`, plus `h/1`, `i`, `v`, etc.
 - `elixir script.exs` to execute a script
 - `IO.puts/1` and `IO.inspect/2`
-- Inspect a string's codepoints with `str <> <<0>>` or `IO.inspect(str, binaries: :as_binaries)`
+- Inspect a string's code points with `str <> <<0>>` or `IO.inspect(str, binaries: :as_binaries)`
 
 ### elixir-lang.org Getting Started Guide concept extraction
 
@@ -85,11 +85,11 @@ The initial breakdown of these concepts, including the ordering, is based on the
     - optionally supports `else`
     - `do`/`end` blocks are a syntactic convenience over the keyword syntax
 - [Character encoding](../../../reference/concepts/character_encoding.md)
-  - Codepoints
-    - `?` operator to return a character's codepoint. E.g., `?a == 97`
-    - `\u` notation to represent a unicode codepoint in a string (as hex).
+  - Code points
+    - `?` operator to return a character's code point. E.g., `?a == 97`
+    - `\u` notation to represent a unicode code point in a string (as hex).
       - e.g, `"\u0061" == "\u{61} == "a"`
-  - [UTF8](../../../reference/concepts/utf8.md) encoding used to represent unicode codepoints in binaries
+  - [UTF8](../../../reference/concepts/utf8.md) encoding used to represent unicode code points in binaries
 - [Bitstrings](../../../reference/types/bit.md)
   - `<<>>` syntax
   - contiguous sequence of bits in memory
@@ -106,10 +106,10 @@ The initial breakdown of these concepts, including the ordering, is based on the
   - pattern matching:
     - `<<x, y, z>> = <<0, 1, 2>>` defaults to matching one byte, use `::n` to specify bits
     - `<<x, y::binary>> = <<0, 1, 2>>` uses `binary` to match the rest of a binary
-      - `x` is a codepoint (integer), `y` is a binary. e.g., `x == 0 and y == <<1, 2>>`
+      - `x` is a code point (integer), `y` is a binary. e.g., `x == 0 and y == <<1, 2>>`
     - `<<x::binary-size(2), y::binary>> = <<0, 1, 2>>` uses `binary-size(2)` to match 2 bytes
     - `<<x, y::binary>> = "hello"` matches on strings since strings are binaries
-    - `<<x::utf8, y::binary>> = "über"` uses `::utf8` match utf8 codepoints instead of a single byte
+    - `<<x::utf8, y::binary>> = "über"` uses `::utf8` match utf8 code points instead of a single byte
 - Charlists
   - list of integers where all the integers are valid code points
   - common when interfacing with erlang; otherwise they are not idiomatic

--- a/languages/elixir/reference/exercise-concepts/pangram.md
+++ b/languages/elixir/reference/exercise-concepts/pangram.md
@@ -57,7 +57,7 @@ end
 - types
   - string
   - boolean
-  - codepoint
+  - code point
     - ? operator
   - lists
     - charlist

--- a/languages/elixir/reference/exercise-concepts/rna-transcription.md
+++ b/languages/elixir/reference/exercise-concepts/rna-transcription.md
@@ -70,12 +70,12 @@ The trickiest concept with this as written was due to it providing a _charlist_ 
 - types
   - list
   - char
-  - codepoint
+  - code point
   - charlist
 - standard library modules
   - Kernel
     - function capture
-    - ? (codepoint)
+    - ? (code point)
   - Enum
     - map/2
 - typespec


### PR DESCRIPTION
As I mentioned in https://github.com/exercism/v3/pull/2876, introducing `randomness` in an exercise that requires `ranges` (`captains-log`) is not great because the exercise that taught `ranges` so far also used a bit of `randomness` (`mensch-aergere-dich-nicht`). To remove that (weak) circular dependency, I want to introduce an exercise that will teach just `ranges` and will come before the other two.