### PR TITLE
[Elixir] Improve `language-list` instructions code snippets

### DIFF
--- a/languages/elixir/exercises/concept/language-list/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/language-list/.docs/instructions.md
@@ -14,25 +14,33 @@ LanguageList.new()
 Define the `add/2` function that takes 2 arguments (a _language list_ and a string literal of a _language_). It should return the resulting list with the new language prepended to the given list.
 
 ```elixir
-LanguageList.new() |> LanguageList.add("Clojure")
-# => ["Clojure"]
+LanguageList.new()
+|> LanguageList.add("Clojure")
+|> LanguageList.add("Haskell")
+# => ["Haskell", "Clojure"]
 ```
 
 ## 3. Define a function to remove a language from the list
 
-Define the `remove/2` function that takes 1 argument (a _language list_). It should return the list minus the first item.
+Define the `remove/2` function that takes 1 argument (a _language list_). It should return the list without the first item.
 
 ```elixir
-LanguageList.new() |> LanguageList.add("Haskell") |> LanguageList.remove()
-# => []
+LanguageList.new()
+|> LanguageList.add("Clojure")
+|> LanguageList.add("Haskell")
+|> LanguageList.remove()
+# => ["Clojure"]
 ```
 
 ## 4. Define a function to return the first item in the list
 
-Define the `first/1` function that takes 1 argument (a _language list_). It should return the string literal of the language that occurs first in the list.
+Define the `first/1` function that takes 1 argument (a _language list_). It should return the the first language in the list.
 
 ```elixir
-LanguageList.new() |> LanguageList.add("Prolog") |> LanguageList.first()
+LanguageList.new()
+|> LanguageList.add("Elm")
+|> LanguageList.add("Prolog")
+|> LanguageList.first()
 # => "Prolog"
 ```
 
@@ -41,8 +49,11 @@ LanguageList.new() |> LanguageList.add("Prolog") |> LanguageList.first()
 Define the `count/1` function that takes 1 argument (a _language list_). It should return the number of languages in the list.
 
 ```elixir
-LanguageList.new() |> LanguageList.add("Elm") |> LanguageList.first()
-# => 1
+LanguageList.new()
+|> LanguageList.add("Elm")
+|> LanguageList.add("Prolog")
+|> LanguageList.count()
+# => 2
 ```
 
 ## 6. Define a function to determine if the list is exciting
@@ -50,6 +61,8 @@ LanguageList.new() |> LanguageList.add("Elm") |> LanguageList.first()
 Define the `exciting_list?/1` function which takes 1 argument (a _language list_). It should return a boolean value. It should return true if _"Elixir"_ is one of the languages in the list.
 
 ```elixir
-LanguageList.new() |> LanguageList.add("Elixir") |> LanguageList.first()
+LanguageList.new()
+|> LanguageList.add("Elixir")
+|> LanguageList.exciting_list?()
 # => true
 ```


### PR DESCRIPTION
I noticed that the function names in the last two steps were incorrect, so I'm fixing that. I also split each function call into its own line so that it's easier to read on the website on a narrower screen, and I extended the code snippets a bit to better show that the languages are prepended to the list, not appended.