### PR TITLE
[Elixir] Extend the `log-level` exercise to justify using `cond` over `if` or `case`

### DIFF
--- a/languages/elixir/exercises/concept/date-parser/lib/date_parser.ex
+++ b/languages/elixir/exercises/concept/date-parser/lib/date_parser.ex
@@ -1,7 +1,15 @@
 defmodule DateParser do
-  def day(), do: raise "Please implement the day/0 function"
-  def month(), do: raise "Please implement the month/0 function"
-  def year(), do: raise "Please implement the year/0 function"
+  def day() do
+    raise "Please implement the day/0 function"
+  end
+
+  def month() do
+    raise "Please implement the month/0 function"
+  end
+
+  def year() do
+    raise "Please implement the year/0 function"
+  end
 
   def day_names() do
     raise "Please implement the day_names/0 function"
@@ -11,18 +19,47 @@ defmodule DateParser do
     raise "Please implement the month_names/0 function"
   end
 
-  def capture_day(), do: raise "Please implement the capture_day/0 function"
-  def capture_month(), do: raise "Please implement the capture_month/0 function"
-  def capture_year(), do: raise "Please implement the capture_year/0 function"
+  def capture_day() do
+    raise "Please implement the capture_day/0 function"
+  end
 
-  def capture_day_name(), do: raise "Please implement the capture_day_name/0 function"
-  def capture_month_name(), do: raise "Please implement the capture_month_name/0 function"
+  def capture_month() do
+    raise "Please implement the capture_month/0 function"
+  end
 
-  def capture_numeric_date(), do: raise "Please implement the capture_numeric_date/0 function"
-  def capture_month_name_date(), do: raise "Please implement the capture_month_name_date/0 function"
-  def capture_day_month_name_date(), do: raise "Please implement the capture_day_month_name_date/0 function"
+  def capture_year() do
+    raise "Please implement the capture_year/0 function"
+  end
 
-  def match_numeric_date(), do: raise "Please implement the match_numeric_date/0 function"
-  def match_month_name_date(), do: raise "Please implement the match_month_name_day/0 function"
-  def match_day_month_name_date(), do: raise "Please implement the match_day_month_name_date/0 function"
+  def capture_day_name() do
+    raise "Please implement the capture_day_name/0 function"
+  end
+
+  def capture_month_name() do
+    raise "Please implement the capture_month_name/0 function"
+  end
+
+  def capture_numeric_date() do
+    raise "Please implement the capture_numeric_date/0 function"
+  end
+
+  def capture_month_name_date() do
+    raise "Please implement the capture_month_name_date/0 function"
+  end
+
+  def capture_day_month_name_date() do
+    raise "Please implement the capture_day_month_name_date/0 function"
+  end
+
+  def match_numeric_date() do
+    raise "Please implement the match_numeric_date/0 function"
+  end
+
+  def match_month_name_date() do
+    raise "Please implement the match_month_name_day/0 function"
+  end
+
+  def match_day_month_name_date() do
+    raise "Please implement the match_day_month_name_date/0 function"
+  end
 end

--- a/languages/elixir/exercises/concept/dna-encoding/lib/dna.ex
+++ b/languages/elixir/exercises/concept/dna-encoding/lib/dna.ex
@@ -1,7 +1,11 @@
 defmodule DNA do
-  def encode_nucleotide(code_point), do: raise "Please implement the encode_nucleotide/1 function"
+  def encode_nucleotide(code_point) do
+    raise "Please implement the encode_nucleotide/1 function"
+  end
 
-  def decode_nucleotide(encoded_code), do: raise "Please implement the decode_nucleotide/1 function"
+  def decode_nucleotide(encoded_code) do
+    raise "Please implement the decode_nucleotide/1 function"
+  end
 
   def encode(dna) do
     raise "Please implement the encode/1 function"

--- a/languages/elixir/exercises/concept/guessing-game/.meta/example.ex
+++ b/languages/elixir/exercises/concept/guessing-game/.meta/example.ex
@@ -10,8 +10,8 @@ defmodule GuessingGame do
   end
 
   def compare(secret_number, guess)
-      when guess == secret_number + 1
-      or guess == secret_number - 1 do
+      when guess == secret_number + 1 or
+           guess == secret_number - 1 do
     "So close"
   end
 

