### PR TITLE
[Elixir] Fine-tune wording across all exercises

### DIFF
--- a/languages/elixir/concepts/basics/about.md
+++ b/languages/elixir/concepts/basics/about.md
@@ -35,7 +35,7 @@
   - If invoked from within its own module, the module name may be omitted.
 - The arity of a function is often used when referring to a named function
 
-  - The arity refers to the number of parameters it accepts.
+  - The arity refers to the number of arguments it accepts.
 
   ```elixir
   def add(x, y, z), do: x + y + z # add/3, because the arity is 3

--- a/languages/elixir/concepts/default-arguments/about.md
+++ b/languages/elixir/concepts/default-arguments/about.md
@@ -5,7 +5,7 @@ def number(n \\ 13), do: "That's not my favorite"
 ```
 
 - During compilation, Elixir creates a function definition for `number/0` (no arguments), and `number/1` (one argument).
-- If more than one argument has default values, the default values will be applied to the function from left to right to fill in for missing parameters.
+- If more than one argument has default values, the default values will be applied to the function from left to right to fill in for missing arguments.
 - If the function has multiple clauses, it is required to write a [function header][function-header] for the default arguments.
 
 ```elixir

--- a/languages/elixir/exercises/concept/basketball-website/lib/basketball_website.ex
+++ b/languages/elixir/exercises/concept/basketball-website/lib/basketball_website.ex
@@ -1,9 +1,9 @@
 defmodule BasketballWebsite do
   def extract_from_path(data, path) do
-    raise "Please implement extract_from_path/2"
+    raise "Please implement the extract_from_path/2 function"
   end
 
   def get_in_path(data, path) do
-    raise "Please implement get_in_path/2"
+    raise "Please implement the get_in_path/2 function"
   end
 end

--- a/languages/elixir/exercises/concept/boutique-suggestions/lib/boutique_suggestions.ex
+++ b/languages/elixir/exercises/concept/boutique-suggestions/lib/boutique_suggestions.ex
@@ -1,5 +1,5 @@
 defmodule BoutiqueSuggestions do
   def get_combinations(tops, bottoms, options) do
-    raise "Please implement get_combinations/3."
+    raise "Please implement the get_combinations/3 function"
   end
 end

--- a/languages/elixir/exercises/concept/date-parser/lib/date_parser.ex
+++ b/languages/elixir/exercises/concept/date-parser/lib/date_parser.ex
@@ -1,28 +1,28 @@
 defmodule DateParser do
-  def day(), do: raise "Please implement day/0"
-  def month(), do: raise "Please implement month/0"
-  def year(), do: raise "Please implement year/0"
+  def day(), do: raise "Please implement the day/0 function"
+  def month(), do: raise "Please implement the month/0 function"
+  def year(), do: raise "Please implement the year/0 function"
 
   def day_names() do
-    raise "Please implement day_names/0"
+    raise "Please implement the day_names/0 function"
   end
 
   def month_names() do
-    raise "Please implement month_names/0"
+    raise "Please implement the month_names/0 function"
   end
 
-  def capture_day(), do: raise "Please implement capture_day/0"
-  def capture_month(), do: raise "Please implement capture_month/0"
-  def capture_year(), do: raise "Please implement capture_year/0"
+  def capture_day(), do: raise "Please implement the capture_day/0 function"
+  def capture_month(), do: raise "Please implement the capture_month/0 function"
+  def capture_year(), do: raise "Please implement the capture_year/0 function"
 
-  def capture_day_name(), do: raise "Please implement capture_day_name/0"
-  def capture_month_name(), do: raise "Please implement capture_month_name/0"
+  def capture_day_name(), do: raise "Please implement the capture_day_name/0 function"
+  def capture_month_name(), do: raise "Please implement the capture_month_name/0 function"
 
-  def capture_numeric_date(), do: raise "Please implement capture_numeric_date/0"
-  def capture_month_name_date(), do: raise "Please implement capture_month_name_date/0"
-  def capture_day_month_name_date(), do: raise "Please implement capture_day_month_name_date/0"
+  def capture_numeric_date(), do: raise "Please implement the capture_numeric_date/0 function"
+  def capture_month_name_date(), do: raise "Please implement the capture_month_name_date/0 function"
+  def capture_day_month_name_date(), do: raise "Please implement the capture_day_month_name_date/0 function"
 
-  def match_numeric_date(), do: raise "Please implement match_numeric_date/0"
-  def match_month_name_date(), do: raise "Please implement match_month_name_day/0"
-  def match_day_month_name_date(), do: raise "Please implement match_day_month_name_date/0"
+  def match_numeric_date(), do: raise "Please implement the match_numeric_date/0 function"
+  def match_month_name_date(), do: raise "Please implement the match_month_name_day/0 function"
+  def match_day_month_name_date(), do: raise "Please implement the match_day_month_name_date/0 function"
 end

--- a/languages/elixir/exercises/concept/dna-encoding/lib/dna.ex
+++ b/languages/elixir/exercises/concept/dna-encoding/lib/dna.ex
@@ -1,13 +1,13 @@
 defmodule DNA do
-  def encode_nucleotide(code_point), do: raise "Please implement encode_nucleotide/1"
+  def encode_nucleotide(code_point), do: raise "Please implement the encode_nucleotide/1 function"
 
-  def decode_nucleotide(encoded_code), do: raise "Please implement decode_nucleotide/1"
+  def decode_nucleotide(encoded_code), do: raise "Please implement the decode_nucleotide/1 function"
 
   def encode(dna) do
-    raise "Please implement encode/1"
+    raise "Please implement the encode/1 function"
   end
 
   def decode(dna) do
-    raise "Please implement decode/1"
+    raise "Please implement the decode/1 function"
   end
 end

--- a/languages/elixir/exercises/concept/file-sniffer/lib/file_sniffer.ex
+++ b/languages/elixir/exercises/concept/file-sniffer/lib/file_sniffer.ex
@@ -1,13 +1,13 @@
 defmodule FileSniffer do
   def type_from_extension(extension) do
-    raise "Please implement type_from_extension/1"
+    raise "Please implement the type_from_extension/1 function"
   end
 
   def type_from_binary(file_binary) do
-    raise "Please implement type_from_binary/1"
+    raise "Please implement the type_from_binary/1 function"
   end
 
   def verify(file_binary, extension) do
-    raise "Please implement verify/2"
+    raise "Please implement the verify/2 function"
   end
 end

--- a/languages/elixir/exercises/concept/guessing-game/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/guessing-game/.docs/introduction.md
@@ -19,7 +19,7 @@ Variables that are unused in the function body should be prefixed with an unders
 
 ## guards
 
-Guards are used to prevent Elixir from invoking functions based on evaluation of the parameters by guard functions. Guards begin with the `when` keyword, followed by a boolean expression. Guard functions are special functions which:
+Guards are used to prevent Elixir from invoking functions based on evaluation of the arguments by guard functions. Guards begin with the `when` keyword, followed by a boolean expression. Guard functions are special functions which:
 
 - Must be pure and not mutate any global states.
 - Must return strict `true` or `false` values.
@@ -34,6 +34,6 @@ Functions may declare default values for one or more arguments. When compiled, E
 def number(n \\ 13), do: "That's not my favorite"
 ```
 
