### PR TITLE
[Elixir] Improve exercise `kitchen-calculator`

### DIFF
--- a/languages/elixir/concepts/tuples/introduction.md
+++ b/languages/elixir/concepts/tuples/introduction.md
@@ -1,6 +1,6 @@
-In Elixir, a tuple is a data structure which organizes data, holding a fixed number of any-type items, but without explicit names for each element. Tuples are often used in Elixir for memory read-intensive operations, since read-access of an element is a constant-time operation. They are not usually used when elements may need to be added/removed dynamically because rather than modifying the existing tuple, a new tuple is created which requires memory to be allocated upfront.
+In Elixir, a tuple is a data structure which organizes data, holding a fixed number of items of any type, but without explicit names for each element. Tuples are often used in Elixir for memory read-intensive operations, since read-access of an element is a constant-time operation. They are not usually used when elements may need to be added/removed dynamically because rather than modifying the existing tuple, a new tuple is created which requires memory to be allocated upfront.
 
-In practice, tuples are created in Elixir using curly braces, and element can be individually accessed using the `elem/1` function using 0-based indexing:
+In practice, tuples are created in Elixir using curly braces. Elements in a tuple can be individually accessed using the `elem/1` function using 0-based indexing:
 
 ```elixir
 empty_tuple = {}

--- a/languages/elixir/exercises/concept/kitchen-calculator/.docs/hints.md
+++ b/languages/elixir/exercises/concept/kitchen-calculator/.docs/hints.md
@@ -1,7 +1,7 @@
 ## General
 
 - [Tuples][tuple-module] are data structures which are arranged in contiguous memory and can hold any data-type.
-- Atoms may be used to denote finite states, as this exercise uses `:cup`, `:fluid_ounce`, `:teaspoon`, `:tablespoon`, `:millilitre` to denote the units used.
+- Atoms may be used to denote finite states, as this exercise uses `:cup`, `:fluid_ounce`, `:teaspoon`, `:tablespoon`, `:milliliter` to denote the units used.
 - You may use `Kernel` or `Tuple` functions or pattern matching to manipulate to manipulate the tuples.
 
 ## 1. Get the numeric component from a volume-pair
@@ -9,15 +9,15 @@
 - Consider using a `Kernel` module function to return the volume-pair's numeric component.
 - Remember, one-line functions are best used for short Elixir functions.
 
-## 2. Convert the volume-pair to millilitres
+## 2. Convert the volume-pair to milliliters
 
 - Use [multiple clause functions][multi-clause] and [pattern matching][pattern-matching] to reduce conditional control flow logic.
-- Implement the function for all units to millilitres, including millilitres to millilitres.
+- Implement the function for all units to milliliters, including milliliters to milliliters.
 
-## 3. Convert the millilitre volume-pair to another unit
+## 3. Convert the milliliter volume-pair to another unit
 
 - Use multiple clause functions and pattern matching to reduce conditional control flow logic.
-- Implement the function for all units to millilitres, including millilitres to millilitres.
+- Implement the function for all units to milliliters, including milliliters to milliliters.
 
 ## 4. Convert from any unit to any unit
 

--- a/languages/elixir/exercises/concept/kitchen-calculator/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/kitchen-calculator/.docs/instructions.md
@@ -1,8 +1,8 @@
-While preparing to bake cookies for your friends, you have found that you have to convert some of the ingredients used in the recipe for your friends. Being only familiar with the metric system, you need to come up with a way to convert common US baking measurements to millilitres (mL) for your own ease.
+While preparing to bake cookies for your friends, you have found that you have to convert some of the ingredients used in the recipe for your friends. Being only familiar with the metric system, you need to come up with a way to convert common US baking measurements to milliliters (mL) for your own ease.
 
 Use this conversion chart for your solution:
 
-| Unit to convert | volume | in millilitres (mL) |
+| Unit to convert | volume | in milliliters (mL) |
 | --------------- | ------ | ------------------- |
 | mL              | 1      | 1                   |
 | US cup          | 1      | 240                 |
@@ -10,7 +10,7 @@ Use this conversion chart for your solution:
 | US teaspoon     | 1      | 5                   |
 | US tablespoon   | 1      | 15                  |
 
-Being a talented programmer in training, you decide to use millilitres as a transition unit to facilitate the conversion from any unit listed to any other (even itself)
+Being a talented programmer in training, you decide to use milliliters as a transition unit to facilitate the conversion from any unit listed to any other (even itself)
 
 ## 1. Get the numeric component from a volume-pair
 
@@ -21,27 +21,27 @@ KitchenCalculator.get_volume({:cup, 2.0})
 # => 2.0
 ```
 
