### PR TITLE
[Elixir] Remove usage of `enum` (a later concept) from the `maps` exercise

### DIFF
--- a/languages/elixir/exercises/concept/high-score/.docs/hints.md
+++ b/languages/elixir/exercises/concept/high-score/.docs/hints.md
@@ -11,37 +11,30 @@
 ## 2. Add players to the high score map
 
 - The resulting map should be returned.
-- [Map module][map-module] contains functions useful for manipulating maps.
+- [Map module][map-module] contains functions useful for manipulating maps. [One of them][map-put] deletes a key from a map.
 
 ## 3. Remove players from the score map
 
 - The resulting map should be returned.
-- [Map module][map-module] contains functions useful for manipulating maps.
+- [Map module][map-module] contains functions useful for manipulating maps. [One of them][map-delete] puts a value in a map under a given key.
 
 ## 4. Reset a player's score
 
 - The resulting map should be returned with the player's score reset to an initial value.
-- [Map module][map-module] contains functions useful for manipulating maps.
+- [Map module][map-module] contains functions useful for manipulating maps. [One of them][map-put] puts a value in a map under a given key.
 
 ## 5. Update a player's score
 
 - The resulting map should be returned with the player's updated score.
-- [Map module][map-module] contains functions useful for manipulating maps.
+- [Map module][map-module] contains functions useful for manipulating maps. [One of them][map-update] updates a value in a map under a given key.
 
-## 6. Get a list of players with scores ordered by player name
+## 6. Get a list of players
 
-- [Enum module][enum] functions can be used on maps.
+- [Map module][map-module] contains functions useful for manipulating maps. [One of them][map-keys] returns a list of all keys in a map.
 
-## 7. Get a list of players ordered by player score in decreasing order
-
-- Maps make use of the [Enumerable][enum-protocol] protocol, so they can be used with [Enum module functions][enum].
-- Make sure the highest score is listed first in the ordered result.
-
-[default-arg]: https://elixir-lang.org/getting-started/modules-and-functions.html#default-arguments
-[enum]: https://hexdocs.pm/elixir/Enum.html
-[enum-protocol]: https://hexdocs.pm/elixir/Enumerable.html
-[integers]: https://elixir-lang.org/getting-started/basic-types.html
 [maps]: https://elixir-lang.org/getting-started/keywords-and-maps.html#maps
 [map-module]: https://hexdocs.pm/elixir/Map.html
-[named-function]: https://elixir-lang.org/getting-started/modules-and-functions.html#named-functions
-[strings]: https://elixir-lang.org/getting-started/basic-types.html#strings
+[map-put]: https://hexdocs.pm/elixir/Map.html#put/3
+[map-delete]: https://hexdocs.pm/elixir/Map.html#delete/2
+[map-update]: https://hexdocs.pm/elixir/Map.html#update/4
+[map-keys]: https://hexdocs.pm/elixir/Map.html#keys/1

--- a/languages/elixir/exercises/concept/high-score/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/high-score/.docs/instructions.md
@@ -77,26 +77,9 @@ score_map = HighScore.update_score(score_map, "José Valim", 5)
 # => %{"José Valim"=> 486_378}
 ```
 
-## 6. Get a list of players with scores ordered by player name
+## 6. Get a list of players
 
-To get a list of players ordered by name, define `HighScore.order_by_players/1`, which takes 1 argument:
-
-- The first argument is the map of scores.
-
-```elixir
-score_map = HighScore.new()
-# => %{}
-score_map = HighScore.add_player(score_map, "Dave Thomas", 2_374)
-# => %{"Dave Thomas" => 2_374}
-score_map = HighScore.add_player(score_map, "José Valim", 486_373)
-# => %{"Dave Thomas" => 2_374, "José Valim"=> 486_373}
-HighScore.order_by_players(score_map)
-# => [{"Dave Thomas", 2_374}, {"José Valim", 486_373}]
-```
-
-## 7. Get a list of players ordered by player score in decreasing order
-
-To get a list of players ordered by scores in decreasing order, define `HighScore.order_by_scores/1`, which takes 1 argument:
+To get a list of players, define `HighScore.get_players/1`, which takes 1 argument:
 
 - The first argument is the map of scores.
 
@@ -107,6 +90,6 @@ score_map = HighScore.add_player(score_map, "Dave Thomas", 2_374)
 # => %{"Dave Thomas" => 2_374}
 score_map = HighScore.add_player(score_map, "José Valim", 486_373)
 # => %{"Dave Thomas" => 2_374, "José Valim"=> 486_373}
-HighScore.order_by_scores(score_map)
-# => [{"José Valim", 486_373}, {"Dave Thomas", 2_374}]
+HighScore.get_players(score_map)
+# => ["Dave Thomas", "José Valim"]
 ```

--- a/languages/elixir/exercises/concept/high-score/.meta/example.ex
+++ b/languages/elixir/exercises/concept/high-score/.meta/example.ex
@@ -19,15 +19,7 @@ defmodule HighScore do
     Map.update(scores, name, score, &(&1 + score))
   end
 