-If more than one argument has default values, the default values will be applied to the function from left to right to fill in for missing parameters.
+If more than one argument has default values, the default values will be applied to the function from left to right to fill in for missing arguments.
 
 [kernel-guards]: https://hexdocs.pm/elixir/master/Kernel.html#guards

--- a/languages/elixir/exercises/concept/guessing-game/lib/guessing_game.ex
+++ b/languages/elixir/exercises/concept/guessing-game/lib/guessing_game.ex
@@ -1,5 +1,5 @@
 defmodule GuessingGame do
   def compare(secret_number, guess) do
-    raise "Implement the compare/2 function."
+    raise "Please implement the compare/2 function"
   end
 end

--- a/languages/elixir/exercises/concept/high-score/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/high-score/.docs/instructions.md
@@ -4,7 +4,7 @@ You have 7 functions to implement, all related to returning and manipulating a m
 
 ## 1. Define a new high score map
 
-To make a new high score map, define the `HighScore.new/0` function which doesn't take any parameters and returns a new, empty map of high scores.
+To make a new high score map, define the `HighScore.new/0` function which doesn't take any arguments and returns a new, empty map of high scores.
 
 ```elixir
 HighScore.new()
@@ -13,11 +13,11 @@ HighScore.new()
 
 ## 2. Add players to the high score map
 
-To add a player to the high score map, define `HighScore.add_player/3`, which is a function which takes 3 parameters:
+To add a player to the high score map, define `HighScore.add_player/3`, which is a function which takes 3 arguments:
 
-- The first parameter is the map of scores.
-- The second parameter is the name of a player as a string.
-- The third parameter is the score as an integer. The parameter is optional, implement the third parameter with a default value of 0.
+- The first argument is the map of scores.
+- The second argument is the name of a player as a string.
+- The third argument is the score as an integer. The argument is optional, implement the third argument with a default value of 0.
 
 ```elixir
 score_map = HighScore.new()
@@ -30,10 +30,10 @@ score_map = HighScore.add_player(score_map, "José Valim", 486_373)
 
 ## 3. Remove players from the score map
 
-To remove a player from the high score map, define `HighScore.remove_player/2`, which takes 2 parameters:
+To remove a player from the high score map, define `HighScore.remove_player/2`, which takes 2 arguments:
 
-- The first parameter is the map of scores.
-- The second parameter is the name of the player as a string.
+- The first argument is the map of scores.
+- The second argument is the name of the player as a string.
 
 ```elixir
 score_map = HighScore.new()
@@ -46,10 +46,10 @@ score_map = HighScore.remove_player(score_map, "Dave Thomas")
 
 ## 4. Reset a player's score
 
-To reset a player's score, define `HighScore.remove_player/2`, which takes 2 parameters:
+To reset a player's score, define `HighScore.remove_player/2`, which takes 2 arguments:
 
-- The first parameter is the map of scores.
-- The second parameter is the name of the player as a string, whose score you wish to reset.
+- The first argument is the map of scores.
+- The second argument is the name of the player as a string, whose score you wish to reset.
 
 ```elixir
 score_map = HighScore.new()
@@ -62,11 +62,11 @@ score_map = HighScore.reset_score(score_map, "José Valim")
 
 ## 5. Update a player's score
 
-To update a players score by adding to the previous score, define `HighScore.update_player/2`, which takes 3 parameters:
+To update a players score by adding to the previous score, define `HighScore.update_player/2`, which takes 3 arguments:
 