-## 2. Convert the volume-pair to millilitres
+## 2. Convert the volume-pair to milliliters
 
-- Given a volume-pair tuple, `{:cup, 2.5}`, convert the volume to millilitres using the conversion chart.
+- Given a volume-pair tuple, `{:cup, 2.5}`, convert the volume to milliliters using the conversion chart.
 
 - use multiple function clauses and pattern matching to create the functions for each unit
-  - the atoms used to denote each unit are: `:cup`, `:fluid_ounce`, `:teaspoon`, `:tablespoon`, `:millilitre`
+  - the atoms used to denote each unit are: `:cup`, `:fluid_ounce`, `:teaspoon`, `:tablespoon`, `:milliliter`
 - return the conversion wrapped in a tuple
 
 ```elixir
-KitchenCalculator.to_millilitre({:cup, 2.5})
-# => {:millilitre, 600.0}
+KitchenCalculator.to_milliliter({:cup, 2.5})
+# => {:milliliter, 600.0}
 ```
 
-## 3. Convert the millilitre volume-pair to another unit
+## 3. Convert the milliliter volume-pair to another unit
 
-- Given a volume-pair tuple, `{:millilitre, 1320.0}`, and the desired unit, `:cup`, convert the volume to the desired unit using the conversion chart.
+- Given a volume-pair tuple, `{:milliliter, 1320.0}`, and the desired unit, `:cup`, convert the volume to the desired unit using the conversion chart.
 - use multiple function clauses and pattern matching to create the functions for each unit
-  - the atoms used to denote each unit are: `:cup`, `:fluid_ounce`, `:teaspoon`, `:tablespoon`, `:millilitre`
+  - the atoms used to denote each unit are: `:cup`, `:fluid_ounce`, `:teaspoon`, `:tablespoon`, `:milliliter`
 
 ```elixir
-KitchenCalculator.from_millilitre({:millilitre, 1320.0}, :cup)
+KitchenCalculator.from_milliliter({:milliliter, 1320.0}, :cup)
 # => {:cup, 5.5}
 ```
 

--- a/languages/elixir/exercises/concept/kitchen-calculator/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/kitchen-calculator/.docs/instructions.md
@@ -14,7 +14,7 @@ Being a talented programmer in training, you decide to use milliliters as a tran
 
 ## 1. Get the numeric component from a volume-pair
 
-- Given a volume-pair tuple, `{:cup, 2.0}`, return just the numeric component.
+Implement the `KitchenCalculator.get_volume/1` function. Given a volume-pair tuple, it should return just the numeric component.
 
 ```elixir
 KitchenCalculator.get_volume({:cup, 2.0})
@@ -23,11 +23,9 @@ KitchenCalculator.get_volume({:cup, 2.0})
 
 ## 2. Convert the volume-pair to milliliters
 
-- Given a volume-pair tuple, `{:cup, 2.5}`, convert the volume to milliliters using the conversion chart.
+Implement the `KitchenCalculator.to_milliliter/1` function. Given a volume-pair tuple, it should convert the volume to milliliters using the conversion chart.
 
-- use multiple function clauses and pattern matching to create the functions for each unit
-  - the atoms used to denote each unit are: `:cup`, `:fluid_ounce`, `:teaspoon`, `:tablespoon`, `:milliliter`
-- return the conversion wrapped in a tuple
+Use multiple function clauses and pattern matching to create the functions for each unit. The atoms used to denote each unit are: `:cup`, `:fluid_ounce`, `:teaspoon`, `:tablespoon`, `:milliliter`. Return the result of the conversion wrapped in a tuple.
 
 ```elixir
 KitchenCalculator.to_milliliter({:cup, 2.5})
@@ -36,9 +34,9 @@ KitchenCalculator.to_milliliter({:cup, 2.5})
 
 ## 3. Convert the milliliter volume-pair to another unit
 
