### PR TITLE
[Rust] patch test_pr.sh for BSD mktemp

### DIFF
--- a/languages/rust/scripts/test_pr.sh
+++ b/languages/rust/scripts/test_pr.sh
@@ -39,7 +39,7 @@ function test_concept() {
     echo "testing $concept in #$num"
 
     local dir
-    dir="$(mktemp --directory)"
+    dir="$(mktemp -d)"
     #shellcheck disable=SC2064
     trap "rm -rf $dir" RETURN
 


### PR DESCRIPTION
It looks like BSD's `mktemp` does not support the long option
`--directory`. But GNU's supports the `-d`. So I updated the script to
use `-d`.

The sweet smell of cross-platform utilities!