-- The first parameter is the map of scores.
-- The second parameter is the name of the player as a string, whose score you wish to update.
-- The third parameter is the score that you wish to **add** to the stored high score.
+- The first argument is the map of scores.
+- The second argument is the name of the player as a string, whose score you wish to update.
+- The third argument is the score that you wish to **add** to the stored high score.
 
 ```elixir
 score_map = HighScore.new()
@@ -79,9 +79,9 @@ score_map = HighScore.update_score(score_map, "José Valim", 5)
 
 ## 6. Get a list of players with scores ordered by player name
 
-To get a list of players ordered by name, define `HighScore.order_by_players/1`, which takes 1 parameter:
+To get a list of players ordered by name, define `HighScore.order_by_players/1`, which takes 1 argument:
 
-- The first parameter is the map of scores.
+- The first argument is the map of scores.
 
 ```elixir
 score_map = HighScore.new()
@@ -96,9 +96,9 @@ HighScore.order_by_players(score_map)
 
 ## 7. Get a list of players ordered by player score in decreasing order
 
-To get a list of players ordered by scores in decreasing order, define `HighScore.order_by_scores/1`, which takes 1 parameter:
+To get a list of players ordered by scores in decreasing order, define `HighScore.order_by_scores/1`, which takes 1 argument:
 
-- The first parameter is the map of scores.
+- The first argument is the map of scores.
 
 ```elixir
 score_map = HighScore.new()

--- a/languages/elixir/exercises/concept/high-score/lib/high_score.ex
+++ b/languages/elixir/exercises/concept/high-score/lib/high_score.ex
@@ -1,27 +1,27 @@
 defmodule HighScore do
-  def new(), do: raise "Please implement the new/0 function."
+  def new(), do: raise "Please implement the new/0 function"
 
   def add_player(scores, name, score) do
-    raise "Please implement the add_player/3 function."
+    raise "Please implement the add_player/3 function"
   end
 
   def remove_player(scores, name) do
-    raise "Please implement the remove_player/2 function."
+    raise "Please implement the remove_player/2 function"
   end
 
   def update_score(scores, name, score) do
-    raise "Please implement the update_score/3 function."
+    raise "Please implement the update_score/3 function"
   end
 
   def reset_score(scores, name) do
-    raise "Please implement the reset_score/2 function."
+    raise "Please implement the reset_score/2 function"
   end
 
   def order_by_players(scores) do
-    raise "Please implement the order_by_players/1 function."
+    raise "Please implement the order_by_players/1 function"
   end
 
   def order_by_scores(scores) do
-    raise "Please implement the order_by_scores/1 function."
+    raise "Please implement the order_by_scores/1 function"
   end
 end

--- a/languages/elixir/exercises/concept/kitchen-calculator/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/kitchen-calculator/.docs/introduction.md
@@ -45,7 +45,7 @@ In the last example if we don't need a variable in a pattern match, we can disca
 
 ### Pattern matching in named functions
 
-Pattern matching is also a useful tool when creating multiple function clauses. Pattern matching can be used on the functions' parameters which then determines which function clause to invoke -- starting from the top of the file down until the first match. Variables may be bound to patterns.
+Pattern matching is also a useful tool when creating multiple function clauses. Pattern matching can be used on the functions' arguments which then determines which function clause to invoke -- starting from the top of the file down until the first match. Variables may be bound to patterns.
 
 ```elixir
 defmodule Example do

--- a/languages/elixir/exercises/concept/kitchen-calculator/.meta/design.md
+++ b/languages/elixir/exercises/concept/kitchen-calculator/.meta/design.md
@@ -6,7 +6,7 @@
 - Know that returning a tuple is a common for of multiple return in Elixir
 - Know how to extract an element from a tuple using `elem/2`
 - Know how to perform a basic pattern match using the `=/2` function
-- Know how to perform basic pattern matching on function parameters to guide which function to invoke
+- Know how to perform basic pattern matching on function arguments to guide which function to invoke
 
 ## Out of scope
 
@@ -21,7 +21,7 @@
 ## Concepts
 
 - `tuples` know of the existence of the `tuple` data type, how to define tuple literals, extract values from a tuple using `elem/2`
-- `pattern-matching` basic knowledge of pattern matching using `=/2` and on function parameters
+- `pattern-matching` basic knowledge of pattern matching using `=/2` and on function arguments
 
 ## Analyzer
 

--- a/languages/elixir/exercises/concept/language-list/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/language-list/.docs/instructions.md
@@ -2,7 +2,7 @@ In this exercise you need to implement some functions to manipulate a list of pr
 
 ## 1. Define a function to return an empty language list
 
-Define the `new/1` function that takes no parameters and returns an empty list.
+Define the `new/1` function that takes no arguments and returns an empty list.
 
 ```elixir
 LanguageList.new()
@@ -11,7 +11,7 @@ LanguageList.new()
 
 ## 2. Define a function to add a language to the list
 
-Define the `add/2` function that takes 2 parameters (a _language list_ and a string literal of a _language_). It should return the resulting list with the new language prepended to the given list.
+Define the `add/2` function that takes 2 arguments (a _language list_ and a string literal of a _language_). It should return the resulting list with the new language prepended to the given list.
 
 ```elixir
 LanguageList.new() |> LanguageList.add("Clojure")
@@ -20,7 +20,7 @@ LanguageList.new() |> LanguageList.add("Clojure")
 
 ## 3. Define a function to remove a language from the list
 