-- Given a volume-pair tuple, `{:milliliter, 1320.0}`, and the desired unit, `:cup`, convert the volume to the desired unit using the conversion chart.
-- use multiple function clauses and pattern matching to create the functions for each unit
-  - the atoms used to denote each unit are: `:cup`, `:fluid_ounce`, `:teaspoon`, `:tablespoon`, `:milliliter`
+Implement the `KitchenCalculator.from_milliliter/2` function. Given a volume-pair tuple and the desired unit, it should convert the volume to the desired unit using the conversion chart.
+
+Use multiple function clauses and pattern matching to create the functions for each unit. The atoms used to denote each unit are: `:cup`, `:fluid_ounce`, `:teaspoon`, `:tablespoon`, `:milliliter`
 
 ```elixir
 KitchenCalculator.from_milliliter({:milliliter, 1320.0}, :cup)
@@ -47,7 +45,7 @@ KitchenCalculator.from_milliliter({:milliliter, 1320.0}, :cup)
 
 ## 4. Convert from any unit to any unit
 
-- Given a volume-pair tuple, `{:teaspoons, 9.0}`, and the desired unit, `:tablespoon`, convert the volume to the desired unit
+Implement the `KitchenCalculator.convert/2` function. Given a volume-pair tuple and the desired unit, it should convert the given volume to the desired unit.
 
 ```elixir
 KitchenCalculator.convert({:teaspoons, 9.0}, :tablespoon)

--- a/languages/elixir/exercises/concept/kitchen-calculator/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/kitchen-calculator/.docs/introduction.md
@@ -1,8 +1,8 @@
 ## tuples
 
-In Elixir, a tuple is a data structure which organizes data, holding a fixed number of any-type items, but without explicit names for each element. Tuples are often used in Elixir for memory read-intensive operations, since read-access of an element is a constant-time operation. They are not usually used when elements may need to be added/removed dynamically because rather than modifying the existing tuple, a new tuple is created which requires memory to be allocated upfront.
+In Elixir, a tuple is a data structure which organizes data, holding a fixed number of items of any type, but without explicit names for each element. Tuples are often used in Elixir for memory read-intensive operations, since read-access of an element is a constant-time operation. They are not usually used when elements may need to be added/removed dynamically because rather than modifying the existing tuple, a new tuple is created which requires memory to be allocated upfront.
 
