### PR TITLE
[Elixir] Extend the `basics` concept to mention the standard library

### DIFF
--- a/languages/elixir/concepts/basics/about.md
+++ b/languages/elixir/concepts/basics/about.md
@@ -55,6 +55,15 @@
 string = "this is a string! 1, 2, 3!"
 ```
 
+### Standard library
+
+- The documentation is available online at [hexdocs.pm/elixir][docs].
+- Most built-in data types have a corresponding module, e.g. `Integer`, `Float`, `String`, `Tuple`, `List`.
+- The `Kernel` module is a special module.
+  - Provides the basic capabilities on top of which the rest of the standard library is built.
+  - Automatically imported.
+  - Its functions can be used without the `Kernel.` prefix.
+
 ## Documentation
 
 - Elixir provides 3 ways to write [inline documentation][inline-documentation].
@@ -91,3 +100,4 @@ string = "this is a string! 1, 2, 3!"
 [defp]: https://hexdocs.pm/elixir/Kernel.html#defp/2
 [defmodule]: https://hexdocs.pm/elixir/Kernel.html#defmodule/2
 [string]: https://elixir-lang.org/getting-started/basic-types.html#strings
+[docs]: https://hexdocs.pm/elixir/Kernel.html#content

--- a/languages/elixir/concepts/basics/introduction.md
+++ b/languages/elixir/concepts/basics/introduction.md
@@ -53,6 +53,14 @@ def add(x, y, z) do
 end
 ```
 
+### Standard library
+
+Elixir has a very rich and well-documented standard library. The documentation is available online at [hexdocs.pm/elixir][docs]. Save this link somewhere - you will use it a lot!
+
+Most built-in data types have a corresponding module that offers functions for working with that data type, e.g. there's the `Integer` module for integers, `String` module for strings, `List` module for lists and so on.
+
+A notable module is the `Kernel` module. It provides the basic capabilities on top of which the rest of the standard library is built, like arithmetic operators, control-flow macros, and much more. Functions for the `Kernel` module are automatically imported, so you can use them without the `Kernel.` prefix.
+
 ### Documentation
 
 Documentation is a priority in high-quality Elixir code bases, and there are 3 ways to write inline documentation:
@@ -62,3 +70,4 @@ Documentation is a priority in high-quality Elixir code bases, and there are 3 w
 - Module-level documentation uses the `@moduledoc` annotation following the module definition
 
 [functional-programming]: https://en.wikipedia.org/wiki/Functional_programming
+[docs]: https://hexdocs.pm/elixir/Kernel.html#content

--- a/languages/elixir/concepts/basics/links.json
+++ b/languages/elixir/concepts/basics/links.json
@@ -10,5 +10,9 @@
   {
     "url": "https://elixirschool.com/en/lessons/basics/basics/",
     "description": "Basics - Elixir School"
+  },
+  {
+    "url": "https://hexdocs.pm/elixir/Kernel.html#module-the-standard-library",
+    "description": "Overview of the standard library"
   }
 ]

--- a/languages/elixir/exercises/concept/lasagna/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/lasagna/.docs/introduction.md
@@ -55,6 +55,14 @@ def add(x, y, z) do
 end
 ```
 
+### Standard library
+
+Elixir has a very rich and well-documented standard library. The documentation is available online at [hexdocs.pm/elixir][docs]. Save this link somewhere - you will use it a lot!
+
+Most built-in data types have a corresponding module that offers functions for working with that data type, e.g. there's the `Integer` module for integers, `String` module for strings, `List` module for lists and so on.
+
+A notable module is the `Kernel` module. It provides the basic capabilities on top of which the rest of the standard library is built, like arithmetic operators, control-flow macros, and much more. Functions for the `Kernel` module are automatically imported, so you can use them without the `Kernel.` prefix.
+
 ### Documentation
 
 Documentation is a priority in high-quality Elixir code bases, and there are 3 ways to write inline documentation:
@@ -64,3 +72,4 @@ Documentation is a priority in high-quality Elixir code bases, and there are 3 w
 - Module-level documentation uses the `@moduledoc` annotation following the module definition
 
 [functional-programming]: https://en.wikipedia.org/wiki/Functional_programming
+[docs]: https://hexdocs.pm/elixir/Kernel.html#content


### PR DESCRIPTION
As I was going through our track on exercism.lol trying to feel like a student, I kept thinking that all of the hints and explanations link to the documentation and mention the Kernel module without any introduction first what that actually is.

To solve this issue, I extended the `basics` concept to shortly explain the standard library.