### PR TITLE
[Elixir] Improve exerecise `stack underflow`

### DIFF
--- a/languages/elixir/concepts/access-behaviour/about.md
+++ b/languages/elixir/concepts/access-behaviour/about.md
@@ -1,10 +1,10 @@
-Elixir uses [_Behaviours_][behaviours] to provide common generic interfaces while facilitating specific implementations for each module which implements the behavior. One of those behaviours is the _Access Behaviour_.
+Elixir uses [_Behaviours_][behaviours] to provide common generic interfaces while facilitating specific implementations for each module which implements the behaviour. One of those behaviours is the _Access Behaviour_.
 
 The _Access Behaviour_ provides a common interface for retrieving key-based data from a data structure. It is implemented for maps and keyword lists.
 
 The [`Access`][access] module defines the callbacks required for the interface. The [`Map`][map] and [`Keyword`][keyword] modules then implements the required callbacks [`fetch/2`][map-fetch], [`get_and_update/3`][map-get-and-update], and [`pop/2`][map-pop]
 
-To use the behavior, you may follow a bound variable with _square brackets_ and then use the key to retrieve the value associated with that key. Maps support atom and string keys, while keyword lists only atom keys.
+To use the behaviour, you may follow a bound variable with _square brackets_ and then use the key to retrieve the value associated with that key. Maps support atom and string keys, while keyword lists only atom keys.
 
 ```elixir
 my_map = %{key: "my value"}
@@ -24,7 +24,7 @@ Structs do not implement the Access behaviour.
 
 ## Access shortcuts
 
-- [`Kernel`][kernel] provides several functions which make using nested data easier with the access behavior. See these links to the library documentation:
+- [`Kernel`][kernel] provides several functions which make using nested data easier with the access behaviour. See these links to the library documentation:
   - [`get_in/2`][get-in-2]
   - [`get_and_update_in/2`][get-and-update-in-2]
   - [`get_and_update_in/3`][get-and-update-in-3]

--- a/languages/elixir/concepts/access-behaviour/introduction.md
+++ b/languages/elixir/concepts/access-behaviour/introduction.md
@@ -7,7 +7,7 @@ The _Access Behaviour_ provides a common interface for retrieving data from a ke
 my_map = %{key: "my value"}
 your_map = %{"key" => "your value"}
 
-# Obtain the value using the Access Behavior
+# Obtain the value using the Access Behaviour
 my_map[:key] == "my value"
 your_map[:key] == nil
 ```

--- a/languages/elixir/concepts/exceptions/introduction.md
+++ b/languages/elixir/concepts/exceptions/introduction.md
@@ -1,4 +1,4 @@
-All errors in Elixir implement the _Exception Behaviour_. Just like the _Access Behaviour_, the _Exception Behavior_ defines callback functions that a module must implement to fulfill the software contract of the behaviour. Once an errors is defined, it has the following properties:
+All errors in Elixir implement the _Exception Behaviour_. Just like the _Access Behaviour_, the _Exception Behaviour_ defines callback functions that a module must implement to fulfill the software contract of the behaviour. Once an errors is defined, it has the following properties:
 
 - The module's name defines the error's name.
 - The module defines an error-struct.

--- a/languages/elixir/concepts/exceptions/introduction.md
+++ b/languages/elixir/concepts/exceptions/introduction.md
@@ -1,15 +1,15 @@
-All errors in Elixir implement the _Exception Behaviour_. Just like the _Access Behaviour_, the _Exception Behaviour_ defines callback functions that a module must implement to fulfill the software contract of the behaviour. Once an errors is defined, it has the following properties:
+All errors in Elixir implement the _Exception Behaviour_. Just like the _Access Behaviour_, the _Exception Behaviour_ defines callback functions that a module must implement to fulfill the software contract of the behaviour. Once an error is defined, it has the following properties:
 
 - The module's name defines the error's name.
 - The module defines an error-struct.
-- The module will have a `:message` field.
+- The struct will have a `:message` field.
 - The module can be be used with `raise/1` and `raise/2` to raise the intended error
 
-The _Exception Behaviour_ also specifies two callbacks: `message/1` and `exception/1`. If unimplemented, default implementations will be used. `message/1` transforms the error-struct to a readable message when called by `raise/_`. `exception/1` allows additional context to be added to the message when it is called with `raise/2`
+The _Exception Behaviour_ also specifies two callbacks: `message/1` and `exception/1`. If unimplemented, default implementations will be used. `message/1` transforms the error-struct to a readable message when called with `raise`. `exception/1` allows additional context to be added to the message when it is called with `raise/2`
 
 ### Defining an exception
 