-Define the `remove/2` function that takes 1 parameter1 (a _language list_). It should return the list minus the first item.
+Define the `remove/2` function that takes 1 argument (a _language list_). It should return the list minus the first item.
 
 ```elixir
 LanguageList.new() |> LanguageList.add("Haskell") |> LanguageList.remove()
@@ -29,7 +29,7 @@ LanguageList.new() |> LanguageList.add("Haskell") |> LanguageList.remove()
 
 ## 4. Define a function to return the first item in the list
 
-Define the `first/1` function that takes 1 parameter (a _language list_). It should return the string literal of the language that occurs first in the list.
+Define the `first/1` function that takes 1 argument (a _language list_). It should return the string literal of the language that occurs first in the list.
 
 ```elixir
 LanguageList.new() |> LanguageList.add("Prolog") |> LanguageList.first()
@@ -38,7 +38,7 @@ LanguageList.new() |> LanguageList.add("Prolog") |> LanguageList.first()
 
 ## 5. Define a function to return how many languages are in the list
 
-Define the `count/1` function that takes 1 parameter (a _language list_). It should return the number of languages in the list.
+Define the `count/1` function that takes 1 argument (a _language list_). It should return the number of languages in the list.
 
 ```elixir
 LanguageList.new() |> LanguageList.add("Elm") |> LanguageList.first()
@@ -47,7 +47,7 @@ LanguageList.new() |> LanguageList.add("Elm") |> LanguageList.first()
 
 ## 6. Define a function to determine if the list is exciting
 
-Define the `exciting_list?/1` function which takes 1 parameter (a _language list_). It should return a boolean value. It should return true if _"Elixir"_ is one of the languages in the list.
+Define the `exciting_list?/1` function which takes 1 argument (a _language list_). It should return a boolean value. It should return true if _"Elixir"_ is one of the languages in the list.
 
 ```elixir
 LanguageList.new() |> LanguageList.add("Elixir") |> LanguageList.first()

--- a/languages/elixir/exercises/concept/lasagna/.docs/hints.md
+++ b/languages/elixir/exercises/concept/lasagna/.docs/hints.md
@@ -10,23 +10,23 @@
 
 ## 2. Calculate the remaining oven time in minutes
 
-- You need to define a [function][functions] with a single parameter.
+- You need to define a [function][functions] with a single argument.
 - You have to [implicitly return an integer][return] from a function.
-- The function's parameter is an [integer][integers].
+- The function's argument is an [integer][integers].
 - You can use the [mathematical operator for subtraction][operators] to subtract values.
 
 ## 3. Calculate the preparation time in minutes
 
-- You need to define a [function][functions] with a single parameter.
+- You need to define a [function][functions] with a single argument.
 - You have to [implicitly return an integer][return] from a function.
-- The function's parameter is an [integer][integers].
+- The function's argument is an [integer][integers].
 - You can use the [mathematical operator for multiplication][operators] to multiply values.
 
 ## 4. Calculate the total working time in minutes
 
-- You need to define a [function][functions] with two parameters.
+- You need to define a [function][functions] with two arguments.
 - You have to [implicitly return an integer][return] from a function.
-- The function's parameter is an [integer][integers].
+- The function's argument is an [integer][integers].
 - You can invoke one of the other functions you've defined previously.
 - You can use the [mathematical operator for addition][operators] to add values.
 

--- a/languages/elixir/exercises/concept/lasagna/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/lasagna/.docs/instructions.md
@@ -4,7 +4,7 @@ You have five tasks, all related to the time spent cooking the lasagna.
 
 ## 1. Define the expected oven time in minutes
 
-Define the `Lasagna.expected_minutes_in_oven/0` method that does not take any parameters and returns how many minutes the lasagna should be in the oven. According to the cooking book, the expected oven time in minutes is 40:
+Define the `Lasagna.expected_minutes_in_oven/0` method that does not take any arguments and returns how many minutes the lasagna should be in the oven. According to the cooking book, the expected oven time in minutes is 40:
 
 ```elixir
 Lasagna.expected_minutes_in_oven()
@@ -13,7 +13,7 @@ Lasagna.expected_minutes_in_oven()
 
 ## 2. Calculate the remaining oven time in minutes
 
-Define the `Lasagna.remaining_minutes_in_oven/1` method that takes the actual minutes the lasagna has been in the oven as a parameter and returns how many minutes the lasagna still has to remain in the oven, based on the expected oven time in minutes from the previous task.
+Define the `Lasagna.remaining_minutes_in_oven/1` method that takes the actual minutes the lasagna has been in the oven as a argument and returns how many minutes the lasagna still has to remain in the oven, based on the expected oven time in minutes from the previous task.
 
 ```elixir
 Lasagna.remaining_minutes_in_oven(30)
@@ -22,7 +22,7 @@ Lasagna.remaining_minutes_in_oven(30)
 
 ## 3. Calculate the preparation time in minutes
 
-Define the `Lasagna.preparation_time_in_minutes/1` method that takes the number of layers you added to the lasagna as a parameter and returns how many minutes you spent preparing the lasagna, assuming each layer takes you 2 minutes to prepare.
+Define the `Lasagna.preparation_time_in_minutes/1` method that takes the number of layers you added to the lasagna as a argument and returns how many minutes you spent preparing the lasagna, assuming each layer takes you 2 minutes to prepare.
 
 ```elixir
 Lasagna.preparation_time_in_minutes(2)
@@ -31,7 +31,7 @@ Lasagna.preparation_time_in_minutes(2)
 
 ## 4. Calculate the total working time in minutes
 
-Define the `Lasagna.total_time_in_minutes/2` method that takes two parameters: the first parameter is the number of layers you added to the lasagna, and the second parameter is the number of minutes the lasagna has been in the oven. The function should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
+Define the `Lasagna.total_time_in_minutes/2` method that takes two arguments: the first argument is the number of layers you added to the lasagna, and the second argument is the number of minutes the lasagna has been in the oven. The function should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
 
 ```elixir
 Lasagna.total_time_in_minutes(3, 20)