--- a/languages/elixir/exercises/concept/guessing-game/test/guessing_game_test.exs
+++ b/languages/elixir/exercises/concept/guessing-game/test/guessing_game_test.exs
@@ -23,7 +23,7 @@ defmodule GuessingGameTest do
 
   @tag :pending
   test "so close when guess differs from 7 secret by +1" do
-    assert GuessingGame.compare(52,53) == "So close"
+    assert GuessingGame.compare(52, 53) == "So close"
   end
 
   @tag :pending

--- a/languages/elixir/exercises/concept/high-score/lib/high_score.ex
+++ b/languages/elixir/exercises/concept/high-score/lib/high_score.ex
@@ -1,5 +1,7 @@
 defmodule HighScore do
-  def new(), do: raise "Please implement the new/0 function"
+  def new() do
+    raise "Please implement the new/0 function"
+  end
 
   def add_player(scores, name, score) do
     raise "Please implement the add_player/3 function"

--- a/languages/elixir/exercises/concept/kitchen-calculator/lib/kitchen_calculator.ex
+++ b/languages/elixir/exercises/concept/kitchen-calculator/lib/kitchen_calculator.ex
@@ -1,5 +1,4 @@
 defmodule KitchenCalculator do
-
   def get_volume(volume_pair) do
     raise "Please implement the get_volume/1 function"
   end

--- a/languages/elixir/exercises/concept/log-level/.docs/hints.md
+++ b/languages/elixir/exercises/concept/log-level/.docs/hints.md
@@ -6,12 +6,9 @@
 
 - You can use the [`cond/1` function][cond] to elegantly handle the various log codes.
 - You can use [equality operators][equality] to compare integers for strict type equality.
-
-## 2. Support unknown logging codes
-
 - There is a [way to specify a default branch][cond] in a cond function that can be used to catch unspecified cases.
 
-## 3. Send an alert
+## 2. Send an alert
 
 - You can use the [`cond/1` function][cond] to decide if an alert should be sent.
 - You can use [equality operators][equality] to compare atoms for equality.

--- a/languages/elixir/exercises/concept/log-level/.docs/instructions.md
+++ b/languages/elixir/exercises/concept/log-level/.docs/instructions.md
@@ -1,41 +1,39 @@
-In this exercise you'll be mapping logging codes to a label.
+You are running a system that consist of a few applications producing many logs. You want to write a small program that will aggregate those logs and give them labels according to their severity level. All applications in your system use the same log codes, but some of the legacy applications don't support all the codes.
 
-These are the different log codes:
-
-- 0 (trace)
-- 1 (debug)
-- 4 (info)
-- 5 (warning)
-- 6 (error)
-- 7 (fatal)
-
-You have three tasks:
+| Log code | Log label | Supported in legacy apps? |
+| -------- | --------- | ------------------------- |
+| 0        | trace     | no                        |
+| 1        | debug     | yes                       |
+| 2        | info      | yes                       |
+| 3        | warning   | yes                       |
+| 4        | error     | yes                       |
+| 5        | fatal     | no                        |
+| ?        | unknown   | -                         |
 
 ## 1. Return the logging code label
 
-Implement the `LogLevel.to_label/1` function to return the label of a log line from an integer code:
+Implement the `LogLevel.to_label/2` function. It should take an integer code and a boolean flag telling you if the log comes from a legacy app, and return the label of a log line as an atom. Unknown log codes and codes unsupported in a legacy app should return an _unknown_ label.
 
 ```elixir
-LogLevel.to_label(1)
+LogLevel.to_label(1, false)
 # => :debug
-```
 
-## 2. Support unknown logging codes
-
-Unfortunately, some log lines occasionally have an unknown log code. To gracefully handle these log lines, add an _unknown_ label to the `LogLevel.to_label/1` function.
-
-```elixir
-LogLevel.to_label(10)
+LogLevel.to_label(1, true)
 # => :unknown
 ```
 
-## 3. Send an alert
+## 2. Send an alert
 
-An engineer wants to be alerted when some events occur in the log. They would like to be notified if an `:error`, `:fatal`, or `:unknown` event occurs.
+Somebody has to be notified when unexpected things happen.
 
-Implement the `LogLevel.send_alert?/1` function to determine if an alert should be sent based on the log line's label.
+Implement the `LogLevel.alert_recipient/2` function to determine to whom the alert needs to be sent. The function should take an integer code and a boolean flag telling you if the log comes from a legacy app, and return the name of the recipient as an atom.
+
+If the log label is _error_ or _fatal_, send the alert to the _ops_ team. If the log label is unknown and it comes from a legacy system, send the alert to the _dev1_ team, otherwise send it to the _dev2_ team. All other log labels can be safely ignored.
 
 ```elixir
-LogLevel.send_alert?(1)
+LogLevel.alert_recipient(-1, true)
+# => :dev1
+
+LogLevel.alert_recipient(0, false)
 # => false
 ```

