### PR TITLE
[Elixir] Ensure that tests are self-contained - `rpn-calculator-output`

### DIFF
--- a/languages/elixir/exercises/concept/rpn-calculator-output/test/rpn_calculator/output_test.exs
+++ b/languages/elixir/exercises/concept/rpn-calculator-output/test/rpn_calculator/output_test.exs
@@ -3,17 +3,12 @@ defmodule RPNCalculator.OutputTest do
 
   import ExUnit.CaptureIO
 
-  @resource __MODULE__
-  @filename "filename"
-  @bad_filename "bad_filename"
-  @equation "1 1 +"
-
   def open(filename \\ "<nil>") do
     send(self(), {:open, filename})
 
     case filename do
-      @filename -> {:ok, :stdio}
-      @bad_filename -> {:ok, spawn(fn -> nil end)}
+      "filename" -> {:ok, :stdio}
+      "bad_filename" -> {:ok, spawn(fn -> nil end)}
     end
   end
 
@@ -25,7 +20,11 @@ defmodule RPNCalculator.OutputTest do
   describe "write/3" do
     # @tag :pending
     test "returns ok tuple if function succeeds" do
-      assert {:ok, @equation} == RPNCalculator.Output.write(@resource, @filename, @equation)
+      resource = __MODULE__
+      filename = "filename"
+      equation = "1 1 +"
+
+      assert {:ok, equation} == RPNCalculator.Output.write(resource, filename, equation)
     end
 
     @tag :pending
@@ -35,8 +34,12 @@ defmodule RPNCalculator.OutputTest do
     E.g.) resource.open(filename)
     """
     test "opens resource" do
-      RPNCalculator.Output.write(@resource, @filename, @equation)
-      assert_received {:open, @filename}, @use_open_error_message
+      resource = __MODULE__
+      filename = "filename"
+      equation = "1 1 +"
+
+      RPNCalculator.Output.write(resource, filename, equation)
+      assert_received {:open, ^filename}, @use_open_error_message
     end
 
     @tag :pending
@@ -44,7 +47,11 @@ defmodule RPNCalculator.OutputTest do
     Use IO.write/2 to write to the opened `filename`.
     """
     test "writes to resource" do
-      assert capture_io(fn -> RPNCalculator.Output.write(@resource, @filename, @equation) end) ==
+      resource = __MODULE__
+      filename = "filename"
+      equation = "1 1 +"
+
+      assert capture_io(fn -> RPNCalculator.Output.write(resource, filename, equation) end) ==
                "1 1 +",
              @use_write_error_message
     end
@@ -56,19 +63,31 @@ defmodule RPNCalculator.OutputTest do
     E.g.) resource.close(filename)
     """
     test "closes resource" do
-      RPNCalculator.Output.write(__MODULE__, @filename, @equation)
+      resource = __MODULE__
+      filename = "filename"
+      equation = "1 1 +"
+
+      RPNCalculator.Output.write(resource, filename, equation)
       assert_received :close, @use_close_error_message
     end
 
     @tag :pending
     test "rescues and returns error tuple from raised error" do
+      resource = __MODULE__
+      bad_filename = "bad_filename"
+      equation = "1 1 +"
+
       assert {:error, "Unable to write to resource"} ==
-               RPNCalculator.Output.write(@resource, @bad_filename, @equation)
+               RPNCalculator.Output.write(resource, bad_filename, equation)
     end
 
     @tag :pending
     test "closes resource even when rescuing from raised error" do
-      RPNCalculator.Output.write(@resource, @bad_filename, @equation)
+      resource = __MODULE__
+      bad_filename = "bad_filename"
+      equation = "1 1 +"
+
+      RPNCalculator.Output.write(resource, bad_filename, equation)
       assert_received :close, "write/3 should close the `resource` even if an error is raised"
     end
   end


### PR DESCRIPTION
Issue: https://github.com/exercism/v3/issues/2894

In case of this exercise, it's not entirely possible to make them fully self-contained because of the need for a test module that implements the `open` and `close` functions. This has to be good enough 🤷 