### PR TITLE
[Elixir] Improve exercise `date-parser`

### DIFF
--- a/languages/elixir/concepts/regular-expressions/introduction.md
+++ b/languages/elixir/concepts/regular-expressions/introduction.md
@@ -21,7 +21,7 @@ Two notes about using sigils:
 Matching a range of characters using square brackets `[]` to denote a _character class_. This will match any one character to the characters in the class. You can also specify a range of characters like `a-z`, as long as the start and end represent a contiguous range of code points.
 
 ```elixir
-regex = ~r/[a-z][AZ][0-9][!?]/
+regex = ~r/[a-z][ADKZ][0-9][!?]/
 "jZ5!" =~ regex
 # => true
 "jB5?" =~ regex

--- a/languages/elixir/concepts/regular-expressions/introduction.md
+++ b/languages/elixir/concepts/regular-expressions/introduction.md
@@ -34,7 +34,7 @@ _Shorthand character classes_ which make the pattern more concise. A small selec
 - `\w` short for `[A-Za-z0-9_]` (any 'word' character)
 - `\s` short for `[ \t\r\n\f]` (any whitespace character)
 
-> Note: when a _shorthand character class_ outside of a sigil, it must be escaped: `"\\d"`
+When a _shorthand character class_ outside of a sigil, it must be escaped: `"\\d"`
 
 _Alternations_ use `|` as a special character to denote matching one _or_ another
 

--- a/languages/elixir/concepts/regular-expressions/introduction.md
+++ b/languages/elixir/concepts/regular-expressions/introduction.md
@@ -13,10 +13,10 @@ The `=~/2` operator is useful to perform a regex match on a string to return a `
 # => true
 ```
 
-> Two notes about using sigils:
->
-> - many different delimiters may be used depending on your requirements rather than `/`
-> - string patterns are already _escaped_, when writing the pattern as a string not using a regex, you will have to _escape_ backslashes (`\`)
+Two notes about using sigils:
+
+- many different delimiters may be used depending on your requirements rather than `/`
+- string patterns are already _escaped_, when writing the pattern as a string not using a regex, you will have to _escape_ backslashes (`\`)
 
 Matching a range of characters using square brackets `[]` to denote a _character class_. This will match any one character to the characters in the class. You can also specify a range of characters like `a-z`, as long as the start and end represent a contiguous range of code points.
 

--- a/languages/elixir/exercises/concept/date-parser/.docs/hints.md
+++ b/languages/elixir/exercises/concept/date-parser/.docs/hints.md
@@ -14,6 +14,9 @@
 - Remember to return a string representing the regular expression pattern.
 - Review how to create _character classes_ or use _shorthand character classes_.
 - Review _quantifiers_.
+- A day is one or two digits.
+- A month is one or two digits.
+- A year is four digits.
 
 ## 2. Match the day of the week and the month of the year
 
@@ -23,15 +26,18 @@
 ## 3. Capture the day, month, and year
 
 - Review how to write patterns for captures and named captures.
+- Reuse the `day/0`, `month/0`, `year/0`, `day_names/0`, and `month_names/0` functions that you already implemented.
 
 ## 4. Combine the captures to capture the whole date
 
 - Remember, string interpolation may be used to join strings.
+- Reuse the `capture_day/0`, `capture_month/0`, `capture_year/0`, `capture_day_name/0`, and `capture_month_name/0` functions that you already implemented.
 
 ## 5. Narrow the capture to match only on the date
 
 - Remembers, _anchors_ help to match the pattern to the **whole line**.
 - String interpolation may be used in the regular expression sigil syntax.
+- Reuse the `capture_numeric_date/0`, `capture_month_name_date/0`, and `capture_day_month_name_date/0` functions that you already implemented.
 
 [regex-docs]: https://hexdocs.pm/elixir/Regex.html
 [sigils-regex]: https://elixir-lang.org/getting-started/sigils.html#regular-expressions

--- a/languages/elixir/exercises/concept/date-parser/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/date-parser/.docs/instructions.md
@@ -4,7 +4,7 @@ You have been tasked to write a service which ingests events. Each event has a d
 - `"January 1, 1970"`
 - `"Thursday, January 1, 1970"`
 
-You would can see there are some similarities between each of them, and decide to write some composable regular expression patterns.
+You can see there are some similarities between each of them, and decide to write some composable regular expression patterns.
 
 ## 1. Match the day, month, and year from a date
 
@@ -23,7 +23,7 @@ Do not worry about error checking. You can assume you will always be passed a va
 
 ## 2. Match the day of the week and the month of the year
 
-Implement `day_names/0` and `month_name/0` to return a string pattern which, when compiled, would match the any named day of the week and the named month of the year respectively.
+Implement `day_names/0` and `month_names/0` to return a string pattern which, when compiled, would match the any named day of the week and the named month of the year respectively.
 
 ```elixir
 "Tuesday" =~ DateParser.day_names() |> Regex.compile!()