-In practice, tuples are created in Elixir using curly braces, and element can be individually accessed using the `elem/1` function using 0-based indexing:
+In practice, tuples are created in Elixir using curly braces. Elements in a tuple can be individually accessed using the `elem/1` function using 0-based indexing:
 
 ```elixir
 empty_tuple = {}

--- a/languages/elixir/exercises/concept/kitchen-calculator/.meta/example.ex
+++ b/languages/elixir/exercises/concept/kitchen-calculator/.meta/example.ex
@@ -1,9 +1,5 @@
 defmodule KitchenCalculator do
-  # Get the number component from the volume-unit pair '{:unit, volume}'
-
   def get_volume(volume_pair), do: elem(volume_pair, 1)
-
-  # Convert to milliliter to another unit
 
   def to_milliliter({:cup, cups}) do
     {:milliliter, cups * 240}
@@ -25,8 +21,6 @@ defmodule KitchenCalculator do
     volume
   end
 
-  # Convert from milliliter to another unit
-
   def from_milliliter({:milliliter, mls}, :cup) do
     {:cup, mls / 240}
   end
@@ -46,8 +40,6 @@ defmodule KitchenCalculator do
   def from_milliliter({:milliliter, _} = volume, :milliliter) do
     volume
   end
-
-  # convert from a supported unit to a supported unit
 
   def convert(volume_pair, to) do
     to_milliliter(volume_pair) |> from_milliliter(to)

--- a/languages/elixir/exercises/concept/kitchen-calculator/.meta/example.ex
+++ b/languages/elixir/exercises/concept/kitchen-calculator/.meta/example.ex
@@ -3,53 +3,53 @@ defmodule KitchenCalculator do
 
   def get_volume(volume_pair), do: elem(volume_pair, 1)
 
-  # Convert to millilitre to another unit
+  # Convert to milliliter to another unit
 
-  def to_millilitre({:cup, cups}) do
-    {:millilitre, cups * 240}
+  def to_milliliter({:cup, cups}) do
+    {:milliliter, cups * 240}
   end
 
-  def to_millilitre({:fluid_ounce, floz}) do
-    {:millilitre, floz * 30}
+  def to_milliliter({:fluid_ounce, floz}) do
+    {:milliliter, floz * 30}
   end
 
-  def to_millilitre({:teaspoon, teaspoons}) do
-    {:millilitre, teaspoons * 5}
+  def to_milliliter({:teaspoon, teaspoons}) do
+    {:milliliter, teaspoons * 5}
   end
 
-  def to_millilitre({:tablespoon, tablespoons}) do
-    {:millilitre, tablespoons * 15}
+  def to_milliliter({:tablespoon, tablespoons}) do
+    {:milliliter, tablespoons * 15}
   end
 
-  def to_millilitre({:millilitre, _} = volume) do
+  def to_milliliter({:milliliter, _} = volume) do
     volume
   end
 
-  # Convert from millilitre to another unit
+  # Convert from milliliter to another unit
 
-  def from_millilitre({:millilitre, mls}, :cup) do
+  def from_milliliter({:milliliter, mls}, :cup) do
     {:cup, mls / 240}
   end
 
-  def from_millilitre({:millilitre, mls}, :fluid_ounce) do
+  def from_milliliter({:milliliter, mls}, :fluid_ounce) do
     {:fluid_ounce, mls / 30}
   end
 
-  def from_millilitre({:millilitre, mls}, :teaspoon) do
+  def from_milliliter({:milliliter, mls}, :teaspoon) do
     {:teaspoon, mls / 5}
   end
 
-  def from_millilitre({:millilitre, mls}, :tablespoon) do
+  def from_milliliter({:milliliter, mls}, :tablespoon) do
     {:tablespoon, mls / 15}
   end
 
-  def from_millilitre({:millilitre, _} = volume, :millilitre) do
+  def from_milliliter({:milliliter, _} = volume, :milliliter) do
     volume
   end
 
   # convert from a supported unit to a supported unit
 
   def convert(volume_pair, to) do
-    to_millilitre(volume_pair) |> from_millilitre(to)
+    to_milliliter(volume_pair) |> from_milliliter(to)
   end
 end

--- a/languages/elixir/exercises/concept/kitchen-calculator/lib/kitchen_calculator.ex
+++ b/languages/elixir/exercises/concept/kitchen-calculator/lib/kitchen_calculator.ex
@@ -1,22 +1,16 @@
 defmodule KitchenCalculator do
 
-  # Get the number component from the volume-unit pair '{:unit, volume}'
-
-  def get_volume(volume_pair), do: raise "Please implement the get_volume/1 function"
-
-  # Convert to milliliter to another unit
+  def get_volume(volume_pair) do
+    raise "Please implement the get_volume/1 function"
+  end
 
   def to_milliliter(volume_pair) do
     raise "Please implement the to_milliliter/1 functions"
   end
 
-  # Convert from milliliter to another unit
-
   def from_milliliter(volume_pair, unit) do
     raise "Please implement the from_milliliter/2 functions"
   end
-
-  # convert from a supported unit to a supported unit
 
   def convert(volume_pair, unit) do
     raise "Please implement the convert/2 function"

--- a/languages/elixir/exercises/concept/kitchen-calculator/lib/kitchen_calculator.ex
+++ b/languages/elixir/exercises/concept/kitchen-calculator/lib/kitchen_calculator.ex
@@ -4,16 +4,16 @@ defmodule KitchenCalculator do
 
   def get_volume(volume_pair), do: raise "Please implement the get_volume/1 function"
 
-  # Convert to millilitre to another unit
+  # Convert to milliliter to another unit
 
-  def to_millilitre(volume_pair) do
-    raise "Please implement the to_millilitre/1 functions"
+  def to_milliliter(volume_pair) do
+    raise "Please implement the to_milliliter/1 functions"
   end
 
-  # Convert from millilitre to another unit
+  # Convert from milliliter to another unit
 
-  def from_millilitre(volume_pair, unit) do
-    raise "Please implement the from_millilitre/2 functions"
+  def from_milliliter(volume_pair, unit) do
+    raise "Please implement the from_milliliter/2 functions"
   end
 
   # convert from a supported unit to a supported unit

--- a/languages/elixir/exercises/concept/kitchen-calculator/test/kitchen_calculator_test.exs
+++ b/languages/elixir/exercises/concept/kitchen-calculator/test/kitchen_calculator_test.exs
@@ -23,64 +23,64 @@ defmodule KitchenCalculatorTest do
     end
 
     @tag :pending
-    test "get millilitres" do
-      assert KitchenCalculator.get_volume({:millilitre, 5}) == 5
+    test "get milliliters" do
+      assert KitchenCalculator.get_volume({:milliliter, 5}) == 5
     end
   end
 
-  describe "convert to millilitres from" do
+  describe "convert to milliliters from" do
     @tag :pending
-    test "millilitres" do
-      assert KitchenCalculator.to_millilitre({:millilitre, 3}) == {:millilitre, 3}
+    test "milliliters" do
+      assert KitchenCalculator.to_milliliter({:milliliter, 3}) == {:milliliter, 3}
     end
 
     @tag :pending
     test "cups" do
-      assert KitchenCalculator.to_millilitre({:cup, 3}) == {:millilitre, 720}
+      assert KitchenCalculator.to_milliliter({:cup, 3}) == {:milliliter, 720}
     end
 
     @tag :pending
     test "fluid ounces" do
-      assert KitchenCalculator.to_millilitre({:fluid_ounce, 100}) == {:millilitre, 3000}
+      assert KitchenCalculator.to_milliliter({:fluid_ounce, 100}) == {:milliliter, 3000}
     end
 
     @tag :pending
     test "teaspoon" do
-      assert KitchenCalculator.to_millilitre({:teaspoon, 3}) == {:millilitre, 15}
+      assert KitchenCalculator.to_milliliter({:teaspoon, 3}) == {:milliliter, 15}
     end
 
     @tag :pending
     test "tablespoon" do
-      assert KitchenCalculator.to_millilitre({:tablespoon, 3}) == {:millilitre, 45}
+      assert KitchenCalculator.to_milliliter({:tablespoon, 3}) == {:milliliter, 45}
     end
   end
 
-  describe "convert from millilitres to" do
+  describe "convert from milliliters to" do
     @tag :pending
-    test "millilitres" do
-      assert KitchenCalculator.from_millilitre({:millilitre, 4}, :millilitre) == {:millilitre, 4}
+    test "milliliters" do
+      assert KitchenCalculator.from_milliliter({:milliliter, 4}, :milliliter) == {:milliliter, 4}
     end
 
     @tag :pending
     test "cups" do
-      assert KitchenCalculator.from_millilitre({:millilitre, 840}, :cup) == {:cup, 3.5}
+      assert KitchenCalculator.from_milliliter({:milliliter, 840}, :cup) == {:cup, 3.5}
     end
 
     @tag :pending
     test "fluid ounces" do
-      assert KitchenCalculator.from_millilitre({:millilitre, 4522.5}, :fluid_ounce) ==
+      assert KitchenCalculator.from_milliliter({:milliliter, 4522.5}, :fluid_ounce) ==
                {:fluid_ounce, 150.75}
     end
 
     @tag :pending
     test "teaspoon" do
-      assert KitchenCalculator.from_millilitre({:millilitre, 61.25}, :teaspoon) ==
+      assert KitchenCalculator.from_milliliter({:milliliter, 61.25}, :teaspoon) ==
                {:teaspoon, 12.25}
     end
 
     @tag :pending
     test "tablespoon" do
-      assert KitchenCalculator.from_millilitre({:millilitre, 71.25}, :tablespoon) ==
+      assert KitchenCalculator.from_milliliter({:milliliter, 71.25}, :tablespoon) ==
                {:tablespoon, 4.75}
     end
   end


### PR DESCRIPTION
According to https://github.com/exercism/v3/blob/9f44de6bda78086709ce345e3b5b12dd7c8b5a49/docs/maintainers/style-guide.md#language all content needs to be AmE, so I changed "millilitre" to "milliliter". I also rephrased the instructions not to use lists (to be consistent with instructions for other exercises), and I removed examples of input values from the paragraphs because examples belong in code snippets.