@@ -40,7 +40,7 @@ Lasagna.total_time_in_minutes(3, 20)
 
 ## 5. Create a notification that the lasagna is ready
 
-Define the `Lasagna.alarm/0` method that does not take any parameters and returns a message indicating that the lasagna is ready to eat.
+Define the `Lasagna.alarm/0` method that does not take any arguments and returns a message indicating that the lasagna is ready to eat.
 
 ```elixir
 Lasagna.alarm()

--- a/languages/elixir/exercises/concept/lasagna/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/lasagna/.docs/introduction.md
@@ -23,9 +23,9 @@ end
 
 ### Named functions
 
-_Named Functions_ must be defined in a module. Each function can have zero or more parameters. All parameters are dynamically-typed, and the return type is not explicitly declared, it is the type of the value returned. An _access modifier_ can be specified for functions, making only desired functions available for use external to the module. In a function, the value of the last line is _implicitly returned_ to the calling function.
+_Named Functions_ must be defined in a module. Each function can have zero or more arguments. All arguments are dynamically-typed, and the return type is not explicitly declared, it is the type of the value returned. An _access modifier_ can be specified for functions, making only desired functions available for use external to the module. In a function, the value of the last line is _implicitly returned_ to the calling function.
 
-Invoking a function is done by specifying its module- and function name and passing arguments for each of the function's parameters. The module name may be omitted if the function is invoked inside of the module.
+Invoking a function is done by specifying its module- and function name and passing arguments for each of the function's arguments. The module name may be omitted if the function is invoked inside of the module.
 
 You may also write short functions using a one-line syntax (note the comma `,` and the colon `:` around the keyword `do`).
 
@@ -46,10 +46,10 @@ sum = Calculator.short_add(2, 2)
 
 ### Arity of functions
 
-It is common to refer to functions with their _arity_. The _arity_ of a function is the number of parameters it accepts.
+It is common to refer to functions with their _arity_. The _arity_ of a function is the number of arguments it accepts.
 
 ```elixir
-# add/3 because this function has three parameters, thus an arity of 3
+# add/3 because this function has three arguments, thus an arity of 3
 def add(x, y, z) do
   x + y + z
 end

--- a/languages/elixir/exercises/concept/lasagna/.meta/design.md
+++ b/languages/elixir/exercises/concept/lasagna/.meta/design.md
@@ -21,7 +21,7 @@
 - Memory and performance characteristics.
 - Function overloads.
 - Anonymous functions.
-- Default parameters.
+- Default arguments.
 - Organizing functions in namespaces.
 - Visibility (`defp`).
 - Single-line functions

--- a/languages/elixir/exercises/concept/pacman-rules/.docs/hints.md
+++ b/languages/elixir/exercises/concept/pacman-rules/.docs/hints.md
@@ -1,6 +1,6 @@
 ## General
 
-Don't worry about how the parameters are derived, just focus on combining the parameters to return the intended result.
+Don't worry about how the arguments are derived, just focus on combining the arguments to return the intended result.
 
 ## 1. Define if pac-man can eat a ghost
 

--- a/languages/elixir/exercises/concept/pacman-rules/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/pacman-rules/.docs/instructions.md
@@ -2,11 +2,11 @@ In this exercise, you need to translate some rules from the classic game Pac-Man
 
 You have four rules to translate, all related to the game states.
 
-> Don't worry about how the parameters are derived, just focus on combining the parameters to return the intended result.
+> Don't worry about how the arguments are derived, just focus on combining the arguments to return the intended result.
 
 ## 1. Define if Pac-Man eats a ghost
 
-Define the `Rules.eat_ghost?/2` function that takes two parameters (_if Pac-Man has a power pellet active_ and _if Pac-Man is touching a ghost_) and returns a boolean value if Pac-Man is able to eat the ghost. The function should return true only if Pac-Man has a power pellet active and is touching a ghost.
+Define the `Rules.eat_ghost?/2` function that takes two arguments (_if Pac-Man has a power pellet active_ and _if Pac-Man is touching a ghost_) and returns a boolean value if Pac-Man is able to eat the ghost. The function should return true only if Pac-Man has a power pellet active and is touching a ghost.
 
 ```elixir
 Rules.eat_ghost?(false, true)
@@ -15,7 +15,7 @@ Rules.eat_ghost?(false, true)
 
 ## 2. Define if Pac-Man scores
 
-Define the `Rules.score?/2` function that takes two parameters (_if Pac-Man is touching a power pellet_ and _if Pac-Man is touching a dot_) and returns a boolean value if Pac-Man scored. The function should return true if Pac-Man is touching a power pellet or a dot.
+Define the `Rules.score?/2` function that takes two arguments (_if Pac-Man is touching a power pellet_ and _if Pac-Man is touching a dot_) and returns a boolean value if Pac-Man scored. The function should return true if Pac-Man is touching a power pellet or a dot.
 
 ```elixir
 Rules.score?(true, true)
@@ -24,7 +24,7 @@ Rules.score?(true, true)
 
 ## 3. Define if Pac-Man loses
 