@@ -45,7 +45,11 @@ DateParser.capture_month_name()
 
 ## 4. Combine the captures to capture the whole date
 
-Implement `capture_numeric_date/0`, `capture_month_name_date()`, and `capture_day_month_name_date/0` to return a string pattern which captures the components from part 3 using the respective date format.
+Implement `capture_numeric_date/0`, `capture_month_name_date()`, and `capture_day_month_name_date/0` to return a string pattern which captures the components from part 3 using the respective date format:
+
+- numeric date - `"01/01/1970"`
+- month name date - `"January 1, 1970"`
+- day month name date - `"Thursday, January 1, 1970"`
 
 ```elixir
 DateParser.capture_numeric_date()
@@ -59,8 +63,6 @@ DateParser.capture_numeric_date()
 Implement `match_numeric_date/0`, `match_month_name_date/0`, and `match_day_month_name_date/0` to return a compiled regular expression that only matches the date, and which can also capture the components.
 
 ```elixir
-"The Unix epoch was Thursday, January 1, 1970" =~ DateParser.match_day_month_name_date()
-# => false
 "Thursday, January 1, 1970 was the Unix epoch." =~ DateParser.match_day_month_name_date()
 # => false
 "Thursday, January 1, 1970" =~ DateParser.match_day_month_name_date()