--- a/languages/elixir/exercises/concept/log-level/.meta/example.ex
+++ b/languages/elixir/exercises/concept/log-level/.meta/example.ex
@@ -1,23 +1,24 @@
 defmodule LogLevel do
-  def to_label(level) do
+  def to_label(level, legacy?) do
     cond do
-      level === 0 -> :trace
+      level === 0 && not legacy? -> :trace
       level === 1 -> :debug
-      level === 4 -> :info
-      level === 5 -> :warning
-      level === 6 -> :error
-      level === 7 -> :fatal
+      level === 2 -> :info
+      level === 3 -> :warning
+      level === 4 -> :error
+      level === 5 && not legacy? -> :fatal
       true -> :unknown
     end
   end
 
-  def send_alert?(level) do
-    label = to_label(level)
+  def alert_recipient(level, legacy?) do
+    label = to_label(level, legacy?)
 
     cond do
-      label == :fatal -> true
-      label == :error -> true
-      label == :unknown -> true
+      label == :fatal -> :ops
+      label == :error -> :ops
+      label == :unknown && legacy? -> :dev1
+      label == :unknown -> :dev2
       true -> false
     end
   end

--- a/languages/elixir/exercises/concept/log-level/lib/log_level.ex
+++ b/languages/elixir/exercises/concept/log-level/lib/log_level.ex
@@ -1,9 +1,9 @@
 defmodule LogLevel do
-  def to_label(level) do
-    raise "Please implement the to_label/1 function"
+  def to_label(level, legacy?) do
+    raise "Please implement the to_label/2 function"
   end
 
-  def send_alert?(level) do
-    raise "Please implement the send_alert?/1 function"
+  def alert_recipient?(level, legacy?) do
+    raise "Please implement the alert_recipient/2 function"
   end
 end

--- a/languages/elixir/exercises/concept/log-level/test/log_level_test.exs
+++ b/languages/elixir/exercises/concept/log-level/test/log_level_test.exs
@@ -3,80 +3,99 @@ defmodule LogLevelTest do
 
   describe "LogLevel.to_label/1" do
     # @tag :pending
-    test "label trace" do
-      assert LogLevel.to_label(0) == :trace
+    test "level 0 has label trace only in a non-legacy app" do
+      assert LogLevel.to_label(0, false) == :trace
+      assert LogLevel.to_label(0, true) == :unknown
     end
 
     @tag :pending
-    test "label debug" do
-      assert LogLevel.to_label(1) == :debug
+    test "level 1 has label debug" do
+      assert LogLevel.to_label(1, false) == :debug
+      assert LogLevel.to_label(1, true) == :debug
     end
 
     @tag :pending
-    test "label info" do
-      assert LogLevel.to_label(4) == :info
+    test "level 2 has label info" do
+      assert LogLevel.to_label(2, false) == :info
+      assert LogLevel.to_label(2, true) == :info
     end
 
     @tag :pending
-    test "label warning" do
-      assert LogLevel.to_label(5) == :warning
+    test "level 3 has label warning" do
+      assert LogLevel.to_label(3, false) == :warning
+      assert LogLevel.to_label(3, true) == :warning
     end
 
     @tag :pending
-    test "label error" do
-      assert LogLevel.to_label(6) == :error
+    test "level 4 has label error" do
+      assert LogLevel.to_label(4, false) == :error
+      assert LogLevel.to_label(4, true) == :error
     end
 
     @tag :pending
-    test "label fatal" do
-      assert LogLevel.to_label(7) == :fatal
+    test "level 5 has label fatal only in a non-legacy app" do
+      assert LogLevel.to_label(5, false) == :fatal
+      assert LogLevel.to_label(5, true) == :unknown
     end
 
     @tag :pending
-    test "label unknown" do
-      assert LogLevel.to_label(10) == :unknown
+    test "level 6 has label unknown" do
+      assert LogLevel.to_label(6, false) == :unknown
+      assert LogLevel.to_label(6, true) == :unknown
     end
 
     @tag :pending
-    test "label another unknown" do
-      assert LogLevel.to_label(-1) == :unknown
+    test "level -1 has label unknown" do
+      assert LogLevel.to_label(-1, false) == :unknown
+      assert LogLevel.to_label(-1, true) == :unknown
     end
   end
 