-Define the `Rules.lose?/2` function that takes two parameters (_if Pac-Man has a power pellet active_ and _if Pac-Man is touching a ghost_) and returns a boolean value if Pac-Man loses. The function should return true if Pac-Man is touching a ghost and does not have a power pellet active.
+Define the `Rules.lose?/2` function that takes two arguments (_if Pac-Man has a power pellet active_ and _if Pac-Man is touching a ghost_) and returns a boolean value if Pac-Man loses. The function should return true if Pac-Man is touching a ghost and does not have a power pellet active.
 
 ```elixir
 Rules.lose?(false, true)
@@ -33,7 +33,7 @@ Rules.lose?(false, true)
 
 ## 4. Define if Pac-Man wins
 
-Define the `Rules.win?/3` function that takes three parameters (_if Pac-Man has eaten all of the dots_, _if Pac-Man has a power pellet active_, and _if Pac-Man is touching a ghost_) and returns a boolean value if Pac-Man wins. The function should return true if Pac-Man has eaten all of the dots and has not lost based on the parameters defined in part 3.
+Define the `Rules.win?/3` function that takes three arguments (_if Pac-Man has eaten all of the dots_, _if Pac-Man has a power pellet active_, and _if Pac-Man is touching a ghost_) and returns a boolean value if Pac-Man wins. The function should return true if Pac-Man has eaten all of the dots and has not lost based on the arguments defined in part 3.
 
 ```elixir
 Rules.win?(false, true, false)

--- a/languages/elixir/exercises/concept/pacman-rules/.meta/design.md
+++ b/languages/elixir/exercises/concept/pacman-rules/.meta/design.md
@@ -2,7 +2,7 @@
 
 - Know what a variable is.
 - Know how to define a named function.
-- Know how to define a function with parameters.
+- Know how to define a function with arguments.
 - Know how to return a value from a function.
 - Know what a boolean is.
 - Know how to use logical operators on booleans.
@@ -11,7 +11,7 @@
 
 ## Out of scope
 
-- Default parameters.
+- Default arguments.
 - Truthy logical comparisons using `&&/2`, `||/2`, `!/1`
 - Single-line functions
 - Booleans as special atoms

--- a/languages/elixir/exercises/concept/pacman-rules/lib/rules.ex
+++ b/languages/elixir/exercises/concept/pacman-rules/lib/rules.ex
@@ -1,17 +1,17 @@
 defmodule Rules do
   def eat_ghost?(power_pellet_active, touching_ghost) do
-    raise "Please implement the eat_ghost?/2  function"
+    raise "Please implement the eat_ghost?/2 function"
   end
 
   def score?(touching_power_pellet, touching_power_pellet) do
-    raise "Please implement the score?/2  function"
+    raise "Please implement the score?/2 function"
   end
 
   def lose?(power_pellet_active, touching_ghost) do
-    raise "Please implement the lose?/2  function"
+    raise "Please implement the lose?/2 function"
   end
 
   def win?(has_eaten_all_dots, power_pellet_active, touching_ghost) do
-    raise "Please implement the win?/3  function"
+    raise "Please implement the win?/3 function"
   end
 end

--- a/languages/elixir/exercises/concept/remote-control-car/lib/remote_control_car.ex
+++ b/languages/elixir/exercises/concept/remote-control-car/lib/remote_control_car.ex
@@ -1,23 +1,23 @@
 defmodule RemoteControlCar do
-  raise "Implement the struct with the specified fields"
+  raise "Please implement the struct with the specified fields"
 
   def new() do
-    raise "Implement new/0"
+    raise "Please implement the new/0 function"
   end
 
   def new(nickname) do
-    raise "Implement new/1"
+    raise "Please implement the new/1 function"
   end
 
   def display_distance(remote_car) do
-    raise "Implement display_distance/1"
+    raise "Please implement the display_distance/1 function"
   end
 
   def display_battery(remote_car) do
-    raise "Implement display_battery/1"
+    raise "Please implement the display_battery/1 function"
   end
 
   def drive(remote_car) do
-    raise "Implement drive/1"
+    raise "Please implement the drive/1 function"
   end
 end

--- a/languages/elixir/exercises/concept/rpg-character-sheet/lib/rpg/character_sheet.ex
+++ b/languages/elixir/exercises/concept/rpg-character-sheet/lib/rpg/character_sheet.ex
@@ -1,21 +1,21 @@
 defmodule RPG.CharacterSheet do
   def welcome() do
-    raise "Implement the welcome/0 function"
+    raise "Please implement the welcome/0 function"
   end
 
   def ask_name() do
-    raise "Implement the ask_name/0 function"
+    raise "Please implement the ask_name/0 function"
   end
 
   def ask_class() do
-    raise "Implement the ask_class/0 function"
+    raise "Please implement the ask_class/0 function"
   end
 
   def ask_level() do
-    raise "Implement the ask_level/0 function"
+    raise "Please implement the ask_level/0 function"
   end
 
   def run() do
-    raise "Implement the run/0 function"
+    raise "Please implement the run/0 function"
   end
 end

--- a/languages/elixir/exercises/concept/rpn-calculator/lib/rpn_calculator.ex
+++ b/languages/elixir/exercises/concept/rpn-calculator/lib/rpn_calculator.ex
@@ -1,13 +1,13 @@
 defmodule RPNCalculator do
   def calculate!(stack, operation) do
-    raise "Please implement calculate!/2"
+    raise "Please implement the calculate!/2 function"
   end
 
   def calculate(stack, operation) do
-    raise "Please implement calculate/2"
+    raise "Please implement the calculate/2 function"
   end
 
   def calculate_verbose(stack, operation) do
