### PR TITLE
[Elixir] Improve exercise `rpn-calculator-output`

### DIFF
--- a/languages/elixir/concepts/dynamic-dispatch/introduction.md
+++ b/languages/elixir/concepts/dynamic-dispatch/introduction.md
@@ -1,23 +1,4 @@
-When Elixir resolves the function to be invoked, it uses the Module's name (atom) to perform a lookup. The lookup can be done dynamically if the Module's name (atom) is bound to a variable.
-
-- You are familiar with the atom type:
-
-```elixir
-is_atom(:an_atom)
-# => true
-```
-
-- A Module's name is also an atom.
-  - All elixir module atoms are automatically prefixed with `Elixir.`
-
-```elixir
-is_atom(Enum)
-# => true
-Enum == Elixir.Enum
-# => true
-```
-
-- we can call a function from the module referenced by the atom:
+When Elixir resolves the function to be invoked, it uses the Module's name to perform a lookup. The lookup can be done dynamically if the Module's name is bound to a variable.
 
 ```elixir
 defmodule MyModule do
@@ -27,4 +8,13 @@ end
 atom = MyModule
 atom.message()
 # => "My message"
+```
+
+Internally, a Module's name is an atom. All Elixir module atoms are automatically prefixed with `Elixir.`
+
+```elixir
+is_atom(Enum)
+# => true
+Enum == Elixir.Enum
+# => true
 ```

--- a/languages/elixir/exercises/concept/rpn-calculator-output/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/rpn-calculator-output/.docs/instructions.md
@@ -1,21 +1,21 @@
-Work is progressing well at _Instruments of Texas_ on the RPN Calculator. Your team now wants to be after to write a string version of the equation to an _IO_ resource.
+Work is progressing well at _Instruments of Texas_ on the RPN Calculator. Your team now wants to be able to write a string version of the equation to an _IO_ resource.
 
 ## 1. Open a file
 
-Your team hasn't decided what type of device to write the equation to, so you suggest using a _dynamic dispatch_ approach to be able to inject the resource into the function rather than hard-code it in. Implement the `write/3` function to open an _`io_device`_ handle using the resource and the filename.
+Your team hasn't decided what type of device to write the equation to, so you suggest using a _dynamic dispatch_ approach to be able to inject the resource into the function rather than hard-code it in. Implement the `write/3` function to open an _IO device_ using the resource and the filename.
 
-You can assume `resource` will always be an atom that represents a module which has an `open/1` function when returns a _handler_.
+You can assume `resource` will always be an atom that represents a module which has an `open/1` function that returns `{:ok, io_device}`.
 
-When the function succeeds, return an ok-tuple with the equation written
+When the function succeeds, return an ok-tuple with the equation.
 
 ```elixir
 RPNCalculator.Output.write(resource, "file_to_be_written", "1 4 +")
 # {:ok, "1 4 +"}
 ```
 
-## 2. Attempt to write to the file
+## 2. Attempt to write to the IO device
 
-Now that you've opened the file, attempt to write to it using `IO.write/2`.
+Now that you've opened the IO device, attempt to write to it using `IO.write/2`.
 
 Extend the `write/3` function to perform this action. The write action attempt may raise an error, rescue from the error returning an error-tuple:
 
@@ -24,8 +24,8 @@ RPNCalculator.Output.write(resource, "bad_file", "1 4 +")
 # {:error, "Unable to write to resource"}
 ```
 
-## 3. Close the file
+## 3. Close the IO device
 
-It is a good practice to always try to release resources that you have opened, release the file opened by closing it, even if the function raises an error. Extend the `write/3` function to call the resource's close function to close the _io handler_.
+It is a good practice to always try to release resources that you have opened, even if the function using the resource raises an error. Extend the `write/3` function to call the resource's close function to close the _IO device_.
 
-You can assume `resource` will always be an atom that represents a module which has a `close/1` function which takes a _handler_.
+You can assume `resource` will always be an atom that represents a module which has a `close/1` function which takes an _IO device_.

--- a/languages/elixir/exercises/concept/rpn-calculator-output/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/rpn-calculator-output/.docs/introduction.md
@@ -23,26 +23,7 @@ end
 
 ## Dynamic Dispatch
 
-When Elixir resolves the function to be invoked, it uses the Module's name (atom) to perform a lookup. The lookup can be done dynamically if the Module's name (atom) is bound to a variable.
-
-- You are familiar with the atom type:
-
-```elixir
-is_atom(:an_atom)
-# => true
-```
-
-- A Module's name is also an atom.
-  - All elixir module atoms are automatically prefixed with `Elixir.`
-
-```elixir
-is_atom(Enum)
-# => true
-Enum == Elixir.Enum
-# => true
-```
-
-- we can call a function from the module referenced by the atom:
+When Elixir resolves the function to be invoked, it uses the Module's name to perform a lookup. The lookup can be done dynamically if the Module's name is bound to a variable.
 
 ```elixir
 defmodule MyModule do
@@ -52,4 +33,13 @@ end
 atom = MyModule
 atom.message()
 # => "My message"
+```
+
+Internally, a Module's name is an atom. All Elixir module atoms are automatically prefixed with `Elixir.`
+
+```elixir
+is_atom(Enum)
+# => true
+Enum == Elixir.Enum
+# => true
 ```


### PR DESCRIPTION
In this PR, I want to change two things:
- Remove a code example from the introduction that doesn't show new syntax.
- Rephrase the instructions to consistently call the value returned by `resource.open` an "IO device" instead of mixing up "IO device", "file", and "handler".