-To define an exception from an error module, we use the `defexception` macro function:
+To define an exception from an error module, we use the `defexception` macro:
 
 ```elixir
 # Defines a minimal error, with the name `MyError`

--- a/languages/elixir/concepts/structs/about.md
+++ b/languages/elixir/concepts/structs/about.md
@@ -19,7 +19,7 @@ plane = %Plane{}
 ## Accessing fields and updating
 
 - Most functions that work with [maps][maps] will also work with structs.
-  - The [_Access Behavior_][access-behavior] is an exception and is **not** implemented for structs.
+  - The [_Access Behaviour_][access-behaviour] is an exception and is **not** implemented for structs.
 - It is recommended to use the _static access operator_ `.` to access struct fields.
 
 - Get/fetch field values:
@@ -57,7 +57,7 @@ end
 ```
 
 [atom]: https://elixir-lang.org/getting-started/basic-types.html#atoms
-[access-behavior]: https://hexdocs.pm/elixir/Access.html#content
+[access-behaviour]: https://hexdocs.pm/elixir/Access.html#content
 [attribute]: https://elixir-lang.org/getting-started/module-attributes.html
 [maps]: https://hexdocs.pm/elixir/Map.html#content
 [getting-started]: https://elixir-lang.org/getting-started/structs.html

--- a/languages/elixir/concepts/structs/introduction.md
+++ b/languages/elixir/concepts/structs/introduction.md
@@ -11,7 +11,7 @@ plane = %Plane{}
 
 ### Accessing fields and updating
 
-Since structs are built on maps, we can use most map functions to get and manipulate values. The _Access Behavior_ is **not** implemented for structs. It is recommended to use the _static access operator_ `.` to access struct fields instead.
+Since structs are built on maps, we can use most map functions to get and manipulate values. The _Access Behaviour_ is **not** implemented for structs. It is recommended to use the _static access operator_ `.` to access struct fields instead.
 
 - get/fetch field values:
 

--- a/languages/elixir/exercises/concept/basketball-website/.docs/hints.md
+++ b/languages/elixir/exercises/concept/basketball-website/.docs/hints.md
@@ -1,6 +1,6 @@
 ## General
 
-- Read about the [`Access` behavior][access-behavior] in the documentation.
+- Read about the [`Access` behaviour][access-behaviour] in the documentation.
 
 ## 1. Extract data from a nested map structure
 
@@ -13,4 +13,4 @@
 
 [kernel-module]: https://hexdocs.pm/elixir/Kernel.html#functions
 [string-module]: https://hexdocs.pm/elixir/String.html#functions
-[access-behavior]: https://hexdocs.pm/elixir/Access.html
+[access-behaviour]: https://hexdocs.pm/elixir/Access.html

--- a/languages/elixir/exercises/concept/basketball-website/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/basketball-website/.docs/introduction.md
@@ -9,7 +9,7 @@ The _Access Behaviour_ provides a common interface for retrieving data from a ke
 my_map = %{key: "my value"}
 your_map = %{"key" => "your value"}
 