-    raise "Please implement calculate_verbose/2"
+    raise "Please implement the calculate_verbose/2 function"
   end
 end

--- a/languages/elixir/exercises/concept/secrets/.docs/hints.md
+++ b/languages/elixir/exercises/concept/secrets/.docs/hints.md
@@ -5,29 +5,29 @@
 
 ## 1. Create an adder
 
-- Return an anonymous function which adds the parameter from the anonymous function to the parameter passed in to `Secret.secret_add/1`
+- Return an anonymous function which adds the argument from the anonymous function to the argument passed in to `Secret.secret_add/1`
 
 ## 2. Create a subtractor
 
-- Return an anonymous function which subtracts the parameter passed in to `Secret.secret_subtract/1` from the parameter from the anonymous function.
+- Return an anonymous function which subtracts the argument passed in to `Secret.secret_subtract/1` from the argument from the anonymous function.
 
 ## 3. Create a multiplier
 
-- Return an anonymous function which multiplies the parameter from the anonymous function to the parameter passed in to `Secret.secret_multiply/1`
+- Return an anonymous function which multiplies the argument from the anonymous function to the argument passed in to `Secret.secret_multiply/1`
 
 ## 4. Create a divider
 
-- return an anonymous function which divides the parameter from the anonymous function by the parameter passed in to `Secret.secret_divide/1`
+- return an anonymous function which divides the argument from the anonymous function by the argument passed in to `Secret.secret_divide/1`
 - make use of [integer division][div]
 
 ## 5. Create an "and"-er
 
-- Return an anonymous function which performs a [bitwise _and_][bitwise-wiki] operation using the parameter passed in to the anonymous function and the parameter passed in to `Secret.secret_and/1`
+- Return an anonymous function which performs a [bitwise _and_][bitwise-wiki] operation using the argument passed in to the anonymous function and the argument passed in to `Secret.secret_and/1`
 - functions in the [Bitwise module][bitwise-hexdocs] may be of use.
 
 ## 6. Create an "xor"-er
 
-- Return an anonymous function which performs a [bitwise _xor_][bitwise-wiki] operation using the parameter passed in to the anonymous function and the parameter passed in to `Secret.secret_xor/1`
+- Return an anonymous function which performs a [bitwise _xor_][bitwise-wiki] operation using the argument passed in to the anonymous function and the argument passed in to `Secret.secret_xor/1`
 - functions in the [Bitwise module][bitwise-hexdocs] may be of use.
 
 ## 7. Create a function combiner

--- a/languages/elixir/exercises/concept/secrets/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/secrets/.docs/instructions.md
@@ -2,13 +2,13 @@ In this exercise, you've been tasked with writing the software for an encryption
 
 For each task, make use of a closure and return a function that can be invoked from the calling scope.
 
-All functions should expect integer parameters. Integers are also suitable for performing bitwise operations in Elixir.
+All functions should expect integer arguments. Integers are also suitable for performing bitwise operations in Elixir.
 
 You have seven tasks:
 
 ## 1. Create an adder
 
-Implement `Secrets.secret_add/1`, have it return a function which takes one parameter and adds it to the parameter passed in to `secret_add`.
+Implement `Secrets.secret_add/1`, have it return a function which takes one argument and adds it to the argument passed in to `secret_add`.
 
 ```elixir
 adder = Secrets.secret_add(2)
@@ -18,7 +18,7 @@ adder.(2)
 
 ## 2. Create a subtractor
 
-Implement `Secrets.secret_subtract/1`, have it return a function which takes one parameter and subtracts the parameter passed in to `secret_subtract`.
+Implement `Secrets.secret_subtract/1`, have it return a function which takes one argument and subtracts the argument passed in to `secret_subtract`.
 
 ```elixir
 subtractor = Secrets.secret_subtract(2)
@@ -28,7 +28,7 @@ subtractor.(3)
 
 ## 3. Create a multiplier
 
-Implement `Secrets.secret_multiply/1`, have it return a function which takes one parameter and multiplies it by the parameter passed in to `secret_multiply`.
+Implement `Secrets.secret_multiply/1`, have it return a function which takes one argument and multiplies it by the argument passed in to `secret_multiply`.
 
 ```elixir
 multiplier = Secrets.secret_multiply(7)
@@ -38,7 +38,7 @@ multiplier.(3)
 
 ## 4. Create a divider
 
-Implement `Secrets.secret_divide/1`, have it return a function which takes one parameter and divides it by the parameter passed in to `secret_divide`.
+Implement `Secrets.secret_divide/1`, have it return a function which takes one argument and divides it by the argument passed in to `secret_divide`.
 
 ```elixir
 divider = Secrets.secret_divide(3)
@@ -50,7 +50,7 @@ Make use of integer division.
 
 ## 5. Create a "and"-er
 
-Implement `Secrets.secret_and/1`, have it return a function which takes one parameter and performs a bitwise _and_ operation to the parameter passed in to `secret_and`.
+Implement `Secrets.secret_and/1`, have it return a function which takes one argument and performs a bitwise _and_ operation to the argument passed in to `secret_and`.
 
 ```elixir
 ander = Secrets.secret_and(1)
@@ -60,7 +60,7 @@ ander.(2)
 
 ## 6. Create a "xor"-er
 
-Implement `Secrets.secret_xor/1`, have it return a function which takes one parameter and performs a bitwise _xor_ operation to the parameter passed in to `secret_xor`.
+Implement `Secrets.secret_xor/1`, have it return a function which takes one argument and performs a bitwise _xor_ operation to the argument passed in to `secret_xor`.
 
 ```elixir
 xorer = Secrets.secret_xor(1)