-  def order_by_players(scores) do
-    scores
-    |> Map.to_list()
-    |> Enum.sort_by(&(&1 |> Kernel.elem(0) |> String.downcase()))
-  end
-
-  def order_by_scores(scores) do
-    scores
-    |> Map.to_list()
-    |> Enum.sort_by(&Kernel.elem(&1, 1), &>=/2)
+  def get_players(scores) do
+    Map.keys(scores)
   end
 end

--- a/languages/elixir/exercises/concept/high-score/lib/high_score.ex
+++ b/languages/elixir/exercises/concept/high-score/lib/high_score.ex
@@ -17,11 +17,7 @@ defmodule HighScore do
     raise "Please implement the reset_score/2 function"
   end
 
-  def order_by_players(scores) do
-    raise "Please implement the order_by_players/1 function"
-  end
-
-  def order_by_scores(scores) do
-    raise "Please implement the order_by_scores/1 function"
+  def get_players(scores) do
+    raise "Please implement the get_players/1 function"
   end
 end

--- a/languages/elixir/exercises/concept/high-score/test/high_score_test.exs
+++ b/languages/elixir/exercises/concept/high-score/test/high_score_test.exs
@@ -144,104 +144,43 @@ defmodule HighScoreTest do
     end
   end
 
-  describe "order_by_players/1" do
+  describe "get_players/1" do
     @tag :pending
     test "empty score map gives empty list" do
       scores_by_player =
         HighScore.new()
-        |> HighScore.order_by_players()
+        |> HighScore.get_players()
 
       assert scores_by_player == []
     end
 
     @tag :pending
     test "score map with one entry gives one result" do
-      scores_by_player =
+      players =
         HighScore.new()
         |> HighScore.add_player("José Valim")
         |> HighScore.update_score("José Valim", 486_373)
-        |> HighScore.order_by_players()
+        |> HighScore.get_players()
 
-      assert scores_by_player == [{"José Valim", 486_373}]
+      assert players == ["José Valim"]
     end
 
     @tag :pending
-    test "score map with two entries gives ordered result" do
-      scores_by_player =
-        HighScore.new()
-        |> HighScore.add_player("José Valim", 486_373)
-        |> HighScore.add_player("Dave Thomas", 2_374)
-        |> HighScore.order_by_players()
-
-      assert scores_by_player == [{"Dave Thomas", 2_374}, {"José Valim", 486_373}]
-    end
-
-    @tag :pending
-    test "score map with multiple entries gives ordered result" do
-      scores_by_player =
+    test "score map with multiple entries gives results in unknown order" do
+      players =
         HighScore.new()
         |> HighScore.add_player("José Valim", 486_373)
         |> HighScore.add_player("Dave Thomas", 2_374)
         |> HighScore.add_player("Chris McCord", 0)
         |> HighScore.add_player("Saša Jurić", 762)
-        |> HighScore.order_by_players()
+        |> HighScore.get_players()
+        |> Enum.sort()
 
-      assert scores_by_player == [
-               {"Chris McCord", 0},
-               {"Dave Thomas", 2_374},
-               {"José Valim", 486_373},
-               {"Saša Jurić", 762}
-             ]
-    end
-  end
-
-  describe "order_by_scores/1" do
-    @tag :pending
-    test "empty score map gives empty list" do
-      scores_by_player =
-        HighScore.new()
-        |> HighScore.order_by_scores()
-
-      assert scores_by_player == []
-    end
-
-    @tag :pending
-    test "score map with one entry gives one result" do
-      scores_by_player =
-        HighScore.new()
-        |> HighScore.add_player("José Valim")
-        |> HighScore.update_score("José Valim", 486_373)
-        |> HighScore.order_by_scores()
-
-      assert scores_by_player == [{"José Valim", 486_373}]
-    end
-
-    @tag :pending
-    test "score map with two entries gives ordered result" do
-      scores_by_player =
-        HighScore.new()
-        |> HighScore.add_player("José Valim", 486_373)
-        |> HighScore.add_player("Dave Thomas", 2_374)
-        |> HighScore.order_by_scores()
-
-      assert scores_by_player == [{"José Valim", 486_373}, {"Dave Thomas", 2_374}]
-    end
-
-    @tag :pending
-    test "score map with multiple entries gives ordered result" do
-      scores_by_player =
-        HighScore.new()
-        |> HighScore.add_player("José Valim", 486_373)
-        |> HighScore.add_player("Dave Thomas", 2_374)
-        |> HighScore.add_player("Chris McCord", 0)
-        |> HighScore.add_player("Saša Jurić", 762)
-        |> HighScore.order_by_scores()
-
-      assert scores_by_player == [
-               {"José Valim", 486_373},
-               {"Dave Thomas", 2_374},
-               {"Saša Jurić", 762},
-               {"Chris McCord", 0}
+      assert players == [
+               "Chris McCord",
+               "Dave Thomas",
+               "José Valim",
+               "Saša Jurić"
              ]
     end
   end


### PR DESCRIPTION
Issue: https://github.com/exercism/v3/issues/2513

I'm replacing the last two steps that used `Enum` with a single simple step that uses `Map.keys`.