-# Obtain the value using the Access Behavior
+# Obtain the value using the Access Behaviour
 my_map[:key] == "my value"
 your_map[:key] == nil
 ```

--- a/languages/elixir/exercises/concept/basketball-website/.meta/design.md
+++ b/languages/elixir/exercises/concept/basketball-website/.meta/design.md
@@ -40,5 +40,5 @@ Follows the **Basketball Website Story** (outlined [here](https://github.com/exe
 - That `structs` aren't used.
 - That the `static access operator` isn't used.
 - That `Map` module functions aren't used.
-- That for `extract_from_path/2` get_in isn't used, but that access behavior is used
+- That for `extract_from_path/2` get_in isn't used, but that access behaviour is used
 - That for `get_in_path/2` get_in is used

--- a/languages/elixir/exercises/concept/remote-control-car/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/remote-control-car/.docs/introduction.md
@@ -13,7 +13,7 @@ plane = %Plane{}
 
 ### Accessing fields and updating
 
-Since structs are built on maps, we can use most map functions to get and manipulate values. The _Access Behavior_ is **not** implemented for structs. It is recommended to use the _static access operator_ `.` to access struct fields instead.
+Since structs are built on maps, we can use most map functions to get and manipulate values. The _Access Behaviour_ is **not** implemented for structs. It is recommended to use the _static access operator_ `.` to access struct fields instead.
 
 - get/fetch field values:
 

--- a/languages/elixir/exercises/concept/stack-underflow/.docs/hints.md
+++ b/languages/elixir/exercises/concept/stack-underflow/.docs/hints.md
@@ -8,11 +8,13 @@
 ## 1. Error for Division by Zero
 
 - Implement the module, specifying the message using a special [built-in macro for defining exceptions][defexception].
+- Modules can be nested inside of other modules.
 
 ## 2. Error when encountering stack underflow
 
 - Implement the module, specifying the message using a special [built-in macro for defining exceptions][defexception].
 - You can use one of the Exception Behaviour callbacks to define an exception whose message changes based on the arguments passed to `raise/2`.
+- Modules can be nested inside of other modules.
 
 ## 3. Write a dividing function
 

--- a/languages/elixir/exercises/concept/stack-underflow/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/stack-underflow/.docs/instructions.md
@@ -1,4 +1,4 @@
-While continuing your work at _Instruments of Texas_, there is progress being made on the elixir implementation of the RPN calculator. Your team would like to be able to raise errors that are more specific than the generic errors provided by the standard library. You are doing some research, but you have decided to implement two new errors which implement the _Exception Behaviour_.
+While continuing your work at _Instruments of Texas_, there is progress being made on the Elixir implementation of the RPN calculator. Your team would like to be able to raise errors that are more specific than the generic errors provided by the standard library. You are doing some research, but you have decided to implement two new errors which implement the _Exception Behaviour_.
 
 ## 1. Error for Division by Zero
 

--- a/languages/elixir/exercises/concept/stack-underflow/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/stack-underflow/.docs/introduction.md
@@ -1,6 +1,6 @@
 ## Exceptions
 
-All errors in Elixir implement the _Exception Behaviour_. Just like the _Access Behaviour_, the _Exception Behavior_ defines callback functions that a module must implement to fulfill the software contract of the behaviour. Once an errors is defined, it has the following properties:
+All errors in Elixir implement the _Exception Behaviour_. Just like the _Access Behaviour_, the _Exception Behaviour_ defines callback functions that a module must implement to fulfill the software contract of the behaviour. Once an errors is defined, it has the following properties:
 
 - The module's name defines the error's name.
 - The module defines an error-struct.

--- a/languages/elixir/exercises/concept/stack-underflow/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/stack-underflow/.docs/introduction.md
@@ -1,17 +1,17 @@
 ## Exceptions
 
-All errors in Elixir implement the _Exception Behaviour_. Just like the _Access Behaviour_, the _Exception Behaviour_ defines callback functions that a module must implement to fulfill the software contract of the behaviour. Once an errors is defined, it has the following properties:
+All errors in Elixir implement the _Exception Behaviour_. Just like the _Access Behaviour_, the _Exception Behaviour_ defines callback functions that a module must implement to fulfill the software contract of the behaviour. Once an error is defined, it has the following properties:
 
 - The module's name defines the error's name.
 - The module defines an error-struct.
-- The module will have a `:message` field.
+- The struct will have a `:message` field.
 - The module can be be used with `raise/1` and `raise/2` to raise the intended error
 
-The _Exception Behaviour_ also specifies two callbacks: `message/1` and `exception/1`. If unimplemented, default implementations will be used. `message/1` transforms the error-struct to a readable message when called by `raise/_`. `exception/1` allows additional context to be added to the message when it is called with `raise/2`
+The _Exception Behaviour_ also specifies two callbacks: `message/1` and `exception/1`. If unimplemented, default implementations will be used. `message/1` transforms the error-struct to a readable message when called with `raise`. `exception/1` allows additional context to be added to the message when it is called with `raise/2`
 
 ### Defining an exception
 
-To define an exception from an error module, we use the `defexception` macro function:
+To define an exception from an error module, we use the `defexception` macro:
 
 ```elixir
 # Defines a minimal error, with the name `MyError`

--- a/languages/elixir/exercises/concept/stack-underflow/test/rpn_calculator/exception_test.exs
+++ b/languages/elixir/exercises/concept/stack-underflow/test/rpn_calculator/exception_test.exs
@@ -93,7 +93,7 @@ defmodule RPNCalculator.ExceptionTest do
 
   describe "divide/2" do
     @tag :pending
-    test "when stack doesn't contain enough numbers, raise" do
+    test "when stack doesn't contain any numbers, raise StackUnderflowError" do
       assert_raise(
         RPNCalculator.Exception.StackUnderflowError,
         "stack underflow occurred, context: when dividing",
@@ -104,7 +104,29 @@ defmodule RPNCalculator.ExceptionTest do
     end
 
     @tag :pending
-    test "when divisor is 0, raise" do
+    test "when stack contains only one number, raise StackUnderflowError" do
+      assert_raise(
+        RPNCalculator.Exception.StackUnderflowError,
+        "stack underflow occurred, context: when dividing",
+        fn ->
+          RPNCalculator.Exception.divide([3])
+        end
+      )
+    end
+
+    @tag :pending
+    test "when stack contains only one number, raise StackUnderflowError, even when it's a zero" do
+      assert_raise(
+        RPNCalculator.Exception.StackUnderflowError,
+        "stack underflow occurred, context: when dividing",
+        fn ->
+          RPNCalculator.Exception.divide([0])
+        end
+      )
+    end
+
+    @tag :pending
+    test "when divisor is 0, raise DivisionByZeroError" do
       assert_raise(RPNCalculator.Exception.DivisionByZeroError, "division by zero occurred", fn ->
         RPNCalculator.Exception.divide([0, 2])
       end)


### PR DESCRIPTION
This PR:
- Changes the spelling of "behavior" to "behaviour" when talking about the Elixir concept.
- Adds more test cases so it's clear which error to raise when the stack has only one number, and when that number is a zero.
- Adds a hint that modules can be nested. I think this didn't pop up anywhere.