@@ -70,7 +70,7 @@ xorer.(3)
 
 ## 7. Create a function combiner
 
-Implement `Secrets.secret_combine/2`, have it return a function which applies the functions parameter passed in to `secret_combine` in sequence.
+Implement `Secrets.secret_combine/2`, have it return a function which applies the functions argument passed in to `secret_combine` in sequence.
 
 ```elixir
 multiply = Secrets.secret_multiply(7)

--- a/languages/elixir/exercises/concept/secrets/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/secrets/.docs/introduction.md
@@ -13,9 +13,9 @@ We might use anonymous functions to:
 - Hide data using lexical scope (also known as a closure).
 - Dynamically create functions at run-time.
 
-Anonymous function start with the reserved word `fn`, the parameters are separated from the body of the function with the `->` token, and they are finished with an `end`. As with named functions, the last expression in the function is _implicitly returned_ to the calling function.
+Anonymous function start with the reserved word `fn`, the arguments are separated from the body of the function with the `->` token, and they are finished with an `end`. As with named functions, the last expression in the function is _implicitly returned_ to the calling function.
 
-To invoke a function reference, you must use a `.` between the reference variable and the list of parameters:
+To invoke a function reference, you must use a `.` between the reference variable and the list of arguments:
 
 ```elixir
 function_variable = fn param ->

--- a/languages/elixir/exercises/concept/secrets/lib/secrets.ex
+++ b/languages/elixir/exercises/concept/secrets/lib/secrets.ex
@@ -1,29 +1,29 @@
 defmodule Secrets do
   def secret_add(secret) do
-    raise "Please implement the secret_add/1 function."
+    raise "Please implement the secret_add/1 function"
   end
 
   def secret_subtract(secret) do
-    raise "Please implement the secret_subtract/1 function."
+    raise "Please implement the secret_subtract/1 function"
   end
 
   def secret_multiply(secret) do
-    raise "Please implement the secret_multiply/1 function."
+    raise "Please implement the secret_multiply/1 function"
   end
 
   def secret_divide(secret) do
-    raise "Please implement the secret_divide/1 function."
+    raise "Please implement the secret_divide/1 function"
   end
 
   def secret_and(secret) do
-    raise "Please implement the secret_and/1 function."
+    raise "Please implement the secret_and/1 function"
   end
 
   def secret_xor(secret) do
-    raise "Please implement the secret_xor/1 function."
+    raise "Please implement the secret_xor/1 function"
   end
 
   def secret_combine(secret_f, secret_g) do
-    raise "Please implement the secret_combine/2 function."
+    raise "Please implement the secret_combine/2 function"
   end
 end

--- a/languages/elixir/exercises/concept/stack-underflow/lib/rpn_calculator/exception.ex
+++ b/languages/elixir/exercises/concept/stack-underflow/lib/rpn_calculator/exception.ex
@@ -1,5 +1,5 @@
 defmodule RPNCalculator.Exception do
-  # Implement DivisonByZeroError here.
+  # Please implement DivisonByZeroError here.
 
-  # Implement StackUnderflowErrror here.
+  # Please implement StackUnderflowErrror here.
 end

--- a/languages/elixir/reference/README.md
+++ b/languages/elixir/reference/README.md
@@ -184,7 +184,7 @@ The initial breakdown of these concepts, including the ordering, is based on the
 - [Default arguments](../../../reference/concepts/default_arguments.md)
 - Capture Syntax
 - Guards and defguard
-- Parameters prefixed with `_`
+- Arguments prefixed with `_`
 - Local variables
 - Expression results
 - Recursion
@@ -281,7 +281,7 @@ The concept exercises use the following concepts:
 | `maps`                           | Introduction to the map data type.                                                                        |
 | `module-attributes-as-constants` | Introduction to using module attributes as constants.                                                     |
 | `multiple-clause-functions`      | Named function can be overloaded and each attempted to invoke until one succeeds.                         |
-| `pattern-matching`               | Basic knowledge of pattern matching using `=/2` and on function parameters.                               |
+| `pattern-matching`               | Basic knowledge of pattern matching using `=/2` and on function arguments.                                |
 | `recursion`                      | How to write basic recursive functions.                                                                   |
 | `regular-expressions`            | Basic regular expression patterns and the use of the `~r` sigil.                                          |
 | `strings`                        | How to do string processing, concatenation, interpolation, and multiline strings.                         |

--- a/languages/elixir/reference/exercise-concepts/word-count.md
+++ b/languages/elixir/reference/exercise-concepts/word-count.md
@@ -41,4 +41,4 @@ end
 - Higher order functions
   - updating the map is best achieved with `Enum.reduce/3`, which takes a function as an argument
 - Anonymous Functions
-  - anonymous functions can be used to supply function parameters
+  - anonymous functions can be used to supply function arguments


### PR DESCRIPTION
This PR is mostly an indulgence of my obsessive need to have everything consistent and procrastinating on writing concept exercises 👻. It does two things:

- Replaces the usage of the word "parameter" with "argument". In many other programming languages those are considered to be synonyms, but Elixir is pretty consistent about exclusively using the word "argument" to describe the data passed into functions. Normally I wouldn't care who uses which word, but we're trying to teach here and I think it might help some beginner programmers if we use the same wording as the docs and the error messages (e.g. ArgumentError) do.
- Updates the error message in boilerplate files to always follow the pattern "Please implement the foo/n function".