--- a/languages/elixir/exercises/concept/date-parser/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/date-parser/.docs/introduction.md
@@ -23,7 +23,7 @@ Two notes about using sigils:
 Matching a range of characters using square brackets `[]` to denote a _character class_. This will match any one character to the characters in the class. You can also specify a range of characters like `a-z`, as long as the start and end represent a contiguous range of code points.
 
 ```elixir
-regex = ~r/[a-z][AZ][0-9][!?]/
+regex = ~r/[a-z][ADKZ][0-9][!?]/
 "jZ5!" =~ regex
 # => true
 "jB5?" =~ regex

--- a/languages/elixir/exercises/concept/date-parser/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/date-parser/.docs/introduction.md
@@ -36,7 +36,7 @@ _Shorthand character classes_ which make the pattern more concise. A small selec
 - `\w` short for `[A-Za-z0-9_]` (any 'word' character)
 - `\s` short for `[ \t\r\n\f]` (any whitespace character)
 
-> Note: when a _shorthand character class_ outside of a sigil, it must be escaped: `"\\d"`
+When a _shorthand character class_ outside of a sigil, it must be escaped: `"\\d"`
 
 _Alternations_ use `|` as a special character to denote matching one _or_ another
 

--- a/languages/elixir/exercises/concept/date-parser/.docs/introduction.md
+++ b/languages/elixir/exercises/concept/date-parser/.docs/introduction.md
@@ -15,10 +15,10 @@ The `=~/2` operator is useful to perform a regex match on a string to return a `
 # => true
 ```
 
-> Two notes about using sigils:
->
-> - many different delimiters may be used depending on your requirements rather than `/`
-> - string patterns are already _escaped_, when writing the pattern as a string not using a regex, you will have to _escape_ backslashes (`\`)
+Two notes about using sigils:
+
+- many different delimiters may be used depending on your requirements rather than `/`
+- string patterns are already _escaped_, when writing the pattern as a string not using a regex, you will have to _escape_ backslashes (`\`)
 
 Matching a range of characters using square brackets `[]` to denote a _character class_. This will match any one character to the characters in the class. You can also specify a range of characters like `a-z`, as long as the start and end represent a contiguous range of code points.
 

--- a/languages/elixir/exercises/concept/date-parser/test/date_parser_test.exs
+++ b/languages/elixir/exercises/concept/date-parser/test/date_parser_test.exs
@@ -2,157 +2,174 @@ defmodule DateParserTest do
   use ExUnit.Case
 
   describe "numeric pattern for day matches" do
-    test "un-padded 1", do: assert "1" =~ Regex.compile!(DateParser.day())
-    test "un-padded 2", do: assert "2" =~ Regex.compile!(DateParser.day())
-    test "un-padded 3", do: assert "3" =~ Regex.compile!(DateParser.day())
-    test "un-padded 4", do: assert "4" =~ Regex.compile!(DateParser.day())
-    test "un-padded 5", do: assert "5" =~ Regex.compile!(DateParser.day())
-    test "un-padded 6", do: assert "6" =~ Regex.compile!(DateParser.day())
-    test "un-padded 7", do: assert "7" =~ Regex.compile!(DateParser.day())
-    test "un-padded 8", do: assert "8" =~ Regex.compile!(DateParser.day())
-    test "un-padded 9", do: assert "9" =~ Regex.compile!(DateParser.day())
-    test "un-padded 10", do: assert "10" =~ Regex.compile!(DateParser.day())
-    test "un-padded 11", do: assert "11" =~ Regex.compile!(DateParser.day())
-    test "un-padded 12", do: assert "12" =~ Regex.compile!(DateParser.day())
-    test "un-padded 13", do: assert "13" =~ Regex.compile!(DateParser.day())
-    test "un-padded 14", do: assert "14" =~ Regex.compile!(DateParser.day())
-    test "un-padded 15", do: assert "15" =~ Regex.compile!(DateParser.day())
-    test "un-padded 16", do: assert "16" =~ Regex.compile!(DateParser.day())
-    test "un-padded 17", do: assert "17" =~ Regex.compile!(DateParser.day())
-    test "un-padded 18", do: assert "18" =~ Regex.compile!(DateParser.day())
-    test "un-padded 19", do: assert "19" =~ Regex.compile!(DateParser.day())
-    test "un-padded 20", do: assert "20" =~ Regex.compile!(DateParser.day())
-    test "un-padded 21", do: assert "21" =~ Regex.compile!(DateParser.day())
-    test "un-padded 22", do: assert "22" =~ Regex.compile!(DateParser.day())
-    test "un-padded 23", do: assert "23" =~ Regex.compile!(DateParser.day())
-    test "un-padded 24", do: assert "24" =~ Regex.compile!(DateParser.day())
-    test "un-padded 25", do: assert "25" =~ Regex.compile!(DateParser.day())
-    test "un-padded 26", do: assert "26" =~ Regex.compile!(DateParser.day())
-    test "un-padded 27", do: assert "27" =~ Regex.compile!(DateParser.day())
-    test "un-padded 28", do: assert "28" =~ Regex.compile!(DateParser.day())
-    test "un-padded 29", do: assert "29" =~ Regex.compile!(DateParser.day())
-    test "un-padded 30", do: assert "30" =~ Regex.compile!(DateParser.day())
-    test "un-padded 31", do: assert "31" =~ Regex.compile!(DateParser.day())
+    test "un-padded 1", do: assert("1" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 2", do: assert("2" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 3", do: assert("3" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 4", do: assert("4" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 5", do: assert("5" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 6", do: assert("6" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 7", do: assert("7" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 8", do: assert("8" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 9", do: assert("9" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 10", do: assert("10" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 11", do: assert("11" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 12", do: assert("12" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 13", do: assert("13" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 14", do: assert("14" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 15", do: assert("15" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 16", do: assert("16" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 17", do: assert("17" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 18", do: assert("18" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 19", do: assert("19" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 20", do: assert("20" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 21", do: assert("21" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 22", do: assert("22" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 23", do: assert("23" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 24", do: assert("24" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 25", do: assert("25" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 26", do: assert("26" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 27", do: assert("27" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 28", do: assert("28" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 29", do: assert("29" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 30", do: assert("30" =~ Regex.compile!(DateParser.day()))
+    test "un-padded 31", do: assert("31" =~ Regex.compile!(DateParser.day()))
 
-    test "padded 01", do: assert "01" =~ Regex.compile!(DateParser.day())
-    test "padded 02", do: assert "02" =~ Regex.compile!(DateParser.day())
-    test "padded 03", do: assert "03" =~ Regex.compile!(DateParser.day())
-    test "padded 04", do: assert "04" =~ Regex.compile!(DateParser.day())
-    test "padded 05", do: assert "05" =~ Regex.compile!(DateParser.day())
-    test "padded 06", do: assert "06" =~ Regex.compile!(DateParser.day())
-    test "padded 07", do: assert "07" =~ Regex.compile!(DateParser.day())
+    test "padded 01", do: assert("01" =~ Regex.compile!(DateParser.day()))
+    test "padded 02", do: assert("02" =~ Regex.compile!(DateParser.day()))
+    test "padded 03", do: assert("03" =~ Regex.compile!(DateParser.day()))
+    test "padded 04", do: assert("04" =~ Regex.compile!(DateParser.day()))
+    test "padded 05", do: assert("05" =~ Regex.compile!(DateParser.day()))
+    test "padded 06", do: assert("06" =~ Regex.compile!(DateParser.day()))
+    test "padded 07", do: assert("07" =~ Regex.compile!(DateParser.day()))
     @tag :pending
-    test "padded 08", do: assert "08" =~ Regex.compile!(DateParser.day())
+    test "padded 08", do: assert("08" =~ Regex.compile!(DateParser.day()))
     @tag :pending
-    test "padded 09", do: assert "09" =~ Regex.compile!(DateParser.day())
+    test "padded 09", do: assert("09" =~ Regex.compile!(DateParser.day()))
   end
 
   describe "numeric pattern for day doesn't match" do
     @tag :pending
-    test "too few digits", do: refute "" =~ Regex.compile!("^#{DateParser.day()}$")
+    test "too few digits", do: refute("" =~ Regex.compile!("^#{DateParser.day()}$"))
     @tag :pending
-    test "too many digits", do: refute "111" =~ Regex.compile!("^#{DateParser.day()}$")
+    test "too many digits", do: refute("111" =~ Regex.compile!("^#{DateParser.day()}$"))
     @tag :pending
-    test "one letter", do: refute "a" =~ Regex.compile!(DateParser.day())
+    test "one letter", do: refute("a" =~ Regex.compile!(DateParser.day()))
     @tag :pending
-    test "two letters", do: refute "bb" =~ Regex.compile!(DateParser.day())
+    test "two letters", do: refute("bb" =~ Regex.compile!(DateParser.day()))
   end
 
   describe "numeric pattern for month matches" do
     @tag :pending
-    test "un-padded 1", do: assert "1" =~ Regex.compile!(DateParser.month())
+    test "un-padded 1", do: assert("1" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "un-padded 2", do: assert "2" =~ Regex.compile!(DateParser.month())
+    test "un-padded 2", do: assert("2" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "un-padded 3", do: assert "3" =~ Regex.compile!(DateParser.month())
+    test "un-padded 3", do: assert("3" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "un-padded 4", do: assert "4" =~ Regex.compile!(DateParser.month())
+    test "un-padded 4", do: assert("4" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "un-padded 5", do: assert "5" =~ Regex.compile!(DateParser.month())
+    test "un-padded 5", do: assert("5" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "un-padded 6", do: assert "6" =~ Regex.compile!(DateParser.month())
+    test "un-padded 6", do: assert("6" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "un-padded 7", do: assert "7" =~ Regex.compile!(DateParser.month())
+    test "un-padded 7", do: assert("7" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "un-padded 8", do: assert "8" =~ Regex.compile!(DateParser.month())
+    test "un-padded 8", do: assert("8" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "un-padded 9", do: assert "9" =~ Regex.compile!(DateParser.month())
+    test "un-padded 9", do: assert("9" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "un-padded 10", do: assert "10" =~ Regex.compile!(DateParser.month())
+    test "un-padded 10", do: assert("10" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "un-padded 11", do: assert "11" =~ Regex.compile!(DateParser.month())
+    test "un-padded 11", do: assert("11" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "un-padded 12", do: assert "11" =~ Regex.compile!(DateParser.month())
+    test "un-padded 12", do: assert("11" =~ Regex.compile!(DateParser.month()))
 
     @tag :pending
-    test "padded 01", do: assert "01" =~ Regex.compile!(DateParser.month())
+    test "padded 01", do: assert("01" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "padded 02", do: assert "02" =~ Regex.compile!(DateParser.month())
+    test "padded 02", do: assert("02" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "padded 03", do: assert "03" =~ Regex.compile!(DateParser.month())
+    test "padded 03", do: assert("03" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "padded 04", do: assert "04" =~ Regex.compile!(DateParser.month())
+    test "padded 04", do: assert("04" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "padded 05", do: assert "05" =~ Regex.compile!(DateParser.month())
+    test "padded 05", do: assert("05" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "padded 06", do: assert "06" =~ Regex.compile!(DateParser.month())
+    test "padded 06", do: assert("06" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "padded 07", do: assert "07" =~ Regex.compile!(DateParser.month())
+    test "padded 07", do: assert("07" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "padded 08", do: assert "08" =~ Regex.compile!(DateParser.month())
+    test "padded 08", do: assert("08" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "padded 09", do: assert "09" =~ Regex.compile!(DateParser.month())
+    test "padded 09", do: assert("09" =~ Regex.compile!(DateParser.month()))
   end
 
   describe "numeric pattern for month doesn't match" do
     @tag :pending
-    test "too few digits", do: refute "" =~ Regex.compile!("^#{DateParser.month()}$")
+    test "too few digits", do: refute("" =~ Regex.compile!("^#{DateParser.month()}$"))
     @tag :pending
-    test "too many digits", do: refute "111" =~ Regex.compile!("^#{DateParser.month()}$")
+    test "too many digits", do: refute("111" =~ Regex.compile!("^#{DateParser.month()}$"))
     @tag :pending
-    test "one letter", do: refute "a" =~ Regex.compile!(DateParser.month())
+    test "one letter", do: refute("a" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "two letters", do: refute "bb" =~ Regex.compile!(DateParser.month())
+    test "two letters", do: refute("bb" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "short month name", do: refute "Jan" =~ Regex.compile!(DateParser.month())
+    test "short month name", do: refute("Jan" =~ Regex.compile!(DateParser.month()))
     @tag :pending
-    test "long month name", do: refute "January" =~ Regex.compile!(DateParser.month())
+    test "long month name", do: refute("January" =~ Regex.compile!(DateParser.month()))
   end
 
   describe "numeric pattern for year" do
     @tag :pending
-    test "matches 4 digits", do: assert "1970" =~ Regex.compile!("^#{DateParser.year()}$")
+    test "matches 4 digits", do: assert("1970" =~ Regex.compile!("^#{DateParser.year()}$"))
     @tag :pending
-    test "doesn't match short year", do: refute "84" =~ Regex.compile!("^#{DateParser.year()}$")
+    test "doesn't match short year", do: refute("84" =~ Regex.compile!("^#{DateParser.year()}$"))
     @tag :pending
-    test "doesn't match letters", do: refute "198A" =~ Regex.compile!("^#{DateParser.year()}$")
+    test "doesn't match letters", do: refute("198A" =~ Regex.compile!("^#{DateParser.year()}$"))
     @tag :pending
-    test "doesn't match too few", do: refute "198" =~ Regex.compile!("^#{DateParser.year()}$")
+    test "doesn't match too few", do: refute("198" =~ Regex.compile!("^#{DateParser.year()}$"))
     @tag :pending
-    test "doesn't match too many", do: refute "19701" =~ Regex.compile!("^#{DateParser.year()}$")
+    test "doesn't match too many", do: refute("19701" =~ Regex.compile!("^#{DateParser.year()}$"))
   end
 
   describe "day names match" do
     @tag :pending
-    test "Sunday", do: assert "Sunday" =~ Regex.compile!(DateParser.day_names())
+    test "Sunday", do: assert("Sunday" =~ Regex.compile!(DateParser.day_names()))
     @tag :pending
-    test "Monday", do: assert "Monday" =~ Regex.compile!(DateParser.day_names())
+    test "Monday", do: assert("Monday" =~ Regex.compile!(DateParser.day_names()))
     @tag :pending
-    test "Tuesday", do: assert "Tuesday" =~ Regex.compile!(DateParser.day_names())
+    test "Tuesday", do: assert("Tuesday" =~ Regex.compile!(DateParser.day_names()))
     @tag :pending
-    test "Wednesday", do: assert "Wednesday" =~ Regex.compile!(DateParser.day_names())
+    test "Wednesday", do: assert("Wednesday" =~ Regex.compile!(DateParser.day_names()))
     @tag :pending
-    test "Thursday", do: assert "Thursday" =~ Regex.compile!(DateParser.day_names())
+    test "Thursday", do: assert("Thursday" =~ Regex.compile!(DateParser.day_names()))
     @tag :pending
-    test "Friday", do: assert "Friday" =~ Regex.compile!(DateParser.day_names())
+    test "Friday", do: assert("Friday" =~ Regex.compile!(DateParser.day_names()))
     @tag :pending
-    test "Saturday", do: assert "Saturday" =~ Regex.compile!(DateParser.day_names())
+    test "Saturday", do: assert("Saturday" =~ Regex.compile!(DateParser.day_names()))
+  end
+
+  describe "day names don't match with trailing or leading whitespace" do
+    @tag :pending
+    test "Sunday", do: refute(" Sunday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
+    @tag :pending
+    test "Monday", do: refute(" Monday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
+    @tag :pending
+    test "Tuesday", do: refute(" Tuesday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
+    @tag :pending
+    test "Wednesday", do: refute(" Wednesday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
+    @tag :pending
+    test "Thursday", do: refute(" Thursday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
+    @tag :pending
+    test "Friday", do: refute(" Friday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
+    @tag :pending
+    test "Saturday", do: refute(" Saturday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
   end
 
   describe "day names don't match" do
     @tag :pending
     test "combined" do
-      refute "SundayMonday" =~ Regex.compile!("^#{DateParser.day_names()}$")
+      refute "TuesdayWednesday" =~ Regex.compile!("^#{DateParser.day_names()}$")
     end
 
     @tag :pending
@@ -173,29 +190,56 @@ defmodule DateParserTest do
 
   describe "month names match" do
     @tag :pending
-    test "January", do: assert "January" =~ Regex.compile!(DateParser.month_names())
+    test "January", do: assert("January" =~ Regex.compile!(DateParser.month_names()))
     @tag :pending
-    test "February", do: assert "February" =~ Regex.compile!(DateParser.month_names())
+    test "February", do: assert("February" =~ Regex.compile!(DateParser.month_names()))
     @tag :pending
-    test "March", do: assert "March" =~ Regex.compile!(DateParser.month_names())
+    test "March", do: assert("March" =~ Regex.compile!(DateParser.month_names()))
     @tag :pending
-    test "April", do: assert "April" =~ Regex.compile!(DateParser.month_names())
+    test "April", do: assert("April" =~ Regex.compile!(DateParser.month_names()))
     @tag :pending
-    test "May", do: assert "May" =~ Regex.compile!(DateParser.month_names())
+    test "May", do: assert("May" =~ Regex.compile!(DateParser.month_names()))
     @tag :pending
-    test "June", do: assert "June" =~ Regex.compile!(DateParser.month_names())
+    test "June", do: assert("June" =~ Regex.compile!(DateParser.month_names()))
     @tag :pending
-    test "July", do: assert "July" =~ Regex.compile!(DateParser.month_names())
+    test "July", do: assert("July" =~ Regex.compile!(DateParser.month_names()))
     @tag :pending
-    test "August", do: assert "August" =~ Regex.compile!(DateParser.month_names())
+    test "August", do: assert("August" =~ Regex.compile!(DateParser.month_names()))
     @tag :pending
-    test "September", do: assert "September" =~ Regex.compile!(DateParser.month_names())
+    test "September", do: assert("September" =~ Regex.compile!(DateParser.month_names()))
     @tag :pending
-    test "October", do: assert "October" =~ Regex.compile!(DateParser.month_names())
+    test "October", do: assert("October" =~ Regex.compile!(DateParser.month_names()))
     @tag :pending
-    test "November", do: assert "November" =~ Regex.compile!(DateParser.month_names())
+    test "November", do: assert("November" =~ Regex.compile!(DateParser.month_names()))
     @tag :pending
-    test "December", do: assert "December" =~ Regex.compile!(DateParser.month_names())
+    test "December", do: assert("December" =~ Regex.compile!(DateParser.month_names()))
+  end
+
+  describe "month names don't match with trailing or leading whitespace" do
+    @tag :pending
+    test "January", do: refute(" January " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @tag :pending
+    test "February", do: refute(" February " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @tag :pending
+    test "March", do: refute(" March " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @tag :pending
+    test "April", do: refute(" April " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @tag :pending
+    test "May", do: refute(" May " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @tag :pending
+    test "June", do: refute(" June " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @tag :pending
+    test "July", do: refute(" July " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @tag :pending
+    test "August", do: refute(" August " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @tag :pending
+    test "September", do: refute(" September " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @tag :pending
+    test "October", do: refute(" October " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @tag :pending
+    test "November", do: refute(" November " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @tag :pending
+    test "December", do: refute(" December " =~ Regex.compile!("^#{DateParser.month_names()}$"))
   end
 
   describe "month names don't match" do
@@ -224,65 +268,70 @@ defmodule DateParserTest do
     @tag :pending
     test "numeric month" do
       assert %{"month" => "01"} =
-        DateParser.capture_month()
-        |> Regex.compile!()
-        |> Regex.named_captures("01")
+               DateParser.capture_month()
+               |> Regex.compile!()
+               |> Regex.named_captures("01")
     end
 
     @tag :pending
     test "numeric day" do
       assert %{"day" => "01"} =
-        DateParser.capture_day()
-        |> Regex.compile!()
-        |> Regex.named_captures("01")
+               DateParser.capture_day()
+               |> Regex.compile!()
+               |> Regex.named_captures("01")
     end
 
     @tag :pending
     test "numeric year" do
       assert %{"year" => "1970"} =
-        DateParser.capture_year()
-        |> Regex.compile!()
-        |> Regex.named_captures("1970")
+               DateParser.capture_year()
+               |> Regex.compile!()
+               |> Regex.named_captures("1970")
     end
 
     @tag :pending
     test "capture day name" do
       assert %{"day_name" => "Monday"} =
-        DateParser.capture_day_name()
-        |> Regex.compile!()
-        |> Regex.named_captures("Monday")
+               DateParser.capture_day_name()
+               |> Regex.compile!()
+               |> Regex.named_captures("Monday")
     end
 
     @tag :pending
     test "capture month name" do
       assert %{"month_name" => "February"} =
-        DateParser.capture_month_name()
-        |> Regex.compile!()
-        |> Regex.named_captures("February")
+               DateParser.capture_month_name()
+               |> Regex.compile!()
+               |> Regex.named_captures("February")
     end
 
     @tag :pending
     test "numeric date" do
       assert %{"year" => "1970", "month" => "02", "day" => "01"} =
-        DateParser.capture_numeric_date()
-        |> Regex.compile!()
-        |> Regex.named_captures("01/02/1970")
+               DateParser.capture_numeric_date()
+               |> Regex.compile!()
+               |> Regex.named_captures("01/02/1970")
     end
 
     @tag :pending
     test "month named date" do
       assert %{"year" => "1970", "month_name" => "January", "day" => "1"} =
-        DateParser.capture_month_name_date()
-        |> Regex.compile!()
-        |> Regex.named_captures("January 1, 1970")
+               DateParser.capture_month_name_date()
+               |> Regex.compile!()
+               |> Regex.named_captures("January 1, 1970")
     end
 
     @tag :pending
     test "day and month named date" do
-      assert %{"year" => "1970", "month_name" => "January", "day" => "1", "day_name" => "Thursday"} =
-        DateParser.capture_day_month_name_date()
-        |> Regex.compile!()
-        |> Regex.named_captures("Thursday, January 1, 1970")
+      assert %{
+               "year" => "1970",
+               "month_name" => "January",
+               "day" => "1",
+               "day_name" => "Thursday"
+             } =
+               DateParser.capture_day_month_name_date()
+               |> Regex.compile!()
+               |> Regex.named_captures("Thursday, January 1, 1970")
     end
   end
 
@@ -290,22 +339,27 @@ defmodule DateParserTest do
     @tag :pending
     test "numeric date" do
       assert %{"year" => "1970", "month" => "02", "day" => "01"} =
-        DateParser.match_numeric_date()
-        |> Regex.named_captures("01/02/1970")
+               DateParser.match_numeric_date()
+               |> Regex.named_captures("01/02/1970")
     end
 
     @tag :pending
     test "month named date" do
       assert %{"year" => "1970", "month_name" => "January", "day" => "1"} =
-        DateParser.match_month_name_date()
-        |> Regex.named_captures("January 1, 1970")
+               DateParser.match_month_name_date()
+               |> Regex.named_captures("January 1, 1970")
     end
 
     @tag :pending
     test "day and month named date" do
-      assert %{"year" => "1970", "month_name" => "January", "day" => "1", "day_name" => "Thursday"} =
-        DateParser.match_day_month_name_date()
-        |> Regex.named_captures("Thursday, January 1, 1970")
+      assert %{
+               "year" => "1970",
+               "month_name" => "January",
+               "day" => "1",
+               "day_name" => "Thursday"
+             } =
+               DateParser.match_day_month_name_date()
+               |> Regex.named_captures("Thursday, January 1, 1970")
     end
   end
 end

--- a/languages/elixir/exercises/concept/date-parser/test/date_parser_test.exs
+++ b/languages/elixir/exercises/concept/date-parser/test/date_parser_test.exs
@@ -337,21 +337,56 @@ defmodule DateParserTest do
 
   describe "regex match" do
     @tag :pending
-    test "numeric date" do
+    test "numeric date matches" do
+      assert DateParser.match_numeric_date() |> Regex.match?("01/02/1970")
+    end
+
+    @tag :pending
+    test "numeric date has named captures" do
       assert %{"year" => "1970", "month" => "02", "day" => "01"} =
                DateParser.match_numeric_date()
                |> Regex.named_captures("01/02/1970")
     end
 
     @tag :pending
-    test "month named date" do
+    test "numeric date with a prefix doesn't match" do
+      refute DateParser.match_numeric_date() |> Regex.match?("The day was 01/02/1970")
+    end
+
+    @tag :pending
+    test "numeric date with a suffix doesn't match" do
+      refute DateParser.match_numeric_date() |> Regex.match?("01/02/1970 was the day")
+    end
+
+    @tag :pending
+    test "month named date matches" do
+      assert DateParser.match_month_name_date() |> Regex.match?("January 1, 1970")
+    end
+
+    @tag :pending
+    test "month named date has named captures" do
       assert %{"year" => "1970", "month_name" => "January", "day" => "1"} =
                DateParser.match_month_name_date()
                |> Regex.named_captures("January 1, 1970")
     end
 
     @tag :pending
-    test "day and month named date" do
+    test "month named date with a prefix doesn't match" do
+      refute DateParser.match_month_name_date() |> Regex.match?("The day was January 1, 1970")
+    end
+
+    @tag :pending
+    test "month named date with a suffix doesn't match" do
+      refute DateParser.match_month_name_date() |> Regex.match?("January 1, 1970 was the day")
+    end
+
+    @tag :pending
+    test "day and month names date matches" do
+      assert DateParser.match_day_month_name_date() |> Regex.match?("Thursday, January 1, 1970")
+    end
+
+    @tag :pending
+    test "day and month names date has named captures" do
       assert %{
                "year" => "1970",
                "month_name" => "January",
@@ -360,6 +395,18 @@ defmodule DateParserTest do
              } =
                DateParser.match_day_month_name_date()
                |> Regex.named_captures("Thursday, January 1, 1970")
+    end
+
+    @tag :pending
+    test "day and month names date with a prefix doesn't match" do
+      refute DateParser.match_day_month_name_date()
+             |> Regex.match?("The day way Thursday, January 1, 1970")
+    end
+
+    @tag :pending
+    test "day and month names date with a suffix doesn't match" do
+      refute DateParser.match_day_month_name_date()
+             |> Regex.match?("Thursday, January 1, 1970 was the day")
     end
   end
 end


### PR DESCRIPTION
This PR, among other changes, includes two additions to the test suite.
- Added tests for `month_names` and `day_names` that will detect if write `"Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday"` instead of `"(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday)"` regardless of the order of the days/months. There was a check for something like that with the "combined" assertion that it doesn't match "SundayMonday", but that would only detect this problem if you start listing the days from Sunday. In many places you start with Monday, and chaotic people might even write it out of order :).
- Added tests for `match_` that will detect if somebody forgot to use `^` and `$`. It's required according to the examples given for this step in the instructions.