### PR TITLE
[Elixir] Remove mention of string literals from lists

### DIFF
--- a/languages/elixir/concepts/lists/introduction.md
+++ b/languages/elixir/concepts/lists/introduction.md
@@ -4,7 +4,7 @@ Lists are built-in to the Elixir language. They are considered a basic type, den
 empty_list = []
 one_item_list = [1]
 two_item_list = [1, 2]
-multiple_type_list = [1, :pi, 3.14]
+multiple_type_list = [1, :pi, 3.14, "four"]
 ```
 
 Elixir implements lists as a linked list, where each node stores the reference to the next list. The first item in the list is referred to as the _head_ and the remaining list of items is called the _tail_. We can use this notation in code:
@@ -32,15 +32,5 @@ There are several Elixir Kernel functions for working with lists, e.g.
 ```elixir
 # Check if 1 is a member of the list
 1 in [1, 2, 3, 4]
-# => true
-```
-
-String literals are a sequence of characters surrounded by double quotes.
-
-```elixir
-string_variable = "this is a string! 1, 2, 3!"
-
-# Check if "c" is a member of the list
-"c" in ["a", "b", "c", "d"]
 # => true
 ```

--- a/languages/elixir/exercises/concept/language-list/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/language-list/.docs/introduction.md
@@ -36,13 +36,3 @@ There are several Elixir Kernel functions for working with lists, e.g.
 1 in [1, 2, 3, 4]
 # => true
 ```
-
-String literals are a sequence of characters surrounded by double quotes.
-
-```elixir
-string_variable = "this is a string! 1, 2, 3!"
-
-# Check if "c" is a member of the list
-"c" in ["a", "b", "c", "d"]
-# => true
-```


### PR DESCRIPTION
String literals were added to the `basics` (https://github.com/exercism/v3/commit/d9a84126c0e7aee415804d20d58d58fd1d31f915) concept so they don't need to be mentioned again for `lists`