### PR TITLE
[rust] validate example.rs formatting

### DIFF
--- a/languages/rust/scripts/test_pr.sh
+++ b/languages/rust/scripts/test_pr.sh
@@ -60,6 +60,7 @@ function test_concept() {
     # that spells subshell
     if ! (
         set -e
+        cargo fmt -- --check
         cargo check
         cargo test
         cargo test -- --ignored


### PR DESCRIPTION
This asserts the example.rs file has been formatted using `cargo fmt`.
It avoids doing the change since `test_pr.sh` exists for our manual
benefit.
Next steps would be to codify this into a GitHub action.