-  describe "LogLevel.send_alert?/1" do
+  describe "LogLevel.alert_recipient/2" do
     @tag :pending
-    test "if :fatal code sends alert" do
-      assert LogLevel.send_alert?(7)
+    test "fatal code sends alert to ops" do
+      assert LogLevel.alert_recipient(5, false) == :ops
     end
 
     @tag :pending
-    test "if :error code sends alert" do
-      assert LogLevel.send_alert?(6)
+    test "error code sends alert to ops" do
+      assert LogLevel.alert_recipient(4, false) == :ops
+      assert LogLevel.alert_recipient(4, true) == :ops
     end
 
     @tag :pending
-    test "if :unknown code sends alert" do
-      assert LogLevel.send_alert?(10)
+    test "unknown code sends alert to dev team 1 for a legacy app" do
+      assert LogLevel.alert_recipient(6, true) == :dev1
+      assert LogLevel.alert_recipient(0, true) == :dev1
+      assert LogLevel.alert_recipient(5, true) == :dev1
     end
 
     @tag :pending
-    test "if :trace code does not send alert" do
-      refute LogLevel.send_alert?(0)
+    test "unknown code sends alert to dev team 2" do
+      assert LogLevel.alert_recipient(6, false) == :dev2
     end
 
     @tag :pending
-    test "if :debug code does not send alert" do
-      refute LogLevel.send_alert?(1)
+    test "trace code does not send alert" do
+      refute LogLevel.alert_recipient(0, false)
     end
 
     @tag :pending
-    test "if :info code does not send alert" do
-      refute LogLevel.send_alert?(4)
+    test "debug code does not send alert" do
+      refute LogLevel.alert_recipient(1, false)
+      refute LogLevel.alert_recipient(1, true)
     end
 
     @tag :pending
-    test "if :warning code does not send alert" do
-      refute LogLevel.send_alert?(5)
+    test "info code does not send alert" do
+      refute LogLevel.alert_recipient(2, false)
+      refute LogLevel.alert_recipient(2, true)
+    end
+
+    @tag :pending
+    test "warning code does not send alert" do
+      refute LogLevel.alert_recipient(3, false)
+      refute LogLevel.alert_recipient(3, true)
     end
   end
 end

--- a/languages/elixir/exercises/concept/stack-underflow/.meta/example.ex
+++ b/languages/elixir/exercises/concept/stack-underflow/.meta/example.ex
@@ -9,14 +9,15 @@ defmodule RPNCalculator.Exception do
     @impl true
     def exception(value) do
       error = %StackUnderflowError{}
+
       case value do
         [] -> error
-        _ ->  %{error | message: "#{error.message}, context: #{value}"}
+        _ -> %{error | message: "#{error.message}, context: #{value}"}
       end
     end
   end
 
-  def divide(stack) when length(stack) < 2, do: raise StackUnderflowError, "when dividing"
-  def divide([divisor, _number | _]) when divisor == 0, do: raise DivisionByZeroError
+  def divide(stack) when length(stack) < 2, do: raise(StackUnderflowError, "when dividing")
+  def divide([divisor, _number | _]) when divisor == 0, do: raise(DivisionByZeroError)
   def divide([divisor, number | _]), do: number / divisor
 end


### PR DESCRIPTION
The problem with the `cond` expression is that it is only necessary if you have at least 2 different input variables and 3 different output values. If there is a single input, it's easier to use `case`. If there are only 2 output values, it's easier to use `if`. Then I solved the exercise in its original form spontaneously, I did it like this, without `cond`.

```elixir
defmodule LogLevel do
  def to_label(level) do
    case level do
      0 -> :trace
      1 -> :debug
      4 -> :info
      5 -> :warning
      6 -> :error
      7 -> :fatal
      _ -> :unknown
    end
  end

  def send_alert?(level) do
    label = to_label(level)
    label in [:fatal, :error, :unknown]
  end
end
```

To steer people into using `cond`, I'm proposing a change to the exercise that introduces the concept of a "legacy app" that doesn't support all log codes, and changing `send_alert?` to `alert_recipient` to have more than 2 different return values.

PS: This PR includes unrelated reformatting because I saw on Erik's big track v2 <-> v3 merge branch (https://github.com/ErikSchierboom/elixir/pull/1) that some of the concept exercises fail the mix format check script.