### PR TITLE
[Elixir] Ensure that tests are self-contained - `remote_control_car`

### DIFF
--- a/languages/elixir/exercises/concept/remote-control-car/.meta/example.ex
+++ b/languages/elixir/exercises/concept/remote-control-car/.meta/example.ex
@@ -17,6 +17,7 @@ defmodule RemoteControlCar do
   def display_battery(%RemoteControlCar{battery_percentage: 0}) do
     "Battery empty"
   end
+
   def display_battery(%RemoteControlCar{battery_percentage: b}) do
     "Battery at #{b}%"
   end
@@ -25,5 +26,6 @@ defmodule RemoteControlCar do
     d = r.distance_driven_in_meters
     %{r | battery_percentage: b - 1, distance_driven_in_meters: d + 20}
   end
+
   def drive(%RemoteControlCar{} = r), do: r
 end

--- a/languages/elixir/exercises/concept/remote-control-car/test/remote_control_car_test.exs
+++ b/languages/elixir/exercises/concept/remote-control-car/test/remote_control_car_test.exs
@@ -1,12 +1,5 @@
 defmodule RemoteControlCarTest do
   use ExUnit.Case
-  import CompileTimeAssertions
-
-  @fake_car %{
-    battery_percentage: 100,
-    distance_driven_in_meters: 0,
-    nickname: "Fake"
-  }
 
   # @tag :pending
   test "required key 'nickname' should not have a default value" do
@@ -41,8 +34,14 @@ defmodule RemoteControlCarTest do
 
   @tag :pending
   test "display distance raises error when not given struct" do
+    fake_car = %{
+      battery_percentage: 100,
+      distance_driven_in_meters: 0,
+      nickname: "Fake"
+    }
+
     assert_raise(FunctionClauseError, fn ->
-      RemoteControlCar.display_distance(@fake_car)
+      RemoteControlCar.display_distance(fake_car)
     end)
   end
 
@@ -63,8 +62,14 @@ defmodule RemoteControlCarTest do
 
   @tag :pending
   test "display battery raises error when not given struct" do
+    fake_car = %{
+      battery_percentage: 100,
+      distance_driven_in_meters: 0,
+      nickname: "Fake"
+    }
+
     assert_raise(FunctionClauseError, fn ->
-      RemoteControlCar.display_battery(@fake_car)
+      RemoteControlCar.display_battery(fake_car)
     end)
   end
 
@@ -85,8 +90,14 @@ defmodule RemoteControlCarTest do
 
   @tag :pending
   test "drive raises error when not given struct" do
+    fake_car = %{
+      battery_percentage: 100,
+      distance_driven_in_meters: 0,
+      nickname: "Fake"
+    }
+
     assert_raise(FunctionClauseError, fn ->
-      RemoteControlCar.drive(@fake_car)
+      RemoteControlCar.drive(fake_car)
     end)
   end
 


### PR DESCRIPTION
Issue: https://github.com/exercism/v3/issues/2894

This PR removes the usage of a module attribute and runs `mix format`.