### PR TITLE
Convert editor key in .meta/config.json files

### DIFF
--- a/languages/clojure/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/languages/clojure/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["fsharp/booleans"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.clj"]
   }
 }

--- a/languages/clojure/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/languages/clojure/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "porkostomus"
     }
   ],
-  "forked_from": ["fsharp/booleans"]
+  "forked_from": ["fsharp/booleans"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/clojure/exercises/concept/bird-watcher/.meta/config.json
+++ b/languages/clojure/exercises/concept/bird-watcher/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/arrays"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": []
   }
 }

--- a/languages/clojure/exercises/concept/bird-watcher/.meta/config.json
+++ b/languages/clojure/exercises/concept/bird-watcher/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "porkostomus"
     }
   ],
-  "forked_from": ["csharp/arrays"]
+  "forked_from": ["csharp/arrays"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/clojure/exercises/concept/cars-assemble/.meta/config.json
+++ b/languages/clojure/exercises/concept/cars-assemble/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "porkostomus"
     }
   ],
-  "forked_from": ["fsharp/numbers"]
+  "forked_from": ["fsharp/numbers"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/clojure/exercises/concept/cars-assemble/.meta/config.json
+++ b/languages/clojure/exercises/concept/cars-assemble/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["fsharp/numbers"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.clj"]
   }
 }

--- a/languages/clojure/exercises/concept/log-levels/.meta/config.json
+++ b/languages/clojure/exercises/concept/log-levels/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "porkostomus"
     }
   ],
-  "forked_from": ["fsharp/strings"]
+  "forked_from": ["fsharp/strings"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/clojure/exercises/concept/log-levels/.meta/config.json
+++ b/languages/clojure/exercises/concept/log-levels/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["fsharp/strings"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.clj"]
   }
 }

--- a/languages/clojure/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/languages/clojure/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["fsharp/basics"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.clj"]
   }
 }

--- a/languages/clojure/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/languages/clojure/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "porkostomus"
     }
   ],
-  "forked_from": ["fsharp/basics"]
+  "forked_from": ["fsharp/basics"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/clojure/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
+++ b/languages/clojure/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
@@ -11,6 +11,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.clj"]
   }
 }

--- a/languages/clojure/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
+++ b/languages/clojure/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
@@ -8,5 +8,9 @@
       "github_username": "cstby",
       "exercism_username": "cstby"
     }
-  ]
+  ],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/common-lisp/bin/generate-scaffolding/template/.meta/config.json
+++ b/languages/common-lisp/bin/generate-scaffolding/template/.meta/config.json
@@ -7,8 +7,8 @@
   ],
   "contributors": [],
   "forked_from": [],
-  "editor": {
-    "solution_files": ["SLUG.lisp"],
-    "test_files": ["SLUG-test.lisp"]
+  "files": {
+    "solution": ["SLUG.lisp"],
+    "test": ["SLUG-test.lisp"]
   }
 }

--- a/languages/common-lisp/bin/generate-scaffolding/template/.meta/config.json
+++ b/languages/common-lisp/bin/generate-scaffolding/template/.meta/config.json
@@ -9,6 +9,7 @@
   "forked_from": [],
   "files": {
     "solution": ["SLUG.lisp"],
-    "test": ["SLUG-test.lisp"]
+    "test": ["SLUG-test.lisp"],
+    "exemplar": ["exemplar.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/key-comparison/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/key-comparison/.meta/config.json
@@ -9,8 +9,8 @@
       "exercism_username": "TheLostLambda"
     }
   ],
-  "editor": {
-    "solution_files": ["key-comparison.lisp"],
-    "test_files": ["key-comparison-test.lisp"]
+  "files": {
+    "solution": ["key-comparison.lisp"],
+    "test": ["key-comparison-test.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/key-comparison/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/key-comparison/.meta/config.json
@@ -11,6 +11,7 @@
   ],
   "files": {
     "solution": ["key-comparison.lisp"],
-    "test": ["key-comparison-test.lisp"]
+    "test": ["key-comparison-test.lisp"],
+    "exemplar": [".meta/exemplar.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/leslies-lists/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/leslies-lists/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "verdammelt"
     }
   ],
-  "editor": {
-    "solution_files": ["leslies-lists.lisp"],
-    "test_files": ["leslies-lists-test.lisp"]
+  "files": {
+    "solution": ["leslies-lists.lisp"],
+    "test": ["leslies-lists-test.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/leslies-lists/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/leslies-lists/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["leslies-lists.lisp"],
-    "test": ["leslies-lists-test.lisp"]
+    "test": ["leslies-lists-test.lisp"],
+    "exemplar": [".meta/exemplar.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/lillys-lasagna-leftovers/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/lillys-lasagna-leftovers/.meta/config.json
@@ -9,6 +9,7 @@
   "forked_from": ["swift/lasagna-master"],
   "files": {
     "solution": ["lillys-lasagna-leftovers.lisp"],
-    "test": ["lillys-lasagna-leftovers-test.lisp"]
+    "test": ["lillys-lasagna-leftovers-test.lisp"],
+    "exemplar": [".meta/exemplar.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/lillys-lasagna-leftovers/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/lillys-lasagna-leftovers/.meta/config.json
@@ -7,8 +7,8 @@
   ],
   "contributors": [],
   "forked_from": ["swift/lasagna-master"],
-  "editor": {
-    "solution_files": ["lillys-lasagna-leftovers.lisp"],
-    "test_files": ["lillys-lasagna-leftovers-test.lisp"]
+  "files": {
+    "solution": ["lillys-lasagna-leftovers.lisp"],
+    "test": ["lillys-lasagna-leftovers-test.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/lillys-lasagna/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/lillys-lasagna/.meta/config.json
@@ -7,8 +7,8 @@
   ],
   "contributors": [],
   "forked_from": ["ruby/lasagna"],
-  "editor": {
-    "solution_files": ["lillys-lasagna.lisp"],
-    "test_files": ["lillys-lasagna-test.lisp"]
+  "files": {
+    "solution": ["lillys-lasagna.lisp"],
+    "test": ["lillys-lasagna-test.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/lillys-lasagna/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/lillys-lasagna/.meta/config.json
@@ -9,6 +9,7 @@
   "forked_from": ["ruby/lasagna"],
   "files": {
     "solution": ["lillys-lasagna.lisp"],
-    "test": ["lillys-lasagna-test.lisp"]
+    "test": ["lillys-lasagna-test.lisp"],
+    "exemplar": [".meta/exemplar.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/pal-picker/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/pal-picker/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "TheLostLambda"
     }
   ],
-  "editor": {
-    "solution_files": ["pal-picker.lisp"],
-    "test_files": ["pal-picker-test.lisp"]
+  "files": {
+    "solution": ["pal-picker.lisp"],
+    "test": ["pal-picker-test.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/pal-picker/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/pal-picker/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["pal-picker.lisp"],
-    "test": ["pal-picker-test.lisp"]
+    "test": ["pal-picker-test.lisp"],
+    "exemplar": [".meta/exemplar.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/pizza-pi/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/pizza-pi/.meta/config.json
@@ -11,6 +11,7 @@
   ],
   "files": {
     "solution": ["pizza-pi.lisp"],
-    "test": ["pizza-pi-test.lisp"]
+    "test": ["pizza-pi-test.lisp"],
+    "exemplar": [".meta/exemplar.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/pizza-pi/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/pizza-pi/.meta/config.json
@@ -9,8 +9,8 @@
       "exercism_username": "verdammelt"
     }
   ],
-  "editor": {
-    "solution_files": ["pizza-pi.lisp"],
-    "test_files": ["pizza-pi-test.lisp"]
+  "files": {
+    "solution": ["pizza-pi.lisp"],
+    "test": ["pizza-pi-test.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/socks-and-sexprs/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/socks-and-sexprs/.meta/config.json
@@ -11,6 +11,7 @@
   ],
   "files": {
     "solution": ["socks-and-sexprs.lisp"],
-    "test": ["socks-and-sexprs-test.lisp"]
+    "test": ["socks-and-sexprs-test.lisp"],
+    "exemplar": [".meta/exemplar.lisp"]
   }
 }

--- a/languages/common-lisp/exercises/concept/socks-and-sexprs/.meta/config.json
+++ b/languages/common-lisp/exercises/concept/socks-and-sexprs/.meta/config.json
@@ -9,8 +9,8 @@
       "exercism_username": "TheLostLambda"
     }
   ],
-  "editor": {
-    "solution_files": ["socks-and-sexprs.lisp"],
-    "test_files": ["socks-and-sexprs-test.lisp"]
+  "files": {
+    "solution": ["socks-and-sexprs.lisp"],
+    "test": ["socks-and-sexprs-test.lisp"]
   }
 }

--- a/languages/cpp/exercises/concept/strings/.meta/config.json
+++ b/languages/cpp/exercises/concept/strings/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "silvanocerza"
     }
   ],
-  "forked_from": ["csharp/strings"]
+  "forked_from": ["csharp/strings"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/cpp/exercises/concept/strings/.meta/config.json
+++ b/languages/cpp/exercises/concept/strings/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/strings"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.cpp", ".meta/exemplar.h"]
   }
 }

--- a/languages/csharp/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/languages/csharp/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["fsharp/booleans"],
   "files": {
     "solution": ["AnnalynsInfiltration.cs"],
-    "test": ["AnnalynsInfiltrationTests.cs"]
+    "test": ["AnnalynsInfiltrationTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/languages/csharp/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["fsharp/booleans"],
-  "editor": {
-    "solution_files": ["AnnalynsInfiltration.cs"],
-    "test_files": ["AnnalynsInfiltrationTests.cs"]
+  "files": {
+    "solution": ["AnnalynsInfiltration.cs"],
+    "test": ["AnnalynsInfiltrationTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/attack-of-the-trolls/.meta/config.json
+++ b/languages/csharp/exercises/concept/attack-of-the-trolls/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["AttackOfTheTrolls.cs"],
-    "test_files": ["AttackOfTheTrollsTests.cs"]
+  "files": {
+    "solution": ["AttackOfTheTrolls.cs"],
+    "test": ["AttackOfTheTrollsTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/attack-of-the-trolls/.meta/config.json
+++ b/languages/csharp/exercises/concept/attack-of-the-trolls/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["AttackOfTheTrolls.cs"],
-    "test": ["AttackOfTheTrollsTests.cs"]
+    "test": ["AttackOfTheTrollsTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/authentication-system/.meta/config.json
+++ b/languages/csharp/exercises/concept/authentication-system/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["AuthenticationSystem.cs"],
-    "test": ["AuthenticationSystemTests.cs"]
+    "test": ["AuthenticationSystemTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/authentication-system/.meta/config.json
+++ b/languages/csharp/exercises/concept/authentication-system/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["AuthenticationSystem.cs"],
-    "test_files": ["AuthenticationSystemTests.cs"]
+  "files": {
+    "solution": ["AuthenticationSystem.cs"],
+    "test": ["AuthenticationSystemTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/beauty-salon-goes-global/.meta/config.json
+++ b/languages/csharp/exercises/concept/beauty-salon-goes-global/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["BeautySalonGoesGlobal.cs"],
-    "test_files": ["BeautySalonGoesGlobalTests.cs"]
+  "files": {
+    "solution": ["BeautySalonGoesGlobal.cs"],
+    "test": ["BeautySalonGoesGlobalTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/beauty-salon-goes-global/.meta/config.json
+++ b/languages/csharp/exercises/concept/beauty-salon-goes-global/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["BeautySalonGoesGlobal.cs"],
-    "test": ["BeautySalonGoesGlobalTests.cs"]
+    "test": ["BeautySalonGoesGlobalTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/bird-watcher/.meta/config.json
+++ b/languages/csharp/exercises/concept/bird-watcher/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["BirdWatcher.cs"],
-    "test_files": ["BirdWatcherTests.cs"]
+  "files": {
+    "solution": ["BirdWatcher.cs"],
+    "test": ["BirdWatcherTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/bird-watcher/.meta/config.json
+++ b/languages/csharp/exercises/concept/bird-watcher/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["BirdWatcher.cs"],
-    "test": ["BirdWatcherTests.cs"]
+    "test": ["BirdWatcherTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/booking-up-for-beauty/.meta/config.json
+++ b/languages/csharp/exercises/concept/booking-up-for-beauty/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["BookingUpForBeauty.cs"],
-    "test_files": ["BookingUpForBeautyTests.cs"]
+  "files": {
+    "solution": ["BookingUpForBeauty.cs"],
+    "test": ["BookingUpForBeautyTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/booking-up-for-beauty/.meta/config.json
+++ b/languages/csharp/exercises/concept/booking-up-for-beauty/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["BookingUpForBeauty.cs"],
-    "test": ["BookingUpForBeautyTests.cs"]
+    "test": ["BookingUpForBeautyTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/building-telemetry/.meta/config.json
+++ b/languages/csharp/exercises/concept/building-telemetry/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["BuildingTelemetry.cs"],
-    "test": ["BuildingTelemetryTests.cs"]
+    "test": ["BuildingTelemetryTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/building-telemetry/.meta/config.json
+++ b/languages/csharp/exercises/concept/building-telemetry/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["BuildingTelemetry.cs"],
-    "test_files": ["BuildingTelemetryTests.cs"]
+  "files": {
+    "solution": ["BuildingTelemetry.cs"],
+    "test": ["BuildingTelemetryTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/calculator-conundrum/.meta/config.json
+++ b/languages/csharp/exercises/concept/calculator-conundrum/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "archrisV"
     }
   ],
-  "editor": {
-    "solution_files": ["CalculatorConundrum.cs"],
-    "test_files": ["CalculatorConundrumTests.cs"]
+  "files": {
+    "solution": ["CalculatorConundrum.cs"],
+    "test": ["CalculatorConundrumTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/calculator-conundrum/.meta/config.json
+++ b/languages/csharp/exercises/concept/calculator-conundrum/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["CalculatorConundrum.cs"],
-    "test": ["CalculatorConundrumTests.cs"]
+    "test": ["CalculatorConundrumTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/cars-assemble/.meta/config.json
+++ b/languages/csharp/exercises/concept/cars-assemble/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["CarsAssemble.cs"],
-    "test_files": ["CarsAssembleTests.cs"]
+  "files": {
+    "solution": ["CarsAssemble.cs"],
+    "test": ["CarsAssembleTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/cars-assemble/.meta/config.json
+++ b/languages/csharp/exercises/concept/cars-assemble/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["CarsAssemble.cs"],
-    "test": ["CarsAssembleTests.cs"]
+    "test": ["CarsAssembleTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/developer-privileges/.meta/config.json
+++ b/languages/csharp/exercises/concept/developer-privileges/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["WhyCantIPushToMain.cs"],
-    "test": ["WhyCantIPushToMainTests.cs"]
+    "test": ["WhyCantIPushToMainTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/developer-privileges/.meta/config.json
+++ b/languages/csharp/exercises/concept/developer-privileges/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["WhyCantIPushToMain.cs"],
-    "test_files": ["WhyCantIPushToMainTests.cs"]
+  "files": {
+    "solution": ["WhyCantIPushToMain.cs"],
+    "test": ["WhyCantIPushToMainTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/elons-toys/.meta/config.json
+++ b/languages/csharp/exercises/concept/elons-toys/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["ElonsToys.cs"],
-    "test_files": ["ElonsToysTests.cs"]
+  "files": {
+    "solution": ["ElonsToys.cs"],
+    "test": ["ElonsToysTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/elons-toys/.meta/config.json
+++ b/languages/csharp/exercises/concept/elons-toys/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["ElonsToys.cs"],
-    "test": ["ElonsToysTests.cs"]
+    "test": ["ElonsToysTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/faceid-2/.meta/config.json
+++ b/languages/csharp/exercises/concept/faceid-2/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["Faceid2.cs"],
-    "test": ["Faceid2Tests.cs"]
+    "test": ["Faceid2Tests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/faceid-2/.meta/config.json
+++ b/languages/csharp/exercises/concept/faceid-2/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["Faceid2.cs"],
-    "test_files": ["Faceid2Tests.cs"]
+  "files": {
+    "solution": ["Faceid2.cs"],
+    "test": ["Faceid2Tests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/football-match-reports/.meta/config.json
+++ b/languages/csharp/exercises/concept/football-match-reports/.meta/config.json
@@ -15,8 +15,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["FootballMatchReports.cs"],
-    "test_files": ["FootballMatchReportsTests.cs"]
+  "files": {
+    "solution": ["FootballMatchReports.cs"],
+    "test": ["FootballMatchReportsTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/football-match-reports/.meta/config.json
+++ b/languages/csharp/exercises/concept/football-match-reports/.meta/config.json
@@ -17,6 +17,7 @@
   ],
   "files": {
     "solution": ["FootballMatchReports.cs"],
-    "test": ["FootballMatchReportsTests.cs"]
+    "test": ["FootballMatchReportsTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/high-school-sweethearts/.meta/config.json
+++ b/languages/csharp/exercises/concept/high-school-sweethearts/.meta/config.json
@@ -14,6 +14,7 @@
   "forked_from": ["elixir/strings"],
   "files": {
     "solution": ["HighSchoolSweethearts.cs"],
-    "test": ["HighSchoolSweetheartsTests.cs"]
+    "test": ["HighSchoolSweetheartsTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/high-school-sweethearts/.meta/config.json
+++ b/languages/csharp/exercises/concept/high-school-sweethearts/.meta/config.json
@@ -12,8 +12,8 @@
     }
   ],
   "forked_from": ["elixir/strings"],
-  "editor": {
-    "solution_files": ["HighSchoolSweethearts.cs"],
-    "test_files": ["HighSchoolSweetheartsTests.cs"]
+  "files": {
+    "solution": ["HighSchoolSweethearts.cs"],
+    "test": ["HighSchoolSweetheartsTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/hyper-optimized-telemetry/.meta/config.json
+++ b/languages/csharp/exercises/concept/hyper-optimized-telemetry/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["HyperOptimizedTelemetry.cs"],
-    "test": ["HyperOptimizedTelemetryTests.cs"]
+    "test": ["HyperOptimizedTelemetryTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/hyper-optimized-telemetry/.meta/config.json
+++ b/languages/csharp/exercises/concept/hyper-optimized-telemetry/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["HyperOptimizedTelemetry.cs"],
-    "test_files": ["HyperOptimizedTelemetryTests.cs"]
+  "files": {
+    "solution": ["HyperOptimizedTelemetry.cs"],
+    "test": ["HyperOptimizedTelemetryTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/hyperia-forex/.meta/config.json
+++ b/languages/csharp/exercises/concept/hyperia-forex/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["HyperiaForex.cs"],
-    "test_files": ["HyperiaForexTests.cs"]
+  "files": {
+    "solution": ["HyperiaForex.cs"],
+    "test": ["HyperiaForexTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/hyperia-forex/.meta/config.json
+++ b/languages/csharp/exercises/concept/hyperia-forex/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["HyperiaForex.cs"],
-    "test": ["HyperiaForexTests.cs"]
+    "test": ["HyperiaForexTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/hyperinflation-hits-hyperia/.meta/config.json
+++ b/languages/csharp/exercises/concept/hyperinflation-hits-hyperia/.meta/config.json
@@ -23,8 +23,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["HyperinflationHitsHyperia.cs"],
-    "test_files": ["HyperinflationHitsHyperiaTests.cs"]
+  "files": {
+    "solution": ["HyperinflationHitsHyperia.cs"],
+    "test": ["HyperinflationHitsHyperiaTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/hyperinflation-hits-hyperia/.meta/config.json
+++ b/languages/csharp/exercises/concept/hyperinflation-hits-hyperia/.meta/config.json
@@ -25,6 +25,7 @@
   ],
   "files": {
     "solution": ["HyperinflationHitsHyperia.cs"],
-    "test": ["HyperinflationHitsHyperiaTests.cs"]
+    "test": ["HyperinflationHitsHyperiaTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/instruments-of-texas/.meta/config.json
+++ b/languages/csharp/exercises/concept/instruments-of-texas/.meta/config.json
@@ -14,6 +14,7 @@
   "forked_from": ["elixir/errors"],
   "files": {
     "solution": ["InstrumentsOfTexas.cs"],
-    "test": ["InstrumentsOfTexasTests.cs"]
+    "test": ["InstrumentsOfTexasTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/instruments-of-texas/.meta/config.json
+++ b/languages/csharp/exercises/concept/instruments-of-texas/.meta/config.json
@@ -12,8 +12,8 @@
     }
   ],
   "forked_from": ["elixir/errors"],
-  "editor": {
-    "solution_files": ["InstrumentsOfTexas.cs"],
-    "test_files": ["InstrumentsOfTexasTests.cs"]
+  "files": {
+    "solution": ["InstrumentsOfTexas.cs"],
+    "test": ["InstrumentsOfTexasTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/interest-is-interesting/.meta/config.json
+++ b/languages/csharp/exercises/concept/interest-is-interesting/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["InterestIsInteresting.cs"],
-    "test_files": ["InterestIsInterestingTests.cs"]
+  "files": {
+    "solution": ["InterestIsInteresting.cs"],
+    "test": ["InterestIsInterestingTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/interest-is-interesting/.meta/config.json
+++ b/languages/csharp/exercises/concept/interest-is-interesting/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["InterestIsInteresting.cs"],
-    "test": ["InterestIsInterestingTests.cs"]
+    "test": ["InterestIsInterestingTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/international-calling-connoisseur/.meta/config.json
+++ b/languages/csharp/exercises/concept/international-calling-connoisseur/.meta/config.json
@@ -15,8 +15,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["InternationalCallingConnoisseur.cs"],
-    "test_files": ["InternationalCallingConnoisseurTests.cs"]
+  "files": {
+    "solution": ["InternationalCallingConnoisseur.cs"],
+    "test": ["InternationalCallingConnoisseurTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/international-calling-connoisseur/.meta/config.json
+++ b/languages/csharp/exercises/concept/international-calling-connoisseur/.meta/config.json
@@ -17,6 +17,7 @@
   ],
   "files": {
     "solution": ["InternationalCallingConnoisseur.cs"],
-    "test": ["InternationalCallingConnoisseurTests.cs"]
+    "test": ["InternationalCallingConnoisseurTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/land-grab-in-space/.meta/config.json
+++ b/languages/csharp/exercises/concept/land-grab-in-space/.meta/config.json
@@ -21,6 +21,7 @@
   ],
   "files": {
     "solution": ["LandGrabInSpace.cs"],
-    "test": ["LandGrabInSpaceTests.cs"]
+    "test": ["LandGrabInSpaceTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/land-grab-in-space/.meta/config.json
+++ b/languages/csharp/exercises/concept/land-grab-in-space/.meta/config.json
@@ -19,8 +19,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["LandGrabInSpace.cs"],
-    "test_files": ["LandGrabInSpaceTests.cs"]
+  "files": {
+    "solution": ["LandGrabInSpace.cs"],
+    "test": ["LandGrabInSpaceTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/log-levels/.meta/config.json
+++ b/languages/csharp/exercises/concept/log-levels/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["LogLevels.cs"],
-    "test_files": ["LogLevelsTests.cs"]
+  "files": {
+    "solution": ["LogLevels.cs"],
+    "test": ["LogLevelsTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/log-levels/.meta/config.json
+++ b/languages/csharp/exercises/concept/log-levels/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["LogLevels.cs"],
-    "test": ["LogLevelsTests.cs"]
+    "test": ["LogLevelsTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/logs-logs-logs/.meta/config.json
+++ b/languages/csharp/exercises/concept/logs-logs-logs/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["LogsLogsLogs.cs"],
-    "test": ["LogsLogsLogsTests.cs"]
+    "test": ["LogsLogsLogsTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/logs-logs-logs/.meta/config.json
+++ b/languages/csharp/exercises/concept/logs-logs-logs/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["LogsLogsLogs.cs"],
-    "test_files": ["LogsLogsLogsTests.cs"]
+  "files": {
+    "solution": ["LogsLogsLogs.cs"],
+    "test": ["LogsLogsLogsTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/languages/csharp/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["fsharp/basics"],
   "files": {
     "solution": ["LuciansLusciousLasagna.cs"],
-    "test": ["LuciansLusciousLasagnaTests.cs"]
+    "test": ["LuciansLusciousLasagnaTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/languages/csharp/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["fsharp/basics"],
-  "editor": {
-    "solution_files": ["LuciansLusciousLasagna.cs"],
-    "test_files": ["LuciansLusciousLasagnaTests.cs"]
+  "files": {
+    "solution": ["LuciansLusciousLasagna.cs"],
+    "test": ["LuciansLusciousLasagnaTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/need-for-speed/.meta/config.json
+++ b/languages/csharp/exercises/concept/need-for-speed/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["NeedForSpeed.cs"],
-    "test": ["NeedForSpeedTests.cs"]
+    "test": ["NeedForSpeedTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/need-for-speed/.meta/config.json
+++ b/languages/csharp/exercises/concept/need-for-speed/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["NeedForSpeed.cs"],
-    "test_files": ["NeedForSpeedTests.cs"]
+  "files": {
+    "solution": ["NeedForSpeed.cs"],
+    "test": ["NeedForSpeedTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/object-relational-mapping/.meta/config.json
+++ b/languages/csharp/exercises/concept/object-relational-mapping/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["ObjectRelationalMapping.cs"],
-    "test": ["ObjectRelationalMappingTests.cs"]
+    "test": ["ObjectRelationalMappingTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/object-relational-mapping/.meta/config.json
+++ b/languages/csharp/exercises/concept/object-relational-mapping/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["ObjectRelationalMapping.cs"],
-    "test_files": ["ObjectRelationalMappingTests.cs"]
+  "files": {
+    "solution": ["ObjectRelationalMapping.cs"],
+    "test": ["ObjectRelationalMappingTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/orm-in-one-go/.meta/config.json
+++ b/languages/csharp/exercises/concept/orm-in-one-go/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["OrmInOneGo.cs"],
-    "test": ["OrmInOneGoTests.cs"]
+    "test": ["OrmInOneGoTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/orm-in-one-go/.meta/config.json
+++ b/languages/csharp/exercises/concept/orm-in-one-go/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["OrmInOneGo.cs"],
-    "test_files": ["OrmInOneGoTests.cs"]
+  "files": {
+    "solution": ["OrmInOneGo.cs"],
+    "test": ["OrmInOneGoTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/parsing-log-files/.meta/config.json
+++ b/languages/csharp/exercises/concept/parsing-log-files/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["ParsingLogFiles.cs"],
-    "test": ["ParsingLogFilesTests.cs"]
+    "test": ["ParsingLogFilesTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/parsing-log-files/.meta/config.json
+++ b/languages/csharp/exercises/concept/parsing-log-files/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["ParsingLogFiles.cs"],
-    "test_files": ["ParsingLogFilesTests.cs"]
+  "files": {
+    "solution": ["ParsingLogFiles.cs"],
+    "test": ["ParsingLogFilesTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/phone-number-analysis/.meta/config.json
+++ b/languages/csharp/exercises/concept/phone-number-analysis/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["PhoneNumberAnalysis.cs"],
-    "test_files": ["PhoneNumberAnalysisTests.cs"]
+  "files": {
+    "solution": ["PhoneNumberAnalysis.cs"],
+    "test": ["PhoneNumberAnalysisTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/phone-number-analysis/.meta/config.json
+++ b/languages/csharp/exercises/concept/phone-number-analysis/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["PhoneNumberAnalysis.cs"],
-    "test": ["PhoneNumberAnalysisTests.cs"]
+    "test": ["PhoneNumberAnalysisTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/red-vs-blue-darwin-style/.meta/config.json
+++ b/languages/csharp/exercises/concept/red-vs-blue-darwin-style/.meta/config.json
@@ -15,8 +15,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["RedVsBlueDarwinStyle.cs"],
-    "test_files": ["RedVsBlueDarwinStyleTests.cs"]
+  "files": {
+    "solution": ["RedVsBlueDarwinStyle.cs"],
+    "test": ["RedVsBlueDarwinStyleTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/red-vs-blue-darwin-style/.meta/config.json
+++ b/languages/csharp/exercises/concept/red-vs-blue-darwin-style/.meta/config.json
@@ -17,6 +17,7 @@
   ],
   "files": {
     "solution": ["RedVsBlueDarwinStyle.cs"],
-    "test": ["RedVsBlueDarwinStyleTests.cs"]
+    "test": ["RedVsBlueDarwinStyleTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/remote-control-cleanup/.meta/config.json
+++ b/languages/csharp/exercises/concept/remote-control-cleanup/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["RemoteControlCleanup.cs"],
-    "test": ["RemoteControlCleanupTests.cs"]
+    "test": ["RemoteControlCleanupTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/remote-control-cleanup/.meta/config.json
+++ b/languages/csharp/exercises/concept/remote-control-cleanup/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["RemoteControlCleanup.cs"],
-    "test_files": ["RemoteControlCleanupTests.cs"]
+  "files": {
+    "solution": ["RemoteControlCleanup.cs"],
+    "test": ["RemoteControlCleanupTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/remote-control-competition/.meta/config.json
+++ b/languages/csharp/exercises/concept/remote-control-competition/.meta/config.json
@@ -15,8 +15,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["RemoteControlCompetition.cs"],
-    "test_files": ["RemoteControlCompetitionTests.cs"]
+  "files": {
+    "solution": ["RemoteControlCompetition.cs"],
+    "test": ["RemoteControlCompetitionTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/remote-control-competition/.meta/config.json
+++ b/languages/csharp/exercises/concept/remote-control-competition/.meta/config.json
@@ -17,6 +17,7 @@
   ],
   "files": {
     "solution": ["RemoteControlCompetition.cs"],
-    "test": ["RemoteControlCompetitionTests.cs"]
+    "test": ["RemoteControlCompetitionTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/roll-the-die/.meta/config.json
+++ b/languages/csharp/exercises/concept/roll-the-die/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["RollTheDie.cs"],
-    "test": ["RollTheDieTests.cs"]
+    "test": ["RollTheDieTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/roll-the-die/.meta/config.json
+++ b/languages/csharp/exercises/concept/roll-the-die/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["RollTheDie.cs"],
-    "test_files": ["RollTheDieTests.cs"]
+  "files": {
+    "solution": ["RollTheDie.cs"],
+    "test": ["RollTheDieTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/secure-munchester-united/.meta/config.json
+++ b/languages/csharp/exercises/concept/secure-munchester-united/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["SecureMunchesterUnited.cs"],
-    "test_files": ["SecureMunchesterUnitedTests.cs"]
+  "files": {
+    "solution": ["SecureMunchesterUnited.cs"],
+    "test": ["SecureMunchesterUnitedTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/secure-munchester-united/.meta/config.json
+++ b/languages/csharp/exercises/concept/secure-munchester-united/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["SecureMunchesterUnited.cs"],
-    "test": ["SecureMunchesterUnitedTests.cs"]
+    "test": ["SecureMunchesterUnitedTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/squeaky-clean/.meta/config.json
+++ b/languages/csharp/exercises/concept/squeaky-clean/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["SqueakyClean.cs"],
-    "test_files": ["SqueakyCleanTests.cs"]
+  "files": {
+    "solution": ["SqueakyClean.cs"],
+    "test": ["SqueakyCleanTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/squeaky-clean/.meta/config.json
+++ b/languages/csharp/exercises/concept/squeaky-clean/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["SqueakyClean.cs"],
-    "test": ["SqueakyCleanTests.cs"]
+    "test": ["SqueakyCleanTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/the-weather-in-deather/.meta/config.json
+++ b/languages/csharp/exercises/concept/the-weather-in-deather/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["TheWeatherInDeather.cs"],
-    "test": ["TheWeatherInDeatherTests.cs"]
+    "test": ["TheWeatherInDeatherTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/the-weather-in-deather/.meta/config.json
+++ b/languages/csharp/exercises/concept/the-weather-in-deather/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["TheWeatherInDeather.cs"],
-    "test_files": ["TheWeatherInDeatherTests.cs"]
+  "files": {
+    "solution": ["TheWeatherInDeather.cs"],
+    "test": ["TheWeatherInDeatherTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/tim-from-marketing/.meta/config.json
+++ b/languages/csharp/exercises/concept/tim-from-marketing/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "maurelio1234"
     }
   ],
-  "editor": {
-    "solution_files": ["TimFromMarketing.cs"],
-    "test_files": ["TimFromMarketingTests.cs"]
+  "files": {
+    "solution": ["TimFromMarketing.cs"],
+    "test": ["TimFromMarketingTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/tim-from-marketing/.meta/config.json
+++ b/languages/csharp/exercises/concept/tim-from-marketing/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["TimFromMarketing.cs"],
-    "test": ["TimFromMarketingTests.cs"]
+    "test": ["TimFromMarketingTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
+++ b/languages/csharp/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
@@ -12,8 +12,8 @@
     }
   ],
   "forked_from": ["fsharp/lists"],
-  "editor": {
-    "solution_files": ["TracksOnTracksOnTracks.cs"],
-    "test_files": ["TracksOnTracksOnTracksTests.cs"]
+  "files": {
+    "solution": ["TracksOnTracksOnTracks.cs"],
+    "test": ["TracksOnTracksOnTracksTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
+++ b/languages/csharp/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
@@ -14,6 +14,7 @@
   "forked_from": ["fsharp/lists"],
   "files": {
     "solution": ["TracksOnTracksOnTracks.cs"],
-    "test": ["TracksOnTracksOnTracksTests.cs"]
+    "test": ["TracksOnTracksOnTracksTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/weighing-machine/.meta/config.json
+++ b/languages/csharp/exercises/concept/weighing-machine/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["WeighingMachine.cs"],
-    "test_files": ["WeighingMachineTests.cs"]
+  "files": {
+    "solution": ["WeighingMachine.cs"],
+    "test": ["WeighingMachineTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/weighing-machine/.meta/config.json
+++ b/languages/csharp/exercises/concept/weighing-machine/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["WeighingMachine.cs"],
-    "test": ["WeighingMachineTests.cs"]
+    "test": ["WeighingMachineTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/wizards-and-warriors-2/.meta/config.json
+++ b/languages/csharp/exercises/concept/wizards-and-warriors-2/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["WizardsAndWarriors2.cs"],
-    "test": ["WizardsAndWarriors2Tests.cs"]
+    "test": ["WizardsAndWarriors2Tests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/wizards-and-warriors-2/.meta/config.json
+++ b/languages/csharp/exercises/concept/wizards-and-warriors-2/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["WizardsAndWarriors2.cs"],
-    "test_files": ["WizardsAndWarriors2Tests.cs"]
+  "files": {
+    "solution": ["WizardsAndWarriors2.cs"],
+    "test": ["WizardsAndWarriors2Tests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/wizards-and-warriors/.meta/config.json
+++ b/languages/csharp/exercises/concept/wizards-and-warriors/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["WizardsAndWarriors.cs"],
-    "test_files": ["WizardsAndWarriorsTests.cs"]
+  "files": {
+    "solution": ["WizardsAndWarriors.cs"],
+    "test": ["WizardsAndWarriorsTests.cs"]
   }
 }

--- a/languages/csharp/exercises/concept/wizards-and-warriors/.meta/config.json
+++ b/languages/csharp/exercises/concept/wizards-and-warriors/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["WizardsAndWarriors.cs"],
-    "test": ["WizardsAndWarriorsTests.cs"]
+    "test": ["WizardsAndWarriorsTests.cs"],
+    "exemplar": [".meta/Exemplar.cs"]
   }
 }

--- a/languages/elixir/exercises/concept/basketball-website/.meta/config.json
+++ b/languages/elixir/exercises/concept/basketball-website/.meta/config.json
@@ -15,9 +15,9 @@
       "exercism_username": "NobbZ"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/basketball_website.ex"],
-    "test_files": ["test/basketball_website_test.exs"]
+  "files": {
+    "solution": ["lib/basketball_website.ex"],
+    "test": ["test/basketball_website_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/basketball-website/.meta/config.json
+++ b/languages/elixir/exercises/concept/basketball-website/.meta/config.json
@@ -17,7 +17,8 @@
   ],
   "files": {
     "solution": ["lib/basketball_website.ex"],
-    "test": ["test/basketball_website_test.exs"]
+    "test": ["test/basketball_website_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/bird-count/.meta/config.json
+++ b/languages/elixir/exercises/concept/bird-count/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/bird_count.ex"],
-    "test_files": ["test/bird_count_test.exs"]
+  "files": {
+    "solution": ["lib/bird_count.ex"],
+    "test": ["test/bird_count_test.exs"]
   },
   "forked_from": ["csharp/arrays"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/bird-count/.meta/config.json
+++ b/languages/elixir/exercises/concept/bird-count/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/bird_count.ex"],
-    "test": ["test/bird_count_test.exs"]
+    "test": ["test/bird_count_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "forked_from": ["csharp/arrays"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/boutique-inventory/.meta/config.json
+++ b/languages/elixir/exercises/concept/boutique-inventory/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/boutique_inventory.ex"],
-    "test_files": ["test/boutique_inventory_test.exs"]
+  "files": {
+    "solution": ["lib/boutique_inventory.ex"],
+    "test": ["test/boutique_inventory_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/boutique-inventory/.meta/config.json
+++ b/languages/elixir/exercises/concept/boutique-inventory/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/boutique_inventory.ex"],
-    "test": ["test/boutique_inventory_test.exs"]
+    "test": ["test/boutique_inventory_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/boutique-suggestions/.meta/config.json
+++ b/languages/elixir/exercises/concept/boutique-suggestions/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/boutique_suggestions.ex"],
-    "test": ["test/boutique_suggestions_test.exs"]
+    "test": ["test/boutique_suggestions_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/boutique-suggestions/.meta/config.json
+++ b/languages/elixir/exercises/concept/boutique-suggestions/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "angelikatyborska"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/boutique_suggestions.ex"],
-    "test_files": ["test/boutique_suggestions_test.exs"]
+  "files": {
+    "solution": ["lib/boutique_suggestions.ex"],
+    "test": ["test/boutique_suggestions_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/bread-and-potions/.meta/config.json
+++ b/languages/elixir/exercises/concept/bread-and-potions/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/rpg.ex"],
-    "test": ["test/rpg_test.exs"]
+    "test": ["test/rpg_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/bread-and-potions/.meta/config.json
+++ b/languages/elixir/exercises/concept/bread-and-potions/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/rpg.ex"],
-    "test_files": ["test/rpg_test.exs"]
+  "files": {
+    "solution": ["lib/rpg.ex"],
+    "test": ["test/rpg_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/captains-log/.meta/config.json
+++ b/languages/elixir/exercises/concept/captains-log/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/captains_log.ex"],
-    "test_files": ["test/captains_log_test.exs"]
+  "files": {
+    "solution": ["lib/captains_log.ex"],
+    "test": ["test/captains_log_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/captains-log/.meta/config.json
+++ b/languages/elixir/exercises/concept/captains-log/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/captains_log.ex"],
-    "test": ["test/captains_log_test.exs"]
+    "test": ["test/captains_log_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/chessboard/.meta/config.json
+++ b/languages/elixir/exercises/concept/chessboard/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/chessboard.ex"],
-    "test_files": ["test/chessboard_test.exs"]
+  "files": {
+    "solution": ["lib/chessboard.ex"],
+    "test": ["test/chessboard_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/chessboard/.meta/config.json
+++ b/languages/elixir/exercises/concept/chessboard/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/chessboard.ex"],
-    "test": ["test/chessboard_test.exs"]
+    "test": ["test/chessboard_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/community-garden/.meta/config.json
+++ b/languages/elixir/exercises/concept/community-garden/.meta/config.json
@@ -21,7 +21,8 @@
   ],
   "files": {
     "solution": ["lib/community_garden.ex"],
-    "test": ["test/community_garden_test.exs"]
+    "test": ["test/community_garden_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/community-garden/.meta/config.json
+++ b/languages/elixir/exercises/concept/community-garden/.meta/config.json
@@ -19,9 +19,9 @@
       "exercism_username": "efx"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/community_garden.ex"],
-    "test_files": ["test/community_garden_test.exs"]
+  "files": {
+    "solution": ["lib/community_garden.ex"],
+    "test": ["test/community_garden_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/date-parser/.meta/config.json
+++ b/languages/elixir/exercises/concept/date-parser/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/date_parser.ex"],
-    "test": ["test/date_parser_test.exs"]
+    "test": ["test/date_parser_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/date-parser/.meta/config.json
+++ b/languages/elixir/exercises/concept/date-parser/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "angelikatyborska"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/date_parser.ex"],
-    "test_files": ["test/date_parser_test.exs"]
+  "files": {
+    "solution": ["lib/date_parser.ex"],
+    "test": ["test/date_parser_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/dna-encoding/.meta/config.json
+++ b/languages/elixir/exercises/concept/dna-encoding/.meta/config.json
@@ -15,9 +15,9 @@
       "exercism_username": "NobbZ"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/dna.ex"],
-    "test_files": ["test/dna_test.exs"]
+  "files": {
+    "solution": ["lib/dna.ex"],
+    "test": ["test/dna_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/dna-encoding/.meta/config.json
+++ b/languages/elixir/exercises/concept/dna-encoding/.meta/config.json
@@ -17,7 +17,8 @@
   ],
   "files": {
     "solution": ["lib/dna.ex"],
-    "test": ["test/dna_test.exs"]
+    "test": ["test/dna_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/file-sniffer/.meta/config.json
+++ b/languages/elixir/exercises/concept/file-sniffer/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/file_sniffer.ex"],
-    "test": ["test/file_sniffer_test.exs"]
+    "test": ["test/file_sniffer_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/file-sniffer/.meta/config.json
+++ b/languages/elixir/exercises/concept/file-sniffer/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "angelikatyborska"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/file_sniffer.ex"],
-    "test_files": ["test/file_sniffer_test.exs"]
+  "files": {
+    "solution": ["lib/file_sniffer.ex"],
+    "test": ["test/file_sniffer_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/freelancer-rates/.meta/config.json
+++ b/languages/elixir/exercises/concept/freelancer-rates/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/freelancer_rates.ex"],
-    "test": ["test/freelancer_rates_test.exs"]
+    "test": ["test/freelancer_rates_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "forked_from": ["javascript/numbers"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/freelancer-rates/.meta/config.json
+++ b/languages/elixir/exercises/concept/freelancer-rates/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/freelancer_rates.ex"],
-    "test_files": ["test/freelancer_rates_test.exs"]
+  "files": {
+    "solution": ["lib/freelancer_rates.ex"],
+    "test": ["test/freelancer_rates_test.exs"]
   },
   "forked_from": ["javascript/numbers"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/german-sysadmin/.meta/config.json
+++ b/languages/elixir/exercises/concept/german-sysadmin/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/username.ex"],
-    "test": ["test/username_test.exs"]
+    "test": ["test/username_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/german-sysadmin/.meta/config.json
+++ b/languages/elixir/exercises/concept/german-sysadmin/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/username.ex"],
-    "test_files": ["test/username_test.exs"]
+  "files": {
+    "solution": ["lib/username.ex"],
+    "test": ["test/username_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/guessing-game/.meta/config.json
+++ b/languages/elixir/exercises/concept/guessing-game/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/guessing_game.ex"],
-    "test": ["test/guessing_game_test.exs"]
+    "test": ["test/guessing_game_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "forked_from": ["fsharp/pattern-matching"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/guessing-game/.meta/config.json
+++ b/languages/elixir/exercises/concept/guessing-game/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "angelikatyborska"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/guessing_game.ex"],
-    "test_files": ["test/guessing_game_test.exs"]
+  "files": {
+    "solution": ["lib/guessing_game.ex"],
+    "test": ["test/guessing_game_test.exs"]
   },
   "forked_from": ["fsharp/pattern-matching"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/high-school-sweetheart/.meta/config.json
+++ b/languages/elixir/exercises/concept/high-school-sweetheart/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/high_school_sweetheart.ex"],
-    "test_files": ["test/high_school_sweetheart_test.exs"]
+  "files": {
+    "solution": ["lib/high_school_sweetheart.ex"],
+    "test": ["test/high_school_sweetheart_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/high-school-sweetheart/.meta/config.json
+++ b/languages/elixir/exercises/concept/high-school-sweetheart/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/high_school_sweetheart.ex"],
-    "test": ["test/high_school_sweetheart_test.exs"]
+    "test": ["test/high_school_sweetheart_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/high-score/.meta/config.json
+++ b/languages/elixir/exercises/concept/high-score/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["lib/high_score.ex"],
-    "test": ["test/high_score_test.exs"]
+    "test": ["test/high_score_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/high-score/.meta/config.json
+++ b/languages/elixir/exercises/concept/high-score/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/high_score.ex"],
-    "test_files": ["test/high_score_test.exs"]
+  "files": {
+    "solution": ["lib/high_score.ex"],
+    "test": ["test/high_score_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/kitchen-calculator/.meta/config.json
+++ b/languages/elixir/exercises/concept/kitchen-calculator/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/kitchen_calculator.ex"],
-    "test": ["test/kitchen_calculator_test.exs"]
+    "test": ["test/kitchen_calculator_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/kitchen-calculator/.meta/config.json
+++ b/languages/elixir/exercises/concept/kitchen-calculator/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "angelikatyborska"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/kitchen_calculator.ex"],
-    "test_files": ["test/kitchen_calculator_test.exs"]
+  "files": {
+    "solution": ["lib/kitchen_calculator.ex"],
+    "test": ["test/kitchen_calculator_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/language-list/.meta/config.json
+++ b/languages/elixir/exercises/concept/language-list/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/language_list.ex"],
-    "test": ["test/language_list_test.exs"]
+    "test": ["test/language_list_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "forked_from": ["clojure/lists"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/language-list/.meta/config.json
+++ b/languages/elixir/exercises/concept/language-list/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "fireproofsocks"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/language_list.ex"],
-    "test_files": ["test/language_list_test.exs"]
+  "files": {
+    "solution": ["lib/language_list.ex"],
+    "test": ["test/language_list_test.exs"]
   },
   "forked_from": ["clojure/lists"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/lasagna/.meta/config.json
+++ b/languages/elixir/exercises/concept/lasagna/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "angelikatyborska"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/lasagna.ex"],
-    "test_files": ["test/lasagna_test.exs"]
+  "files": {
+    "solution": ["lib/lasagna.ex"],
+    "test": ["test/lasagna_test.exs"]
   },
   "forked_from": ["csharp/basics"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/lasagna/.meta/config.json
+++ b/languages/elixir/exercises/concept/lasagna/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/lasagna.ex"],
-    "test": ["test/lasagna_test.exs"]
+    "test": ["test/lasagna_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "forked_from": ["csharp/basics"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/log-level/.meta/config.json
+++ b/languages/elixir/exercises/concept/log-level/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["lib/log_level.ex"],
-    "test": ["test/log_level_test.exs"]
+    "test": ["test/log_level_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "forked_from": ["csharp/enums"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/log-level/.meta/config.json
+++ b/languages/elixir/exercises/concept/log-level/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/log_level.ex"],
-    "test_files": ["test/log_level_test.exs"]
+  "files": {
+    "solution": ["lib/log_level.ex"],
+    "test": ["test/log_level_test.exs"]
   },
   "forked_from": ["csharp/enums"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/mensch-aergere-dich-nicht/.meta/config.json
+++ b/languages/elixir/exercises/concept/mensch-aergere-dich-nicht/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/mensch_aergere_dich_nicht.ex"],
-    "test": ["test/mensch_aergere_dich_nicht_test.exs"]
+    "test": ["test/mensch_aergere_dich_nicht_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/mensch-aergere-dich-nicht/.meta/config.json
+++ b/languages/elixir/exercises/concept/mensch-aergere-dich-nicht/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/mensch_aergere_dich_nicht.ex"],
-    "test_files": ["test/mensch_aergere_dich_nicht_test.exs"]
+  "files": {
+    "solution": ["lib/mensch_aergere_dich_nicht.ex"],
+    "test": ["test/mensch_aergere_dich_nicht_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/name-badge/.meta/config.json
+++ b/languages/elixir/exercises/concept/name-badge/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/name_badge.ex"],
-    "test_files": ["test/name_badge_test.exs"]
+  "files": {
+    "solution": ["lib/name_badge.ex"],
+    "test": ["test/name_badge_test.exs"]
   },
   "forked_from": ["csharp/nullability"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/name-badge/.meta/config.json
+++ b/languages/elixir/exercises/concept/name-badge/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/name_badge.ex"],
-    "test": ["test/name_badge_test.exs"]
+    "test": ["test/name_badge_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "forked_from": ["csharp/nullability"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/newsletter/.meta/config.json
+++ b/languages/elixir/exercises/concept/newsletter/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "angelikatyborska"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/newsletter.ex"],
-    "test_files": ["test/newsletter_test.exs"]
+  "files": {
+    "solution": ["lib/newsletter.ex"],
+    "test": ["test/newsletter_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/newsletter/.meta/config.json
+++ b/languages/elixir/exercises/concept/newsletter/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["lib/newsletter.ex"],
-    "test": ["test/newsletter_test.exs"]
+    "test": ["test/newsletter_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/pacman-rules/.meta/config.json
+++ b/languages/elixir/exercises/concept/pacman-rules/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "Cohen-Carlisle"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/rules.ex"],
-    "test_files": ["test/rules_test.exs"]
+  "files": {
+    "solution": ["lib/rules.ex"],
+    "test": ["test/rules_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/pacman-rules/.meta/config.json
+++ b/languages/elixir/exercises/concept/pacman-rules/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/rules.ex"],
-    "test": ["test/rules_test.exs"]
+    "test": ["test/rules_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/remote-control-car/.meta/config.json
+++ b/languages/elixir/exercises/concept/remote-control-car/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/remote_control_car.ex"],
-    "test": ["test/remote_control_car_test.exs"]
+    "test": ["test/remote_control_car_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "forked_from": ["csharp/classes"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/remote-control-car/.meta/config.json
+++ b/languages/elixir/exercises/concept/remote-control-car/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "angelikatyborska"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/remote_control_car.ex"],
-    "test_files": ["test/remote_control_car_test.exs"]
+  "files": {
+    "solution": ["lib/remote_control_car.ex"],
+    "test": ["test/remote_control_car_test.exs"]
   },
   "forked_from": ["csharp/classes"],
   "language_versions": ">=1.10"

--- a/languages/elixir/exercises/concept/rpg-character-sheet/.meta/config.json
+++ b/languages/elixir/exercises/concept/rpg-character-sheet/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/rpg/character_sheet.ex"],
-    "test_files": ["test/rpg/character_sheet_test.exs"]
+  "files": {
+    "solution": ["lib/rpg/character_sheet.ex"],
+    "test": ["test/rpg/character_sheet_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/rpg-character-sheet/.meta/config.json
+++ b/languages/elixir/exercises/concept/rpg-character-sheet/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/rpg/character_sheet.ex"],
-    "test": ["test/rpg/character_sheet_test.exs"]
+    "test": ["test/rpg/character_sheet_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/rpn-calculator-output/.meta/config.json
+++ b/languages/elixir/exercises/concept/rpn-calculator-output/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "angelikatyborska"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/rpn_calculator/output.ex"],
-    "test_files": ["test/rpn_calculator/output_test.exs"]
+  "files": {
+    "solution": ["lib/rpn_calculator/output.ex"],
+    "test": ["test/rpn_calculator/output_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/rpn-calculator-output/.meta/config.json
+++ b/languages/elixir/exercises/concept/rpn-calculator-output/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/rpn_calculator/output.ex"],
-    "test": ["test/rpn_calculator/output_test.exs"]
+    "test": ["test/rpn_calculator/output_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/rpn-calculator/.meta/config.json
+++ b/languages/elixir/exercises/concept/rpn-calculator/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/rpn_calculator.ex"],
-    "test": ["test/rpn_calculator_test.exs"]
+    "test": ["test/rpn_calculator_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/rpn-calculator/.meta/config.json
+++ b/languages/elixir/exercises/concept/rpn-calculator/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "angelikatyborska"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/rpn_calculator.ex"],
-    "test_files": ["test/rpn_calculator_test.exs"]
+  "files": {
+    "solution": ["lib/rpn_calculator.ex"],
+    "test": ["test/rpn_calculator_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/secrets/.meta/config.json
+++ b/languages/elixir/exercises/concept/secrets/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["lib/secrets.ex"],
-    "test": ["test/secrets_test.exs"]
+    "test": ["test/secrets_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/secrets/.meta/config.json
+++ b/languages/elixir/exercises/concept/secrets/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/secrets.ex"],
-    "test_files": ["test/secrets_test.exs"]
+  "files": {
+    "solution": ["lib/secrets.ex"],
+    "test": ["test/secrets_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/stack-underflow/.meta/config.json
+++ b/languages/elixir/exercises/concept/stack-underflow/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/rpn_calculator/exception.ex"],
-    "test": ["test/rpn_calculator/exception_test.exs"]
+    "test": ["test/rpn_calculator/exception_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/stack-underflow/.meta/config.json
+++ b/languages/elixir/exercises/concept/stack-underflow/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "angelikatyborska"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/rpn_calculator/exception.ex"],
-    "test_files": ["test/rpn_calculator/exception_test.exs"]
+  "files": {
+    "solution": ["lib/rpn_calculator/exception.ex"],
+    "test": ["test/rpn_calculator/exception_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/take-a-number/.meta/config.json
+++ b/languages/elixir/exercises/concept/take-a-number/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/take_a_number.ex"],
-    "test": ["test/take_a_number_test.exs"]
+    "test": ["test/take_a_number_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/take-a-number/.meta/config.json
+++ b/languages/elixir/exercises/concept/take-a-number/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/take_a_number.ex"],
-    "test_files": ["test/take_a_number_test.exs"]
+  "files": {
+    "solution": ["lib/take_a_number.ex"],
+    "test": ["test/take_a_number_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/wine-cellar/.meta/config.json
+++ b/languages/elixir/exercises/concept/wine-cellar/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["lib/wine_cellar.ex"],
-    "test_files": ["test/wine_cellar_test.exs"]
+  "files": {
+    "solution": ["lib/wine_cellar.ex"],
+    "test": ["test/wine_cellar_test.exs"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elixir/exercises/concept/wine-cellar/.meta/config.json
+++ b/languages/elixir/exercises/concept/wine-cellar/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["lib/wine_cellar.ex"],
-    "test": ["test/wine_cellar_test.exs"]
+    "test": ["test/wine_cellar_test.exs"],
+    "exemplar": [".meta/exemplar.ex"]
   },
   "language_versions": ">=1.10"
 }

--- a/languages/elm/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/languages/elm/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -12,6 +12,7 @@
   "forked_from": ["fsharp/lucians-luscious-lasagna"],
   "files": {
     "solution": ["src/Cook.elm"],
-    "test": ["tests/Tests.elm"]
+    "test": ["tests/Tests.elm"],
+    "exemplar": [".meta/Exemplar.elm"]
   }
 }

--- a/languages/elm/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/languages/elm/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -10,8 +10,8 @@
     }
   ],
   "forked_from": ["fsharp/lucians-luscious-lasagna"],
-  "editor": {
-    "solution_files": ["src/Cook.elm"],
-    "test_files": ["tests/Tests.elm"]
+  "files": {
+    "solution": ["src/Cook.elm"],
+    "test": ["tests/Tests.elm"]
   }
 }

--- a/languages/fsharp/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/languages/fsharp/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["javascript/booleans"],
   "files": {
     "solution": ["AnnalynsInfiltration.fs"],
-    "test": ["AnnalynsInfiltrationTests.fs"]
+    "test": ["AnnalynsInfiltrationTests.fs"],
+    "exemplar": [".meta/Exemplar.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/languages/fsharp/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["javascript/booleans"],
-  "editor": {
-    "solution_files": ["AnnalynsInfiltration.fs"],
-    "test_files": ["AnnalynsInfiltrationTests.fs"]
+  "files": {
+    "solution": ["AnnalynsInfiltration.fs"],
+    "test": ["AnnalynsInfiltrationTests.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/bandwagoner/.meta/config.json
+++ b/languages/fsharp/exercises/concept/bandwagoner/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["Bandwagoner.fs"],
-    "test": ["BandwagonerTests.fs"]
+    "test": ["BandwagonerTests.fs"],
+    "exemplar": [".meta/Exemplar.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/bandwagoner/.meta/config.json
+++ b/languages/fsharp/exercises/concept/bandwagoner/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["Bandwagoner.fs"],
-    "test_files": ["BandwagonerTests.fs"]
+  "files": {
+    "solution": ["Bandwagoner.fs"],
+    "test": ["BandwagonerTests.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/bird-watcher/.meta/config.json
+++ b/languages/fsharp/exercises/concept/bird-watcher/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["csharp/arrays"],
-  "editor": {
-    "solution_files": ["BirdWatcher.fs"],
-    "test_files": ["BirdWatcherTests.fs"]
+  "files": {
+    "solution": ["BirdWatcher.fs"],
+    "test": ["BirdWatcherTests.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/bird-watcher/.meta/config.json
+++ b/languages/fsharp/exercises/concept/bird-watcher/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/arrays"],
   "files": {
     "solution": ["BirdWatcher.fs"],
-    "test": ["BirdWatcherTests.fs"]
+    "test": ["BirdWatcherTests.fs"],
+    "exemplar": [".meta/Exemplar.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/booking-up-for-beauty/.meta/config.json
+++ b/languages/fsharp/exercises/concept/booking-up-for-beauty/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["csharp/datetimes"],
-  "editor": {
-    "solution_files": ["BookingUpForBeauty.fs"],
-    "test_files": ["BookingUpForBeautyTests.fs"]
+  "files": {
+    "solution": ["BookingUpForBeauty.fs"],
+    "test": ["BookingUpForBeautyTests.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/booking-up-for-beauty/.meta/config.json
+++ b/languages/fsharp/exercises/concept/booking-up-for-beauty/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/datetimes"],
   "files": {
     "solution": ["BookingUpForBeauty.fs"],
-    "test": ["BookingUpForBeautyTests.fs"]
+    "test": ["BookingUpForBeautyTests.fs"],
+    "exemplar": [".meta/Exemplar.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/cars-assemble/.meta/config.json
+++ b/languages/fsharp/exercises/concept/cars-assemble/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["csharp/numbers"],
-  "editor": {
-    "solution_files": ["CarsAssemble.fs"],
-    "test_files": ["CarsAssembleTests.fs"]
+  "files": {
+    "solution": ["CarsAssemble.fs"],
+    "test": ["CarsAssembleTests.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/cars-assemble/.meta/config.json
+++ b/languages/fsharp/exercises/concept/cars-assemble/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/numbers"],
   "files": {
     "solution": ["CarsAssemble.fs"],
-    "test": ["CarsAssembleTests.fs"]
+    "test": ["CarsAssembleTests.fs"],
+    "exemplar": [".meta/Exemplar.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/guessing-game/.meta/config.json
+++ b/languages/fsharp/exercises/concept/guessing-game/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["GuessingGame.fs"],
-    "test": ["GuessingGameTests.fs"]
+    "test": ["GuessingGameTests.fs"],
+    "exemplar": [".meta/Exemplar.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/guessing-game/.meta/config.json
+++ b/languages/fsharp/exercises/concept/guessing-game/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["GuessingGame.fs"],
-    "test_files": ["GuessingGameTests.fs"]
+  "files": {
+    "solution": ["GuessingGame.fs"],
+    "test": ["GuessingGameTests.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/interest-is-interesting/.meta/config.json
+++ b/languages/fsharp/exercises/concept/interest-is-interesting/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/floating-point-numbers"],
   "files": {
     "solution": ["InterestIsInteresting.fs"],
-    "test": ["InterestIsInterestingTests.fs"]
+    "test": ["InterestIsInterestingTests.fs"],
+    "exemplar": [".meta/Exemplar.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/interest-is-interesting/.meta/config.json
+++ b/languages/fsharp/exercises/concept/interest-is-interesting/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["csharp/floating-point-numbers"],
-  "editor": {
-    "solution_files": ["InterestIsInteresting.fs"],
-    "test_files": ["InterestIsInterestingTests.fs"]
+  "files": {
+    "solution": ["InterestIsInteresting.fs"],
+    "test": ["InterestIsInterestingTests.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/log-levels/.meta/config.json
+++ b/languages/fsharp/exercises/concept/log-levels/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/strings"],
   "files": {
     "solution": ["LogLevels.fs"],
-    "test": ["LogLevelsTests.fs"]
+    "test": ["LogLevelsTests.fs"],
+    "exemplar": [".meta/Exemplar.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/log-levels/.meta/config.json
+++ b/languages/fsharp/exercises/concept/log-levels/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["csharp/strings"],
-  "editor": {
-    "solution_files": ["LogLevels.fs"],
-    "test_files": ["LogLevelsTests.fs"]
+  "files": {
+    "solution": ["LogLevels.fs"],
+    "test": ["LogLevelsTests.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/languages/fsharp/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["LuciansLusciousLasagna.fs"],
-    "test_files": ["LuciansLusciousLasagnaTests.fs"]
+  "files": {
+    "solution": ["LuciansLusciousLasagna.fs"],
+    "test": ["LuciansLusciousLasagnaTests.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/languages/fsharp/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["LuciansLusciousLasagna.fs"],
-    "test": ["LuciansLusciousLasagnaTests.fs"]
+    "test": ["LuciansLusciousLasagnaTests.fs"],
+    "exemplar": [".meta/Exemplar.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/pizza-pricing/.meta/config.json
+++ b/languages/fsharp/exercises/concept/pizza-pricing/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["PizzaPricing.fs"],
-    "test": ["PizzaPricingTests.fs"]
+    "test": ["PizzaPricingTests.fs"],
+    "exemplar": [".meta/Exemplar.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/pizza-pricing/.meta/config.json
+++ b/languages/fsharp/exercises/concept/pizza-pricing/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["PizzaPricing.fs"],
-    "test_files": ["PizzaPricingTests.fs"]
+  "files": {
+    "solution": ["PizzaPricing.fs"],
+    "test": ["PizzaPricingTests.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
+++ b/languages/fsharp/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["clojure/lists"],
   "files": {
     "solution": ["TracksOnTracksOnTracks.fs"],
-    "test": ["TracksOnTracksOnTracksTests.fs"]
+    "test": ["TracksOnTracksOnTracksTests.fs"],
+    "exemplar": [".meta/Exemplar.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
+++ b/languages/fsharp/exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["clojure/lists"],
-  "editor": {
-    "solution_files": ["TracksOnTracksOnTracks.fs"],
-    "test_files": ["TracksOnTracksOnTracksTests.fs"]
+  "files": {
+    "solution": ["TracksOnTracksOnTracks.fs"],
+    "test": ["TracksOnTracksOnTracksTests.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/valentines-day/.meta/config.json
+++ b/languages/fsharp/exercises/concept/valentines-day/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["ValentinesDay.fs"],
-    "test": ["ValentinesDayTests.fs"]
+    "test": ["ValentinesDayTests.fs"],
+    "exemplar": [".meta/Exemplar.fs"]
   }
 }

--- a/languages/fsharp/exercises/concept/valentines-day/.meta/config.json
+++ b/languages/fsharp/exercises/concept/valentines-day/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "ErikSchierboom"
     }
   ],
-  "editor": {
-    "solution_files": ["ValentinesDay.fs"],
-    "test_files": ["ValentinesDayTests.fs"]
+  "files": {
+    "solution": ["ValentinesDay.fs"],
+    "test": ["ValentinesDayTests.fs"]
   }
 }

--- a/languages/go/exercises/concept/basics/.meta/config.json
+++ b/languages/go/exercises/concept/basics/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["csharp/basics"],
-  "editor": {
-    "solution_files": ["basics.go"],
-    "test_files": ["basics_test.go"]
+  "files": {
+    "solution": ["basics.go"],
+    "test": ["basics_test.go"]
   }
 }

--- a/languages/go/exercises/concept/basics/.meta/config.json
+++ b/languages/go/exercises/concept/basics/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/basics"],
   "files": {
     "solution": ["basics.go"],
-    "test": ["basics_test.go"]
+    "test": ["basics_test.go"],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/go/exercises/concept/booleans/.meta/config.json
+++ b/languages/go/exercises/concept/booleans/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/booleans"],
   "files": {
     "solution": ["booleans.go"],
-    "test": ["booleans_test.go"]
+    "test": ["booleans_test.go"],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/go/exercises/concept/booleans/.meta/config.json
+++ b/languages/go/exercises/concept/booleans/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["csharp/booleans"],
-  "editor": {
-    "solution_files": ["booleans.go"],
-    "test_files": ["booleans_test.go"]
+  "files": {
+    "solution": ["booleans.go"],
+    "test": ["booleans_test.go"]
   }
 }

--- a/languages/go/exercises/concept/comments/.meta/config.json
+++ b/languages/go/exercises/concept/comments/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["comments.go"],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/go/exercises/concept/comments/.meta/config.json
+++ b/languages/go/exercises/concept/comments/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "niki-01"
     }
   ],
-  "editor": {
-    "solution_files": ["comments.go"],
-    "test_files": []
+  "files": {
+    "solution": ["comments.go"],
+    "test": []
   }
 }

--- a/languages/go/exercises/concept/conditionals/.meta/config.json
+++ b/languages/go/exercises/concept/conditionals/.meta/config.json
@@ -13,6 +13,7 @@
   "forked_from": [],
   "files": {
     "solution": ["conditionals.go"],
-    "test": ["conditionals_test.go"]
+    "test": ["conditionals_test.go"],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/go/exercises/concept/conditionals/.meta/config.json
+++ b/languages/go/exercises/concept/conditionals/.meta/config.json
@@ -11,8 +11,8 @@
     }
   ],
   "forked_from": [],
-  "editor": {
-    "solution_files": ["conditionals.go"],
-    "test_files": ["conditionals_test.go"]
+  "files": {
+    "solution": ["conditionals.go"],
+    "test": ["conditionals_test.go"]
   }
 }

--- a/languages/go/exercises/concept/constants/.meta/config.json
+++ b/languages/go/exercises/concept/constants/.meta/config.json
@@ -4,5 +4,9 @@
       "github_username": "jamessouth",
       "exercism_username": "jamessouth"
     }
-  ]
+  ],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/go/exercises/concept/constants/.meta/config.json
+++ b/languages/go/exercises/concept/constants/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/go/exercises/concept/errors/.meta/config.json
+++ b/languages/go/exercises/concept/errors/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": []
   }
 }

--- a/languages/go/exercises/concept/errors/.meta/config.json
+++ b/languages/go/exercises/concept/errors/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "micuffaro"
     }
   ],
-  "editor": {
-    "solution_files": [],
-    "test_files": []
+  "files": {
+    "solution": [],
+    "test": []
   }
 }

--- a/languages/go/exercises/concept/maps/.meta/config.json
+++ b/languages/go/exercises/concept/maps/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "chocopowwwa"
     }
   ],
-  "editor": {
-    "solution_files": ["maps.go"],
-    "test_files": ["maps_test.go"]
+  "files": {
+    "solution": ["maps.go"],
+    "test": ["maps_test.go"]
   }
 }

--- a/languages/go/exercises/concept/maps/.meta/config.json
+++ b/languages/go/exercises/concept/maps/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["maps.go"],
-    "test": ["maps_test.go"]
+    "test": ["maps_test.go"],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/go/exercises/concept/methods/.meta/config.json
+++ b/languages/go/exercises/concept/methods/.meta/config.json
@@ -12,8 +12,8 @@
     }
   ],
   "forked_from": ["csharp/classes"],
-  "editor": {
-    "solution_files": ["methods.go"],
-    "test_files": ["methods_test.go"]
+  "files": {
+    "solution": ["methods.go"],
+    "test": ["methods_test.go"]
   }
 }

--- a/languages/go/exercises/concept/methods/.meta/config.json
+++ b/languages/go/exercises/concept/methods/.meta/config.json
@@ -14,6 +14,7 @@
   "forked_from": ["csharp/classes"],
   "files": {
     "solution": ["methods.go"],
-    "test": ["methods_test.go"]
+    "test": ["methods_test.go"],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/go/exercises/concept/numbers/.meta/config.json
+++ b/languages/go/exercises/concept/numbers/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "tehsphinx"
     }
   ],
-  "editor": {
-    "solution_files": ["numbers.go"],
-    "test_files": ["numbers_test.go"]
+  "files": {
+    "solution": ["numbers.go"],
+    "test": ["numbers_test.go"]
   }
 }

--- a/languages/go/exercises/concept/numbers/.meta/config.json
+++ b/languages/go/exercises/concept/numbers/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["numbers.go"],
-    "test": ["numbers_test.go"]
+    "test": ["numbers_test.go"],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/go/exercises/concept/slices/.meta/config.json
+++ b/languages/go/exercises/concept/slices/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["slices.go"],
-    "test": ["slices_test.go"]
+    "test": ["slices_test.go"],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/go/exercises/concept/slices/.meta/config.json
+++ b/languages/go/exercises/concept/slices/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "tehsphinx"
     }
   ],
-  "editor": {
-    "solution_files": ["slices.go"],
-    "test_files": ["slices_test.go"]
+  "files": {
+    "solution": ["slices.go"],
+    "test": ["slices_test.go"]
   }
 }

--- a/languages/go/exercises/concept/strings-package/.meta/config.json
+++ b/languages/go/exercises/concept/strings-package/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["strings.go"],
-    "test": ["strings_test.go"]
+    "test": ["strings_test.go"],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/go/exercises/concept/strings-package/.meta/config.json
+++ b/languages/go/exercises/concept/strings-package/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "tehsphinx"
     }
   ],
-  "editor": {
-    "solution_files": ["strings.go"],
-    "test_files": ["strings_test.go"]
+  "files": {
+    "solution": ["strings.go"],
+    "test": ["strings_test.go"]
   }
 }

--- a/languages/go/exercises/concept/strings/.meta/config.json
+++ b/languages/go/exercises/concept/strings/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["strings.go"],
-    "test": ["strings_test.go"]
+    "test": ["strings_test.go"],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/go/exercises/concept/strings/.meta/config.json
+++ b/languages/go/exercises/concept/strings/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "oanaOM"
     }
   ],
-  "editor": {
-    "solution_files": ["strings.go"],
-    "test_files": ["strings_test.go"]
+  "files": {
+    "solution": ["strings.go"],
+    "test": ["strings_test.go"]
   }
 }

--- a/languages/go/exercises/concept/structs/.meta/config.json
+++ b/languages/go/exercises/concept/structs/.meta/config.json
@@ -14,6 +14,7 @@
   "forked_from": ["csharp/constructors"],
   "files": {
     "solution": ["structs.go"],
-    "test": ["structs_test.go"]
+    "test": ["structs_test.go"],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/go/exercises/concept/structs/.meta/config.json
+++ b/languages/go/exercises/concept/structs/.meta/config.json
@@ -12,8 +12,8 @@
     }
   ],
   "forked_from": ["csharp/constructors"],
-  "editor": {
-    "solution_files": ["structs.go"],
-    "test_files": ["structs_test.go"]
+  "files": {
+    "solution": ["structs.go"],
+    "test": ["structs_test.go"]
   }
 }

--- a/languages/go/exercises/concept/time/.meta/config.json
+++ b/languages/go/exercises/concept/time/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["csharp/datetimes"],
-  "editor": {
-    "solution_files": ["time.go"],
-    "test_files": ["time_test.go"]
+  "files": {
+    "solution": ["time.go"],
+    "test": ["time_test.go"]
   }
 }

--- a/languages/go/exercises/concept/time/.meta/config.json
+++ b/languages/go/exercises/concept/time/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/datetimes"],
   "files": {
     "solution": ["time.go"],
-    "test": ["time_test.go"]
+    "test": ["time_test.go"],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/go/exercises/concept/zero-value/.meta/config.json
+++ b/languages/go/exercises/concept/zero-value/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "tehsphinx"
     }
   ],
-  "editor": {
-    "solution_files": ["zero_value.go"],
-    "test_files": ["zero_value_test.go"]
+  "files": {
+    "solution": ["zero_value.go"],
+    "test": ["zero_value_test.go"]
   }
 }

--- a/languages/go/exercises/concept/zero-value/.meta/config.json
+++ b/languages/go/exercises/concept/zero-value/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["zero_value.go"],
-    "test": ["zero_value_test.go"]
+    "test": ["zero_value_test.go"],
+    "exemplar": [".meta/exemplar.go"]
   }
 }

--- a/languages/java/exercises/concept/basics/.meta/config.json
+++ b/languages/java/exercises/concept/basics/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "mirkoperillo"
     }
   ],
-  "editor": {
-    "solution_files": ["src/main/java/Lasagna.java"],
-    "test_files": ["src/test/java/LasagnaTest.java"]
+  "files": {
+    "solution": ["src/main/java/Lasagna.java"],
+    "test": ["src/test/java/LasagnaTest.java"]
   },
   "forked_from": ["csharp/basics"]
 }

--- a/languages/java/exercises/concept/basics/.meta/config.json
+++ b/languages/java/exercises/concept/basics/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["src/main/java/Lasagna.java"],
-    "test": ["src/test/java/LasagnaTest.java"]
+    "test": ["src/test/java/LasagnaTest.java"],
+    "exemplar": []
   },
   "forked_from": ["csharp/basics"]
 }

--- a/languages/java/exercises/concept/bird-watcher/.meta/config.json
+++ b/languages/java/exercises/concept/bird-watcher/.meta/config.json
@@ -9,9 +9,9 @@
       "exercism_username": "ystromm"
     }
   ],
-  "editor": {
-    "solution_files": ["src/main/java/BirdWatcher.java"],
-    "test_files": ["src/test/java/BirdWatcherTest.java"]
+  "files": {
+    "solution": ["src/main/java/BirdWatcher.java"],
+    "test": ["src/test/java/BirdWatcherTest.java"]
   },
   "forked_from": ["csharp/arrays"]
 }

--- a/languages/java/exercises/concept/bird-watcher/.meta/config.json
+++ b/languages/java/exercises/concept/bird-watcher/.meta/config.json
@@ -11,7 +11,8 @@
   ],
   "files": {
     "solution": ["src/main/java/BirdWatcher.java"],
-    "test": ["src/test/java/BirdWatcherTest.java"]
+    "test": ["src/test/java/BirdWatcherTest.java"],
+    "exemplar": []
   },
   "forked_from": ["csharp/arrays"]
 }

--- a/languages/java/exercises/concept/booleans/.meta/config.json
+++ b/languages/java/exercises/concept/booleans/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": ["src/main/java/QuestLogic.java"],
-    "test_files": ["src/test/java/QuestLogicTest.java"]
+  "files": {
+    "solution": ["src/main/java/QuestLogic.java"],
+    "test": ["src/test/java/QuestLogicTest.java"]
   },
   "forked_from": ["csharp/booleans"]
 }

--- a/languages/java/exercises/concept/booleans/.meta/config.json
+++ b/languages/java/exercises/concept/booleans/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["src/main/java/QuestLogic.java"],
-    "test": ["src/test/java/QuestLogicTest.java"]
+    "test": ["src/test/java/QuestLogicTest.java"],
+    "exemplar": []
   },
   "forked_from": ["csharp/booleans"]
 }

--- a/languages/java/exercises/concept/chars/.meta/config.json
+++ b/languages/java/exercises/concept/chars/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["src/main/java/Identifier.java"],
-    "test": ["src/test/java/IdentifierTest.java"]
+    "test": ["src/test/java/IdentifierTest.java"],
+    "exemplar": []
   },
   "forked_from": ["csharp/chars"]
 }

--- a/languages/java/exercises/concept/chars/.meta/config.json
+++ b/languages/java/exercises/concept/chars/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "ystromm"
     }
   ],
-  "editor": {
-    "solution_files": ["src/main/java/Identifier.java"],
-    "test_files": ["src/test/java/IdentifierTest.java"]
+  "files": {
+    "solution": ["src/main/java/Identifier.java"],
+    "test": ["src/test/java/IdentifierTest.java"]
   },
   "forked_from": ["csharp/chars"]
 }

--- a/languages/java/exercises/concept/classes/.meta/config.json
+++ b/languages/java/exercises/concept/classes/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "mirkoperillo"
     }
   ],
-  "editor": {
-    "solution_files": ["src/main/java/RemoteControlCar.java"],
-    "test_files": ["src/test/java/RemoteControlCarTest.java"]
+  "files": {
+    "solution": ["src/main/java/RemoteControlCar.java"],
+    "test": ["src/test/java/RemoteControlCarTest.java"]
   },
   "authors": [
     {

--- a/languages/java/exercises/concept/classes/.meta/config.json
+++ b/languages/java/exercises/concept/classes/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["src/main/java/RemoteControlCar.java"],
-    "test": ["src/test/java/RemoteControlCarTest.java"]
+    "test": ["src/test/java/RemoteControlCarTest.java"],
+    "exemplar": []
   },
   "authors": [
     {

--- a/languages/java/exercises/concept/conditionals/.meta/config.json
+++ b/languages/java/exercises/concept/conditionals/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["src/main/java/Blackjack.java"],
-    "test": ["src/test/java/BlackjackTest.java"]
+    "test": ["src/test/java/BlackjackTest.java"],
+    "exemplar": []
   },
   "forked_from": ["go/conditionals"]
 }

--- a/languages/java/exercises/concept/conditionals/.meta/config.json
+++ b/languages/java/exercises/concept/conditionals/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "TalesDias"
     }
   ],
-  "editor": {
-    "solution_files": ["src/main/java/Blackjack.java"],
-    "test_files": ["src/test/java/BlackjackTest.java"]
+  "files": {
+    "solution": ["src/main/java/Blackjack.java"],
+    "test": ["src/test/java/BlackjackTest.java"]
   },
   "forked_from": ["go/conditionals"]
 }

--- a/languages/java/exercises/concept/constructors/.meta/config.json
+++ b/languages/java/exercises/concept/constructors/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "mirkoperillo"
     }
   ],
-  "editor": {
-    "solution_files": ["src/main/java/RemoteControlCar.java"],
-    "test_files": ["src/test/java/RemoteControlCarTest.java"]
+  "files": {
+    "solution": ["src/main/java/RemoteControlCar.java"],
+    "test": ["src/test/java/RemoteControlCarTest.java"]
   },
   "authors": [
     {

--- a/languages/java/exercises/concept/constructors/.meta/config.json
+++ b/languages/java/exercises/concept/constructors/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["src/main/java/RemoteControlCar.java"],
-    "test": ["src/test/java/RemoteControlCarTest.java"]
+    "test": ["src/test/java/RemoteControlCarTest.java"],
+    "exemplar": []
   },
   "authors": [
     {

--- a/languages/java/exercises/concept/inheritance/.meta/config.json
+++ b/languages/java/exercises/concept/inheritance/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "himanshugoyal1065"
     }
   ],
-  "editor": {
-    "solution_files": ["src/main/java/Fighter.java"],
-    "test_files": ["src/test/java/FighterTest.java"]
+  "files": {
+    "solution": ["src/main/java/Fighter.java"],
+    "test": ["src/test/java/FighterTest.java"]
   },
   "forked_from": ["csharp/inheritance"]
 }

--- a/languages/java/exercises/concept/inheritance/.meta/config.json
+++ b/languages/java/exercises/concept/inheritance/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["src/main/java/Fighter.java"],
-    "test": ["src/test/java/FighterTest.java"]
+    "test": ["src/test/java/FighterTest.java"],
+    "exemplar": []
   },
   "forked_from": ["csharp/inheritance"]
 }

--- a/languages/java/exercises/concept/interfaces/.meta/config.json
+++ b/languages/java/exercises/concept/interfaces/.meta/config.json
@@ -12,6 +12,7 @@
       "src/main/java/RemoteControlCar.java",
       "src/main/java/TestTrack.java"
     ],
-    "test": ["src/test/java/RemoteControlCarTest.java"]
+    "test": ["src/test/java/RemoteControlCarTest.java"],
+    "exemplar": []
   }
 }

--- a/languages/java/exercises/concept/interfaces/.meta/config.json
+++ b/languages/java/exercises/concept/interfaces/.meta/config.json
@@ -5,13 +5,13 @@
       "exercism_username": "mikedamay"
     }
   ],
-  "editor": {
-    "solution_files": [
+  "files": {
+    "solution": [
       "src/main/java/ExperimentalRemoteControlCar.java",
       "src/main/java/ProductionRemoteControlCar.java",
       "src/main/java/RemoteControlCar.java",
       "src/main/java/TestTrack.java"
     ],
-    "test_files": ["src/test/java/RemoteControlCarTest.java"]
+    "test": ["src/test/java/RemoteControlCarTest.java"]
   }
 }

--- a/languages/java/exercises/concept/numbers/.meta/config.json
+++ b/languages/java/exercises/concept/numbers/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "TalesDias"
     }
   ],
-  "editor": {
-    "solution_files": ["src/main/java/AssemblyLine.java"],
-    "test_files": ["src/test/java/AssemblyLineTest.java"]
+  "files": {
+    "solution": ["src/main/java/AssemblyLine.java"],
+    "test": ["src/test/java/AssemblyLineTest.java"]
   },
   "forked_from": ["csharp/numbers"]
 }

--- a/languages/java/exercises/concept/numbers/.meta/config.json
+++ b/languages/java/exercises/concept/numbers/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["src/main/java/AssemblyLine.java"],
-    "test": ["src/test/java/AssemblyLineTest.java"]
+    "test": ["src/test/java/AssemblyLineTest.java"],
+    "exemplar": []
   },
   "forked_from": ["csharp/numbers"]
 }

--- a/languages/java/exercises/concept/strings/.meta/config.json
+++ b/languages/java/exercises/concept/strings/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "mirkoperillo"
     }
   ],
-  "editor": {
-    "solution_files": ["src/main/java/LogLine.java"],
-    "test_files": ["src/test/java/LogLineTest.java"]
+  "files": {
+    "solution": ["src/main/java/LogLine.java"],
+    "test": ["src/test/java/LogLineTest.java"]
   },
   "forked_from": ["csharp/strings"]
 }

--- a/languages/java/exercises/concept/strings/.meta/config.json
+++ b/languages/java/exercises/concept/strings/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["src/main/java/LogLine.java"],
-    "test": ["src/test/java/LogLineTest.java"]
+    "test": ["src/test/java/LogLineTest.java"],
+    "exemplar": []
   },
   "forked_from": ["csharp/strings"]
 }

--- a/languages/java/exercises/concept/switch-statement/.meta/config.json
+++ b/languages/java/exercises/concept/switch-statement/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["src/main/java/PlayAnalyzer.java"],
-    "test": ["src/test/java/PlayAnalyzerTest.java"]
+    "test": ["src/test/java/PlayAnalyzerTest.java"],
+    "exemplar": []
   }
 }

--- a/languages/java/exercises/concept/switch-statement/.meta/config.json
+++ b/languages/java/exercises/concept/switch-statement/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "Azumix"
     }
   ],
-  "editor": {
-    "solution_files": ["src/main/java/PlayAnalyzer.java"],
-    "test_files": ["src/test/java/PlayAnalyzerTest.java"]
+  "files": {
+    "solution": ["src/main/java/PlayAnalyzer.java"],
+    "test": ["src/test/java/PlayAnalyzerTest.java"]
   }
 }

--- a/languages/java/exercises/concept/ternary-operators/.meta/config.json
+++ b/languages/java/exercises/concept/ternary-operators/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "TalesDias"
     }
   ],
-  "editor": {
-    "solution_files": ["src/main/java/SalaryCalculator.java"],
-    "test_files": ["src/test/java/SalaryCalculatorTest.java"]
+  "files": {
+    "solution": ["src/main/java/SalaryCalculator.java"],
+    "test": ["src/test/java/SalaryCalculatorTest.java"]
   }
 }

--- a/languages/java/exercises/concept/ternary-operators/.meta/config.json
+++ b/languages/java/exercises/concept/ternary-operators/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["src/main/java/SalaryCalculator.java"],
-    "test": ["src/test/java/SalaryCalculatorTest.java"]
+    "test": ["src/test/java/SalaryCalculatorTest.java"],
+    "exemplar": []
   }
 }

--- a/languages/javascript/exercises/concept/array-loops/.meta/config.json
+++ b/languages/javascript/exercises/concept/array-loops/.meta/config.json
@@ -11,5 +11,9 @@
       "exercism_username": "SleeplessByte"
     }
   ],
-  "forked_from": []
+  "forked_from": [],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/javascript/exercises/concept/array-loops/.meta/config.json
+++ b/languages/javascript/exercises/concept/array-loops/.meta/config.json
@@ -14,6 +14,7 @@
   "forked_from": [],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.js"]
   }
 }

--- a/languages/javascript/exercises/concept/basics/.meta/config.json
+++ b/languages/javascript/exercises/concept/basics/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["ruby/basics"],
-  "editor": {
-    "solution_files": ["basics.js"],
-    "test_files": ["basics.spec.js"]
+  "files": {
+    "solution": ["basics.js"],
+    "test": ["basics.spec.js"]
   }
 }

--- a/languages/javascript/exercises/concept/basics/.meta/config.json
+++ b/languages/javascript/exercises/concept/basics/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["ruby/basics"],
   "files": {
     "solution": ["basics.js"],
-    "test": ["basics.spec.js"]
+    "test": ["basics.spec.js"],
+    "exemplar": []
   }
 }

--- a/languages/javascript/exercises/concept/booleans/.meta/config.json
+++ b/languages/javascript/exercises/concept/booleans/.meta/config.json
@@ -17,6 +17,7 @@
   ],
   "files": {
     "solution": ["booleans.js"],
-    "test": ["booleans.spec.js"]
+    "test": ["booleans.spec.js"],
+    "exemplar": []
   }
 }

--- a/languages/javascript/exercises/concept/booleans/.meta/config.json
+++ b/languages/javascript/exercises/concept/booleans/.meta/config.json
@@ -15,8 +15,8 @@
       "exercism_username": "ovidiu141"
     }
   ],
-  "editor": {
-    "solution_files": ["booleans.js"],
-    "test_files": ["booleans.spec.js"]
+  "files": {
+    "solution": ["booleans.js"],
+    "test": ["booleans.spec.js"]
   }
 }

--- a/languages/javascript/exercises/concept/closures/.meta/config.json
+++ b/languages/javascript/exercises/concept/closures/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["closures.js"],
-    "test": ["closures.spec.js"]
+    "test": ["closures.spec.js"],
+    "exemplar": []
   }
 }

--- a/languages/javascript/exercises/concept/closures/.meta/config.json
+++ b/languages/javascript/exercises/concept/closures/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "neenjaw"
     }
   ],
-  "editor": {
-    "solution_files": ["closures.js"],
-    "test_files": ["closures.spec.js"]
+  "files": {
+    "solution": ["closures.js"],
+    "test": ["closures.spec.js"]
   }
 }

--- a/languages/javascript/exercises/concept/elyses-analytic-enchantments/.meta/config.json
+++ b/languages/javascript/exercises/concept/elyses-analytic-enchantments/.meta/config.json
@@ -10,8 +10,8 @@
       "exercism_username": "SleeplessByte"
     }
   ],
-  "editor": {
-    "solution_files": ["enchantments.js"],
-    "test_files": ["enchantments.spec.js"]
+  "files": {
+    "solution": ["enchantments.js"],
+    "test": ["enchantments.spec.js"]
   }
 }

--- a/languages/javascript/exercises/concept/elyses-analytic-enchantments/.meta/config.json
+++ b/languages/javascript/exercises/concept/elyses-analytic-enchantments/.meta/config.json
@@ -12,6 +12,7 @@
   ],
   "files": {
     "solution": ["enchantments.js"],
-    "test": ["enchantments.spec.js"]
+    "test": ["enchantments.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   }
 }

--- a/languages/javascript/exercises/concept/elyses-destructured-enchantments/.meta/config.json
+++ b/languages/javascript/exercises/concept/elyses-destructured-enchantments/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["enchantments.js"],
-    "test": ["enchantments.spec.js"]
+    "test": ["enchantments.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   }
 }

--- a/languages/javascript/exercises/concept/elyses-destructured-enchantments/.meta/config.json
+++ b/languages/javascript/exercises/concept/elyses-destructured-enchantments/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "SleeplessByte"
     }
   ],
-  "editor": {
-    "solution_files": ["enchantments.js"],
-    "test_files": ["enchantments.spec.js"]
+  "files": {
+    "solution": ["enchantments.js"],
+    "test": ["enchantments.spec.js"]
   }
 }

--- a/languages/javascript/exercises/concept/elyses-enchantments/.meta/config.json
+++ b/languages/javascript/exercises/concept/elyses-enchantments/.meta/config.json
@@ -18,6 +18,7 @@
   "forked_from": ["go/basic-slices"],
   "files": {
     "solution": ["enchantments.js"],
-    "test": ["enchantments.spec.js"]
+    "test": ["enchantments.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   }
 }

--- a/languages/javascript/exercises/concept/elyses-enchantments/.meta/config.json
+++ b/languages/javascript/exercises/concept/elyses-enchantments/.meta/config.json
@@ -16,8 +16,8 @@
     }
   ],
   "forked_from": ["go/basic-slices"],
-  "editor": {
-    "solution_files": ["enchantments.js"],
-    "test_files": ["enchantments.spec.js"]
+  "files": {
+    "solution": ["enchantments.js"],
+    "test": ["enchantments.spec.js"]
   }
 }

--- a/languages/javascript/exercises/concept/elyses-transformative-enchantments/.meta/config.json
+++ b/languages/javascript/exercises/concept/elyses-transformative-enchantments/.meta/config.json
@@ -6,8 +6,8 @@
       "exercism_username": "ajoshguy"
     }
   ],
-  "editor": {
-    "solution_files": [],
-    "test_files": []
+  "files": {
+    "solution": [],
+    "test": []
   }
 }

--- a/languages/javascript/exercises/concept/elyses-transformative-enchantments/.meta/config.json
+++ b/languages/javascript/exercises/concept/elyses-transformative-enchantments/.meta/config.json
@@ -8,6 +8,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.js"]
   }
 }

--- a/languages/javascript/exercises/concept/fruit-picker/.meta/config.json
+++ b/languages/javascript/exercises/concept/fruit-picker/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "sleeplessbyte"
     }
   ],
-  "editor": {
-    "solution_files": ["fruit-picker.js"],
-    "test_files": ["fruit-picker.spec.js"]
+  "files": {
+    "solution": ["fruit-picker.js"],
+    "test": ["fruit-picker.spec.js"]
   }
 }

--- a/languages/javascript/exercises/concept/fruit-picker/.meta/config.json
+++ b/languages/javascript/exercises/concept/fruit-picker/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["fruit-picker.js"],
-    "test": ["fruit-picker.spec.js"]
+    "test": ["fruit-picker.spec.js"],
+    "exemplar": []
   }
 }

--- a/languages/javascript/exercises/concept/lucky-numbers/.meta/config.json
+++ b/languages/javascript/exercises/concept/lucky-numbers/.meta/config.json
@@ -15,8 +15,8 @@
       "exercism_username": "shubhsk88"
     }
   ],
-  "editor": {
-    "solution_files": ["lucky-numbers.js"],
-    "test_files": ["lucky-numbers.spec.js"]
+  "files": {
+    "solution": ["lucky-numbers.js"],
+    "test": ["lucky-numbers.spec.js"]
   }
 }

--- a/languages/javascript/exercises/concept/lucky-numbers/.meta/config.json
+++ b/languages/javascript/exercises/concept/lucky-numbers/.meta/config.json
@@ -17,6 +17,7 @@
   ],
   "files": {
     "solution": ["lucky-numbers.js"],
-    "test": ["lucky-numbers.spec.js"]
+    "test": ["lucky-numbers.spec.js"],
+    "exemplar": []
   }
 }

--- a/languages/javascript/exercises/concept/nullability/.meta/config.json
+++ b/languages/javascript/exercises/concept/nullability/.meta/config.json
@@ -12,6 +12,7 @@
   "forked_from": ["csharp/nullability"],
   "files": {
     "solution": ["nullability.js"],
-    "test": ["nullability.spec.js"]
+    "test": ["nullability.spec.js"],
+    "exemplar": []
   }
 }

--- a/languages/javascript/exercises/concept/nullability/.meta/config.json
+++ b/languages/javascript/exercises/concept/nullability/.meta/config.json
@@ -10,8 +10,8 @@
     }
   ],
   "forked_from": ["csharp/nullability"],
-  "editor": {
-    "solution_files": ["nullability.js"],
-    "test_files": ["nullability.spec.js"]
+  "files": {
+    "solution": ["nullability.js"],
+    "test": ["nullability.spec.js"]
   }
 }

--- a/languages/javascript/exercises/concept/numbers/.meta/config.json
+++ b/languages/javascript/exercises/concept/numbers/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "SleeplessByte"
     }
   ],
-  "editor": {
-    "solution_files": ["numbers.js"],
-    "test_files": ["numbers.spec.js"]
+  "files": {
+    "solution": ["numbers.js"],
+    "test": ["numbers.spec.js"]
   }
 }

--- a/languages/javascript/exercises/concept/numbers/.meta/config.json
+++ b/languages/javascript/exercises/concept/numbers/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["numbers.js"],
-    "test": ["numbers.spec.js"]
+    "test": ["numbers.spec.js"],
+    "exemplar": []
   }
 }

--- a/languages/javascript/exercises/concept/promises/.meta/config.json
+++ b/languages/javascript/exercises/concept/promises/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["promises.js"],
-    "test": ["promises.spec.js"]
+    "test": ["promises.spec.js"],
+    "exemplar": []
   }
 }

--- a/languages/javascript/exercises/concept/promises/.meta/config.json
+++ b/languages/javascript/exercises/concept/promises/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "SleeplessByte"
     }
   ],
-  "editor": {
-    "solution_files": ["promises.js"],
-    "test_files": ["promises.spec.js"]
+  "files": {
+    "solution": ["promises.js"],
+    "test": ["promises.spec.js"]
   }
 }

--- a/languages/javascript/exercises/concept/recursion/.meta/config.json
+++ b/languages/javascript/exercises/concept/recursion/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/nullability"],
   "files": {
     "solution": ["recursion.js"],
-    "test": ["recursion.spec.js"]
+    "test": ["recursion.spec.js"],
+    "exemplar": []
   }
 }

--- a/languages/javascript/exercises/concept/recursion/.meta/config.json
+++ b/languages/javascript/exercises/concept/recursion/.meta/config.json
@@ -6,8 +6,8 @@
     }
   ],
   "forked_from": ["csharp/nullability"],
-  "editor": {
-    "solution_files": ["recursion.js"],
-    "test_files": ["recursion.spec.js"]
+  "files": {
+    "solution": ["recursion.js"],
+    "test": ["recursion.spec.js"]
   }
 }

--- a/languages/javascript/exercises/concept/strings/.meta/config.json
+++ b/languages/javascript/exercises/concept/strings/.meta/config.json
@@ -11,8 +11,8 @@
       "exercism_username": "SleeplessByte"
     }
   ],
-  "editor": {
-    "solution_files": ["strings.js"],
-    "test_files": ["strings.spec.js"]
+  "files": {
+    "solution": ["strings.js"],
+    "test": ["strings.spec.js"]
   }
 }

--- a/languages/javascript/exercises/concept/strings/.meta/config.json
+++ b/languages/javascript/exercises/concept/strings/.meta/config.json
@@ -13,6 +13,7 @@
   ],
   "files": {
     "solution": ["strings.js"],
-    "test": ["strings.spec.js"]
+    "test": ["strings.spec.js"],
+    "exemplar": []
   }
 }

--- a/languages/javascript/exercises/practice/string-iterables/.meta/config.json
+++ b/languages/javascript/exercises/practice/string-iterables/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "SleeplessByte"
     }
   ],
-  "editor": {
-    "solution_files": ["string-iterables.js"],
-    "test_files": ["string-iterables.spec.js"]
+  "files": {
+    "solution": ["string-iterables.js"],
+    "test": ["string-iterables.spec.js"]
   }
 }

--- a/languages/julia/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/languages/julia/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -1,26 +1,26 @@
 {
-    "language_versions": "≥1.0",
-    "files": {
-        "test": [
-            "runtests.jl"
-        ],
-        "solution": [
-            "game.jl"
-        ]
-    },
-    "contributors": [
-        {
-            "github_username": "cmcaine",
-            "exercism_username": "cmcaine"
-        }
+  "language_versions": "≥1.0",
+  "files": {
+    "test": [
+      "runtests.jl"
     ],
-    "authors": [
-        {
-            "github_username": "SaschaMann",
-            "exercism_username": "SaschaMann"
-        }
-    ],
-    "forked_from": [
-        "javascript/boolean"
+    "solution": [
+      "game.jl"
     ]
+  },
+  "contributors": [
+    {
+      "github_username": "cmcaine",
+      "exercism_username": "cmcaine"
+    }
+  ],
+  "authors": [
+    {
+      "github_username": "SaschaMann",
+      "exercism_username": "SaschaMann"
+    }
+  ],
+  "forked_from": [
+    "javascript/boolean"
+  ]
 }

--- a/languages/julia/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/languages/julia/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -4,6 +4,9 @@
     "test": [
       "runtests.jl"
     ],
+    "exemplar": [
+      ".meta/exemplar.jl"
+    ],
     "solution": [
       "game.jl"
     ]

--- a/languages/julia/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/languages/julia/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -1,10 +1,10 @@
 {
     "language_versions": "≥1.0",
-    "editor": {
-        "test_files": [
+    "files": {
+        "test": [
             "runtests.jl"
         ],
-        "solution_files": [
+        "solution": [
             "game.jl"
         ]
     },

--- a/languages/julia/exercises/concept/annalyns-infiltration2/.meta/config.json
+++ b/languages/julia/exercises/concept/annalyns-infiltration2/.meta/config.json
@@ -1,26 +1,26 @@
 {
-    "language_versions": "≥1.0",
-    "files": {
-        "test": [
-            "runtests.jl"
-        ],
-        "solution": [
-            "game.jl"
-        ]
-    },
-    "contributors": [
-        {
-            "github_username": "cmcaine",
-            "exercism_username": "cmcaine"
-        }
+  "language_versions": "≥1.0",
+  "files": {
+    "test": [
+      "runtests.jl"
     ],
-    "authors": [
-        {
-            "github_username": "SaschaMann",
-            "exercism_username": "SaschaMann"
-        }
-    ],
-    "forked_from": [
-        "javascript/boolean"
+    "solution": [
+      "game.jl"
     ]
+  },
+  "contributors": [
+    {
+      "github_username": "cmcaine",
+      "exercism_username": "cmcaine"
+    }
+  ],
+  "authors": [
+    {
+      "github_username": "SaschaMann",
+      "exercism_username": "SaschaMann"
+    }
+  ],
+  "forked_from": [
+    "javascript/boolean"
+  ]
 }

--- a/languages/julia/exercises/concept/annalyns-infiltration2/.meta/config.json
+++ b/languages/julia/exercises/concept/annalyns-infiltration2/.meta/config.json
@@ -4,6 +4,9 @@
     "test": [
       "runtests.jl"
     ],
+    "exemplar": [
+      ".meta/exemplar.jl"
+    ],
     "solution": [
       "game.jl"
     ]

--- a/languages/julia/exercises/concept/annalyns-infiltration2/.meta/config.json
+++ b/languages/julia/exercises/concept/annalyns-infiltration2/.meta/config.json
@@ -1,10 +1,10 @@
 {
     "language_versions": "≥1.0",
-    "editor": {
-        "test_files": [
+    "files": {
+        "test": [
             "runtests.jl"
         ],
-        "solution_files": [
+        "solution": [
             "game.jl"
         ]
     },

--- a/languages/julia/exercises/concept/emoji-times/.meta/config.json
+++ b/languages/julia/exercises/concept/emoji-times/.meta/config.json
@@ -1,10 +1,10 @@
 {
     "language_versions": "≥1.0",
-    "editor": {
-        "test_files": [
+    "files": {
+        "test": [
             "runtests.jl"
         ],
-        "solution_files": [
+        "solution": [
             "emoji-times.jl"
         ]
     },

--- a/languages/julia/exercises/concept/emoji-times/.meta/config.json
+++ b/languages/julia/exercises/concept/emoji-times/.meta/config.json
@@ -1,21 +1,21 @@
 {
-    "language_versions": "≥1.0",
-    "files": {
-        "test": [
-            "runtests.jl"
-        ],
-        "solution": [
-            "emoji-times.jl"
-        ]
-    },
-    "authors": [
-        {
-            "github_username": "cmcaine",
-            "exercism_username": "cmcaine"
-        },
-        {
-            "github_username": "SaschaMann",
-            "exercism_username": "SaschaMann"
-        }
+  "language_versions": "≥1.0",
+  "files": {
+    "test": [
+      "runtests.jl"
+    ],
+    "solution": [
+      "emoji-times.jl"
     ]
+  },
+  "authors": [
+    {
+      "github_username": "cmcaine",
+      "exercism_username": "cmcaine"
+    },
+    {
+      "github_username": "SaschaMann",
+      "exercism_username": "SaschaMann"
+    }
+  ]
 }

--- a/languages/julia/exercises/concept/emoji-times/.meta/config.json
+++ b/languages/julia/exercises/concept/emoji-times/.meta/config.json
@@ -4,6 +4,9 @@
     "test": [
       "runtests.jl"
     ],
+    "exemplar": [
+      ".meta/exemplar.jl"
+    ],
     "solution": [
       "emoji-times.jl"
     ]

--- a/languages/julia/exercises/concept/encounters/.meta/config.json
+++ b/languages/julia/exercises/concept/encounters/.meta/config.json
@@ -4,6 +4,9 @@
     "test": [
       "runtests.jl"
     ],
+    "exemplar": [
+      ".meta/exemplar.jl"
+    ],
     "solution": [
       "encounters.jl"
     ]

--- a/languages/julia/exercises/concept/encounters/.meta/config.json
+++ b/languages/julia/exercises/concept/encounters/.meta/config.json
@@ -1,10 +1,10 @@
 {
     "language_versions": "≥1.0",
-    "editor": {
-        "test_files": [
+    "files": {
+        "test": [
             "runtests.jl"
         ],
-        "solution_files": [
+        "solution": [
             "encounters.jl"
         ]
     },

--- a/languages/julia/exercises/concept/encounters/.meta/config.json
+++ b/languages/julia/exercises/concept/encounters/.meta/config.json
@@ -1,17 +1,17 @@
 {
-    "language_versions": "≥1.0",
-    "files": {
-        "test": [
-            "runtests.jl"
-        ],
-        "solution": [
-            "encounters.jl"
-        ]
-    },
-    "authors": [
-        {
-            "github_username": "SaschaMann",
-            "exercism_username": "SaschaMann"
-        }
+  "language_versions": "≥1.0",
+  "files": {
+    "test": [
+      "runtests.jl"
+    ],
+    "solution": [
+      "encounters.jl"
     ]
+  },
+  "authors": [
+    {
+      "github_username": "SaschaMann",
+      "exercism_username": "SaschaMann"
+    }
+  ]
 }

--- a/languages/julia/exercises/concept/exercism-matrix/.meta/config.json
+++ b/languages/julia/exercises/concept/exercism-matrix/.meta/config.json
@@ -1,17 +1,17 @@
 {
-    "language_versions": "≥1.0",
-    "files": {
-        "test": [
-            "runtests.jl"
-        ],
-        "solution": [
-            "exercism-matrix.jl"
-        ]
-    },
-    "authors": [
-        {
-            "github_username": "SaschaMann",
-            "exercism_username": "SaschaMann"
-        }
+  "language_versions": "≥1.0",
+  "files": {
+    "test": [
+      "runtests.jl"
+    ],
+    "solution": [
+      "exercism-matrix.jl"
     ]
+  },
+  "authors": [
+    {
+      "github_username": "SaschaMann",
+      "exercism_username": "SaschaMann"
+    }
+  ]
 }

--- a/languages/julia/exercises/concept/exercism-matrix/.meta/config.json
+++ b/languages/julia/exercises/concept/exercism-matrix/.meta/config.json
@@ -1,10 +1,10 @@
 {
     "language_versions": "≥1.0",
-    "editor": {
-        "test_files": [
+    "files": {
+        "test": [
             "runtests.jl"
         ],
-        "solution_files": [
+        "solution": [
             "exercism-matrix.jl"
         ]
     },

--- a/languages/julia/exercises/concept/exercism-matrix/.meta/config.json
+++ b/languages/julia/exercises/concept/exercism-matrix/.meta/config.json
@@ -4,6 +4,9 @@
     "test": [
       "runtests.jl"
     ],
+    "exemplar": [
+      ".meta/exemplar.jl"
+    ],
     "solution": [
       "exercism-matrix.jl"
     ]

--- a/languages/julia/exercises/concept/fibonacci-iterator/.meta/config.json
+++ b/languages/julia/exercises/concept/fibonacci-iterator/.meta/config.json
@@ -1,10 +1,10 @@
 {
     "language_versions": "≥1.0",
-    "editor": {
-        "test_files": [
+    "files": {
+        "test": [
             "runtests.jl"
         ],
-        "solution_files": [
+        "solution": [
             "fibonacci.jl"
         ]
     },

--- a/languages/julia/exercises/concept/fibonacci-iterator/.meta/config.json
+++ b/languages/julia/exercises/concept/fibonacci-iterator/.meta/config.json
@@ -1,17 +1,17 @@
 {
-    "language_versions": "≥1.0",
-    "files": {
-        "test": [
-            "runtests.jl"
-        ],
-        "solution": [
-            "fibonacci.jl"
-        ]
-    },
-    "authors": [
-        {
-            "github_username": "SaschaMann",
-            "exercism_username": "SaschaMann"
-        }
+  "language_versions": "≥1.0",
+  "files": {
+    "test": [
+      "runtests.jl"
+    ],
+    "solution": [
+      "fibonacci.jl"
     ]
+  },
+  "authors": [
+    {
+      "github_username": "SaschaMann",
+      "exercism_username": "SaschaMann"
+    }
+  ]
 }

--- a/languages/julia/exercises/concept/fibonacci-iterator/.meta/config.json
+++ b/languages/julia/exercises/concept/fibonacci-iterator/.meta/config.json
@@ -4,6 +4,9 @@
     "test": [
       "runtests.jl"
     ],
+    "exemplar": [
+      ".meta/exemplar.jl"
+    ],
     "solution": [
       "fibonacci.jl"
     ]

--- a/languages/julia/exercises/concept/lasagna/.meta/config.json
+++ b/languages/julia/exercises/concept/lasagna/.meta/config.json
@@ -1,10 +1,10 @@
 {
     "language_versions": "≥1.0",
-    "editor": {
-        "test_files": [
+    "files": {
+        "test": [
             "runtests.jl"
         ],
-        "solution_files": [
+        "solution": [
             "lasagna.jl"
         ]
     },

--- a/languages/julia/exercises/concept/lasagna/.meta/config.json
+++ b/languages/julia/exercises/concept/lasagna/.meta/config.json
@@ -1,20 +1,20 @@
 {
-    "language_versions": "≥1.0",
-    "files": {
-        "test": [
-            "runtests.jl"
-        ],
-        "solution": [
-            "lasagna.jl"
-        ]
-    },
-    "forked_from": [
-        "fsharp/basics"
+  "language_versions": "≥1.0",
+  "files": {
+    "test": [
+      "runtests.jl"
     ],
-    "authors": [
-        {
-            "github_username": "SaschaMann",
-            "exercism_username": "SaschaMann"
-        }
+    "solution": [
+      "lasagna.jl"
     ]
+  },
+  "forked_from": [
+    "fsharp/basics"
+  ],
+  "authors": [
+    {
+      "github_username": "SaschaMann",
+      "exercism_username": "SaschaMann"
+    }
+  ]
 }

--- a/languages/julia/exercises/concept/lasagna/.meta/config.json
+++ b/languages/julia/exercises/concept/lasagna/.meta/config.json
@@ -4,6 +4,9 @@
     "test": [
       "runtests.jl"
     ],
+    "exemplar": [
+      ".meta/exemplar.jl"
+    ],
     "solution": [
       "lasagna.jl"
     ]

--- a/languages/julia/exercises/concept/vehicle-purchase/.meta/config.json
+++ b/languages/julia/exercises/concept/vehicle-purchase/.meta/config.json
@@ -1,10 +1,10 @@
 {
     "language_versions": "≥1.0",
-    "editor": {
-        "test_files": [
+    "files": {
+        "test": [
             "runtests.jl"
         ],
-        "solution_files": [
+        "solution": [
             "vehicle-purchase.jl"
         ]
     },

--- a/languages/julia/exercises/concept/vehicle-purchase/.meta/config.json
+++ b/languages/julia/exercises/concept/vehicle-purchase/.meta/config.json
@@ -4,6 +4,9 @@
     "test": [
       "runtests.jl"
     ],
+    "exemplar": [
+      ".meta/exemplar.jl"
+    ],
     "solution": [
       "vehicle-purchase.jl"
     ]

--- a/languages/julia/exercises/concept/vehicle-purchase/.meta/config.json
+++ b/languages/julia/exercises/concept/vehicle-purchase/.meta/config.json
@@ -1,20 +1,20 @@
 {
-    "language_versions": "≥1.0",
-    "files": {
-        "test": [
-            "runtests.jl"
-        ],
-        "solution": [
-            "vehicle-purchase.jl"
-        ]
-    },
-    "forked_from": [
-        "swift/vehicle-purchase"
+  "language_versions": "≥1.0",
+  "files": {
+    "test": [
+      "runtests.jl"
     ],
-    "authors": [
-        {
-            "github_username": "SaschaMann",
-            "exercism_username": "SaschaMann"
-        }
+    "solution": [
+      "vehicle-purchase.jl"
     ]
+  },
+  "forked_from": [
+    "swift/vehicle-purchase"
+  ],
+  "authors": [
+    {
+      "github_username": "SaschaMann",
+      "exercism_username": "SaschaMann"
+    }
+  ]
 }

--- a/languages/kotlin/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/languages/kotlin/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["fsharp/booleans"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": []
   }
 }

--- a/languages/kotlin/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/languages/kotlin/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "dector"
     }
   ],
-  "forked_from": ["fsharp/booleans"]
+  "forked_from": ["fsharp/booleans"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/kotlin/exercises/concept/basics/.meta/config.json
+++ b/languages/kotlin/exercises/concept/basics/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "dector"
     }
   ],
-  "forked_from": ["fsharp/basics"]
+  "forked_from": ["fsharp/basics"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/kotlin/exercises/concept/basics/.meta/config.json
+++ b/languages/kotlin/exercises/concept/basics/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["fsharp/basics"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": []
   }
 }

--- a/languages/nim/exercises/concept/basics/.meta/config.json
+++ b/languages/nim/exercises/concept/basics/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "ynfle"
     }
   ],
-  "forked_from": ["javascript/basics", "python/basics"]
+  "forked_from": ["javascript/basics", "python/basics"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/nim/exercises/concept/basics/.meta/config.json
+++ b/languages/nim/exercises/concept/basics/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["javascript/basics", "python/basics"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.nim"]
   }
 }

--- a/languages/purescript/exercises/concept/booleans/.meta/config.json
+++ b/languages/purescript/exercises/concept/booleans/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["javascript/booleans"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/Exemplar.purs"]
   }
 }

--- a/languages/purescript/exercises/concept/booleans/.meta/config.json
+++ b/languages/purescript/exercises/concept/booleans/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "aimorris"
     }
   ],
-  "forked_from": ["javascript/booleans"]
+  "forked_from": ["javascript/booleans"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/python/exercises/concept/chaitanas-colossal-coaster/.meta/config.json
+++ b/languages/python/exercises/concept/chaitanas-colossal-coaster/.meta/config.json
@@ -17,6 +17,7 @@
   ],
   "files": {
     "solution": ["list_methods.py"],
-    "test": ["list_methods_test.py"]
+    "test": ["list_methods_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/languages/python/exercises/concept/chaitanas-colossal-coaster/.meta/config.json
+++ b/languages/python/exercises/concept/chaitanas-colossal-coaster/.meta/config.json
@@ -15,8 +15,8 @@
       "exercism_username": "BethanyG"
     }
   ],
-  "editor": {
-    "solution_files": ["list_methods.py"],
-    "test_files": ["list_methods_test.py"]
+  "files": {
+    "solution": ["list_methods.py"],
+    "test": ["list_methods_test.py"]
   }
 }

--- a/languages/python/exercises/concept/currency-exchange/.meta/config.json
+++ b/languages/python/exercises/concept/currency-exchange/.meta/config.json
@@ -23,6 +23,7 @@
   ],
   "files": {
     "solution": ["numbers.py"],
-    "test": ["numbers_test.py"]
+    "test": ["numbers_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/languages/python/exercises/concept/currency-exchange/.meta/config.json
+++ b/languages/python/exercises/concept/currency-exchange/.meta/config.json
@@ -21,8 +21,8 @@
       "exercism_username": "wnstj2007"
     }
   ],
-  "editor": {
-    "solution_files": ["numbers.py"],
-    "test_files": ["numbers_test.py"]
+  "files": {
+    "solution": ["numbers.py"],
+    "test": ["numbers_test.py"]
   }
 }

--- a/languages/python/exercises/concept/elyses-enchantments/.meta/config.json
+++ b/languages/python/exercises/concept/elyses-enchantments/.meta/config.json
@@ -17,6 +17,7 @@
   ],
   "files": {
     "solution": ["lists.py"],
-    "test": ["lists_test.py"]
+    "test": ["lists_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/languages/python/exercises/concept/elyses-enchantments/.meta/config.json
+++ b/languages/python/exercises/concept/elyses-enchantments/.meta/config.json
@@ -15,8 +15,8 @@
       "exercism_username": "itamargal"
     }
   ],
-  "editor": {
-    "solution_files": ["lists.py"],
-    "test_files": ["lists_test.py"]
+  "files": {
+    "solution": ["lists.py"],
+    "test": ["lists_test.py"]
   }
 }

--- a/languages/python/exercises/concept/ghost-gobble-arcade-game/.meta/config.json
+++ b/languages/python/exercises/concept/ghost-gobble-arcade-game/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "cmccandless"
     }
   ],
-  "editor": {
-    "solution_files": ["arcade_game.py"],
-    "test_files": ["arcade_game_test.py"]
+  "files": {
+    "solution": ["arcade_game.py"],
+    "test": ["arcade_game_test.py"]
   },
   "forked_from": ["elixir/booleans"],
   "language_versions": ">=3.5"

--- a/languages/python/exercises/concept/ghost-gobble-arcade-game/.meta/config.json
+++ b/languages/python/exercises/concept/ghost-gobble-arcade-game/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["arcade_game.py"],
-    "test": ["arcade_game_test.py"]
+    "test": ["arcade_game_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   },
   "forked_from": ["elixir/booleans"],
   "language_versions": ">=3.5"

--- a/languages/python/exercises/concept/guidos-gorgeous-lasagna/.meta/config.json
+++ b/languages/python/exercises/concept/guidos-gorgeous-lasagna/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "BethanyG"
     }
   ],
-  "editor": {
-    "solution_files": ["lasagna.py"],
-    "test_files": ["lasagna_test.py"]
+  "files": {
+    "solution": ["lasagna.py"],
+    "test": ["lasagna_test.py"]
   },
   "forked_from": ["csharp/basics", "ruby/basics"]
 }

--- a/languages/python/exercises/concept/guidos-gorgeous-lasagna/.meta/config.json
+++ b/languages/python/exercises/concept/guidos-gorgeous-lasagna/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["lasagna.py"],
-    "test": ["lasagna_test.py"]
+    "test": ["lasagna_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   },
   "forked_from": ["csharp/basics", "ruby/basics"]
 }

--- a/languages/python/exercises/concept/inventory-management/.meta/config.json
+++ b/languages/python/exercises/concept/inventory-management/.meta/config.json
@@ -15,8 +15,8 @@
       "exercism_username": "bethanyG"
     }
   ],
-  "editor": {
-    "solution_files": ["dicts.py"],
-    "test_files": ["dicts_test.py"]
+  "files": {
+    "solution": ["dicts.py"],
+    "test": ["dicts_test.py"]
   }
 }

--- a/languages/python/exercises/concept/inventory-management/.meta/config.json
+++ b/languages/python/exercises/concept/inventory-management/.meta/config.json
@@ -17,6 +17,7 @@
   ],
   "files": {
     "solution": ["dicts.py"],
-    "test": ["dicts_test.py"]
+    "test": ["dicts_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/languages/python/exercises/concept/little-sisters-essay/.meta/config.json
+++ b/languages/python/exercises/concept/little-sisters-essay/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "olivia"
     }
   ],
-  "editor": {
-    "solution_files": ["string_methods.py"],
-    "test_files": ["string_methods_test.py"]
+  "files": {
+    "solution": ["string_methods.py"],
+    "test": ["string_methods_test.py"]
   }
 }

--- a/languages/python/exercises/concept/little-sisters-essay/.meta/config.json
+++ b/languages/python/exercises/concept/little-sisters-essay/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["string_methods.py"],
-    "test": ["string_methods_test.py"]
+    "test": ["string_methods_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/languages/python/exercises/concept/log-levels/.meta/config.json
+++ b/languages/python/exercises/concept/log-levels/.meta/config.json
@@ -11,9 +11,9 @@
       "exercism_username": "mohanrajanr"
     }
   ],
-  "editor": {
-    "solution_files": ["enums.py"],
-    "test_files": ["enums_test.py"]
+  "files": {
+    "solution": ["enums.py"],
+    "test": ["enums_test.py"]
   },
   "forked_from": ["csharp/enums"]
 }

--- a/languages/python/exercises/concept/log-levels/.meta/config.json
+++ b/languages/python/exercises/concept/log-levels/.meta/config.json
@@ -13,7 +13,8 @@
   ],
   "files": {
     "solution": ["enums.py"],
-    "test": ["enums_test.py"]
+    "test": ["enums_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   },
   "forked_from": ["csharp/enums"]
 }

--- a/languages/python/exercises/concept/making-the-grade/.meta/config.json
+++ b/languages/python/exercises/concept/making-the-grade/.meta/config.json
@@ -9,8 +9,8 @@
       "exercism_username": "BethanyG"
     }
   ],
-  "editor": {
-    "solution_files": ["loops.py"],
-    "test_files": ["loops_test.py"]
+  "files": {
+    "solution": ["loops.py"],
+    "test": ["loops_test.py"]
   }
 }

--- a/languages/python/exercises/concept/making-the-grade/.meta/config.json
+++ b/languages/python/exercises/concept/making-the-grade/.meta/config.json
@@ -11,6 +11,7 @@
   ],
   "files": {
     "solution": ["loops.py"],
-    "test": ["loops_test.py"]
+    "test": ["loops_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/languages/python/exercises/concept/pretty-leaflet/.meta/config.json
+++ b/languages/python/exercises/concept/pretty-leaflet/.meta/config.json
@@ -17,6 +17,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/languages/python/exercises/concept/pretty-leaflet/.meta/config.json
+++ b/languages/python/exercises/concept/pretty-leaflet/.meta/config.json
@@ -14,5 +14,9 @@
       "github_username": "valentin-p",
       "exercism_username": "valentin-p"
     }
-  ]
+  ],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/python/exercises/concept/processing-logs/.meta/config.json
+++ b/languages/python/exercises/concept/processing-logs/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["strings.py"],
-    "test": ["strings_test.py"]
+    "test": ["strings_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   },
   "forked_from": ["csharp/strings"]
 }

--- a/languages/python/exercises/concept/processing-logs/.meta/config.json
+++ b/languages/python/exercises/concept/processing-logs/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "aldraco"
     }
   ],
-  "editor": {
-    "solution_files": ["strings.py"],
-    "test_files": ["strings_test.py"]
+  "files": {
+    "solution": ["strings.py"],
+    "test": ["strings_test.py"]
   },
   "forked_from": ["csharp/strings"]
 }

--- a/languages/python/exercises/concept/restaurant-rozalynn/.meta/config.json
+++ b/languages/python/exercises/concept/restaurant-rozalynn/.meta/config.json
@@ -9,8 +9,8 @@
       "exercism_username": "BethanyG"
     }
   ],
-  "editor": {
-    "solution_files": ["none.py"],
-    "test_files": ["none_test.py"]
+  "files": {
+    "solution": ["none.py"],
+    "test": ["none_test.py"]
   }
 }

--- a/languages/python/exercises/concept/restaurant-rozalynn/.meta/config.json
+++ b/languages/python/exercises/concept/restaurant-rozalynn/.meta/config.json
@@ -11,6 +11,7 @@
   ],
   "files": {
     "solution": ["none.py"],
-    "test": ["none_test.py"]
+    "test": ["none_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/languages/python/exercises/concept/sets/.meta/config.json
+++ b/languages/python/exercises/concept/sets/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["sets.py"],
-    "test": ["sets_test.py"]
+    "test": ["sets_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/languages/python/exercises/concept/sets/.meta/config.json
+++ b/languages/python/exercises/concept/sets/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "BethanyG"
     }
   ],
-  "editor": {
-    "solution_files": ["sets.py"],
-    "test_files": ["sets_test.py"]
+  "files": {
+    "solution": ["sets.py"],
+    "test": ["sets_test.py"]
   }
 }

--- a/languages/python/exercises/concept/tisbury-treasure-hunt/.meta/config.json
+++ b/languages/python/exercises/concept/tisbury-treasure-hunt/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["tuples.py"],
-    "test": ["tuples_test.py"]
+    "test": ["tuples_test.py"],
+    "exemplar": [".meta/exemplar.py"]
   }
 }

--- a/languages/python/exercises/concept/tisbury-treasure-hunt/.meta/config.json
+++ b/languages/python/exercises/concept/tisbury-treasure-hunt/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "BethanyG"
     }
   ],
-  "editor": {
-    "solution_files": ["tuples.py"],
-    "test_files": ["tuples_test.py"]
+  "files": {
+    "solution": ["tuples.py"],
+    "test": ["tuples_test.py"]
   }
 }

--- a/languages/ruby/exercises/concept/amusement-park-rides/.meta/config.json
+++ b/languages/ruby/exercises/concept/amusement-park-rides/.meta/config.json
@@ -22,6 +22,7 @@
   "language_versions": ">=2.6.6",
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rb"]
   }
 }

--- a/languages/ruby/exercises/concept/amusement-park-rides/.meta/config.json
+++ b/languages/ruby/exercises/concept/amusement-park-rides/.meta/config.json
@@ -19,5 +19,9 @@
       "exercism_username": "kayn1"
     }
   ],
-  "language_versions": ">=2.6.6"
+  "language_versions": ">=2.6.6",
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/ruby/exercises/concept/arrays/.meta/config.json
+++ b/languages/ruby/exercises/concept/arrays/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/arrays"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rb"]
   }
 }

--- a/languages/ruby/exercises/concept/arrays/.meta/config.json
+++ b/languages/ruby/exercises/concept/arrays/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "pvcarrera"
     }
   ],
-  "forked_from": ["csharp/arrays"]
+  "forked_from": ["csharp/arrays"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/ruby/exercises/concept/exceptions/.meta/config.json
+++ b/languages/ruby/exercises/concept/exceptions/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "pvcarrera"
     }
   ],
-  "forked_from": ["csharp/exceptions"]
+  "forked_from": ["csharp/exceptions"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/ruby/exercises/concept/exceptions/.meta/config.json
+++ b/languages/ruby/exercises/concept/exceptions/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/exceptions"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rb"]
   }
 }

--- a/languages/ruby/exercises/concept/floating-point-numbers/.meta/config.json
+++ b/languages/ruby/exercises/concept/floating-point-numbers/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "dvik1950"
     }
   ],
-  "forked_from": ["csharp/floating-point-numbers"]
+  "forked_from": ["csharp/floating-point-numbers"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/ruby/exercises/concept/floating-point-numbers/.meta/config.json
+++ b/languages/ruby/exercises/concept/floating-point-numbers/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/floating-point-numbers"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rb"]
   }
 }

--- a/languages/ruby/exercises/concept/instance-variables/.meta/config.json
+++ b/languages/ruby/exercises/concept/instance-variables/.meta/config.json
@@ -18,6 +18,7 @@
   "language_versions": ">=2.6.6",
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rb"]
   }
 }

--- a/languages/ruby/exercises/concept/instance-variables/.meta/config.json
+++ b/languages/ruby/exercises/concept/instance-variables/.meta/config.json
@@ -15,5 +15,9 @@
       "exercism_username": "kotp"
     }
   ],
-  "language_versions": ">=2.6.6"
+  "language_versions": ">=2.6.6",
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/ruby/exercises/concept/lasagna/.meta/config.json
+++ b/languages/ruby/exercises/concept/lasagna/.meta/config.json
@@ -11,6 +11,7 @@
   ],
   "files": {
     "solution": ["lasagna.rb"],
-    "test": ["lasagna_test.rb"]
+    "test": ["lasagna_test.rb"],
+    "exemplar": [".meta/exemplar.rb"]
   }
 }

--- a/languages/ruby/exercises/concept/lasagna/.meta/config.json
+++ b/languages/ruby/exercises/concept/lasagna/.meta/config.json
@@ -9,8 +9,8 @@
       "exercism_username": "pvcarrera"
     }
   ],
-  "editor": {
-    "solution_files": ["lasagna.rb"],
-    "test_files": ["lasagna_test.rb"]
+  "files": {
+    "solution": ["lasagna.rb"],
+    "test": ["lasagna_test.rb"]
   }
 }

--- a/languages/ruby/exercises/concept/numbers/.meta/config.json
+++ b/languages/ruby/exercises/concept/numbers/.meta/config.json
@@ -15,5 +15,9 @@
       "exercism_username": "iHiD"
     }
   ],
-  "forked_from": ["csharp/numbers"]
+  "forked_from": ["csharp/numbers"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/ruby/exercises/concept/numbers/.meta/config.json
+++ b/languages/ruby/exercises/concept/numbers/.meta/config.json
@@ -18,6 +18,7 @@
   "forked_from": ["csharp/numbers"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rb"]
   }
 }

--- a/languages/ruby/exercises/concept/strings/.meta/config.json
+++ b/languages/ruby/exercises/concept/strings/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rb"]
   }
 }

--- a/languages/ruby/exercises/concept/strings/.meta/config.json
+++ b/languages/ruby/exercises/concept/strings/.meta/config.json
@@ -4,5 +4,9 @@
       "github_username": "pvcarrera",
       "exercism_username": "pvcarrera"
     }
-  ]
+  ],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/rust/exercises/concept/entry-api/.meta/config.json
+++ b/languages/rust/exercises/concept/entry-api/.meta/config.json
@@ -4,5 +4,9 @@
       "github_username": "seanchen1991",
       "exercism_username": "seanchen1991"
     }
-  ]
+  ],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/rust/exercises/concept/entry-api/.meta/config.json
+++ b/languages/rust/exercises/concept/entry-api/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rs"]
   }
 }

--- a/languages/rust/exercises/concept/enums/.meta/config.json
+++ b/languages/rust/exercises/concept/enums/.meta/config.json
@@ -4,5 +4,9 @@
       "github_username": "efx",
       "exercism_username": "efx"
     }
-  ]
+  ],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/rust/exercises/concept/enums/.meta/config.json
+++ b/languages/rust/exercises/concept/enums/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rs"]
   }
 }

--- a/languages/rust/exercises/concept/numbers/.meta/config.json
+++ b/languages/rust/exercises/concept/numbers/.meta/config.json
@@ -4,5 +4,9 @@
       "github_username": "LewisClement",
       "exercism_username": "LewisClement"
     }
-  ]
+  ],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/rust/exercises/concept/numbers/.meta/config.json
+++ b/languages/rust/exercises/concept/numbers/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rs"]
   }
 }

--- a/languages/rust/exercises/concept/options/.meta/config.json
+++ b/languages/rust/exercises/concept/options/.meta/config.json
@@ -8,5 +8,9 @@
       "github_username": "coriolinus",
       "exercism_username": "coriolinus"
     }
-  ]
+  ],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/rust/exercises/concept/options/.meta/config.json
+++ b/languages/rust/exercises/concept/options/.meta/config.json
@@ -11,6 +11,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rs"]
   }
 }

--- a/languages/rust/exercises/concept/string-vs-str/.meta/config.json
+++ b/languages/rust/exercises/concept/string-vs-str/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rs"]
   }
 }

--- a/languages/rust/exercises/concept/string-vs-str/.meta/config.json
+++ b/languages/rust/exercises/concept/string-vs-str/.meta/config.json
@@ -4,5 +4,9 @@
       "github_username": "gilescope",
       "exercism_username": "gilescope"
     }
-  ]
+  ],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/rust/exercises/concept/structs/.meta/config.json
+++ b/languages/rust/exercises/concept/structs/.meta/config.json
@@ -4,5 +4,9 @@
       "github_username": "seanchen1991",
       "exercism_username": "seanchen1991"
     }
-  ]
+  ],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/rust/exercises/concept/structs/.meta/config.json
+++ b/languages/rust/exercises/concept/structs/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rs"]
   }
 }

--- a/languages/rust/exercises/concept/tuples/.meta/config.json
+++ b/languages/rust/exercises/concept/tuples/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rs"]
   }
 }

--- a/languages/rust/exercises/concept/tuples/.meta/config.json
+++ b/languages/rust/exercises/concept/tuples/.meta/config.json
@@ -4,5 +4,9 @@
       "github_username": "coriolinus",
       "exercism_username": "coriolinus"
     }
-  ]
+  ],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/rust/exercises/concept/vec-macro/.meta/config.json
+++ b/languages/rust/exercises/concept/vec-macro/.meta/config.json
@@ -8,5 +8,9 @@
       "github_username": "coriolinus",
       "exercism_username": "coriolinus"
     }
-  ]
+  ],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/rust/exercises/concept/vec-macro/.meta/config.json
+++ b/languages/rust/exercises/concept/vec-macro/.meta/config.json
@@ -11,6 +11,7 @@
   ],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.rs"]
   }
 }

--- a/languages/scala/exercises/concept/basics/.meta/config.json
+++ b/languages/scala/exercises/concept/basics/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "stillleben"
     }
   ],
-  "forked_from": ["csharp/basics"]
+  "forked_from": ["csharp/basics"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/scala/exercises/concept/basics/.meta/config.json
+++ b/languages/scala/exercises/concept/basics/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/basics"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/Exemplar.scala"]
   }
 }

--- a/languages/swift/exercises/concept/bomb-defuser/.meta/config.json
+++ b/languages/swift/exercises/concept/bomb-defuser/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/BombDefuser/BombDefuser.swift"],
-    "test_files": ["Tests/BombDefuserTests/BombDefuserTests.swift"]
+  "files": {
+    "solution": ["Sources/BombDefuser/BombDefuser.swift"],
+    "test": ["Tests/BombDefuserTests/BombDefuserTests.swift"]
   },
   "contributors": [],
   "forked_from": []

--- a/languages/swift/exercises/concept/bomb-defuser/.meta/config.json
+++ b/languages/swift/exercises/concept/bomb-defuser/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["Sources/BombDefuser/BombDefuser.swift"],
-    "test": ["Tests/BombDefuserTests/BombDefuserTests.swift"]
+    "test": ["Tests/BombDefuserTests/BombDefuserTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   },
   "contributors": [],
   "forked_from": []

--- a/languages/swift/exercises/concept/custom-signs/.meta/config.json
+++ b/languages/swift/exercises/concept/custom-signs/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/CustomSigns/CustomSigns.swift"],
-    "test_files": ["Tests/CustomSignsTests/CustomSignsTests.swift"]
+  "files": {
+    "solution": ["Sources/CustomSigns/CustomSigns.swift"],
+    "test": ["Tests/CustomSignsTests/CustomSignsTests.swift"]
   }
 }

--- a/languages/swift/exercises/concept/custom-signs/.meta/config.json
+++ b/languages/swift/exercises/concept/custom-signs/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["Sources/CustomSigns/CustomSigns.swift"],
-    "test": ["Tests/CustomSignsTests/CustomSignsTests.swift"]
+    "test": ["Tests/CustomSignsTests/CustomSignsTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   }
 }

--- a/languages/swift/exercises/concept/freelancer-rates/.meta/config.json
+++ b/languages/swift/exercises/concept/freelancer-rates/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/FreelancerRates/FreelancerRates.swift"],
-    "test_files": ["Tests/FreelancerRatesTests/FreelancerRatesTests.swift"]
+  "files": {
+    "solution": ["Sources/FreelancerRates/FreelancerRates.swift"],
+    "test": ["Tests/FreelancerRatesTests/FreelancerRatesTests.swift"]
   },
   "forked_from": ["javascript/numbers"],
   "language_versions": ">=5.0"

--- a/languages/swift/exercises/concept/freelancer-rates/.meta/config.json
+++ b/languages/swift/exercises/concept/freelancer-rates/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["Sources/FreelancerRates/FreelancerRates.swift"],
-    "test": ["Tests/FreelancerRatesTests/FreelancerRatesTests.swift"]
+    "test": ["Tests/FreelancerRatesTests/FreelancerRatesTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   },
   "forked_from": ["javascript/numbers"],
   "language_versions": ">=5.0"

--- a/languages/swift/exercises/concept/high-score-board/.meta/config.json
+++ b/languages/swift/exercises/concept/high-score-board/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/HighScoreBoard/HighScoreBoard.swift"],
-    "test_files": ["Tests/HighScoreBoardTests/HighScoreBoardTests.swift"]
+  "files": {
+    "solution": ["Sources/HighScoreBoard/HighScoreBoard.swift"],
+    "test": ["Tests/HighScoreBoardTests/HighScoreBoardTests.swift"]
   },
   "forked_from": ["elixir/maps"]
 }

--- a/languages/swift/exercises/concept/high-score-board/.meta/config.json
+++ b/languages/swift/exercises/concept/high-score-board/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["Sources/HighScoreBoard/HighScoreBoard.swift"],
-    "test": ["Tests/HighScoreBoardTests/HighScoreBoardTests.swift"]
+    "test": ["Tests/HighScoreBoardTests/HighScoreBoardTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   },
   "forked_from": ["elixir/maps"]
 }

--- a/languages/swift/exercises/concept/lasagna-master/.meta/config.json
+++ b/languages/swift/exercises/concept/lasagna-master/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/LasagnaMaster/LasagnaMaster.swift"],
-    "test_files": ["Tests/LasagnaMasterTests/LasagnaMasterTests.swift"]
+  "files": {
+    "solution": ["Sources/LasagnaMaster/LasagnaMaster.swift"],
+    "test": ["Tests/LasagnaMasterTests/LasagnaMasterTests.swift"]
   }
 }

--- a/languages/swift/exercises/concept/lasagna-master/.meta/config.json
+++ b/languages/swift/exercises/concept/lasagna-master/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["Sources/LasagnaMaster/LasagnaMaster.swift"],
-    "test": ["Tests/LasagnaMasterTests/LasagnaMasterTests.swift"]
+    "test": ["Tests/LasagnaMasterTests/LasagnaMasterTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   }
 }

--- a/languages/swift/exercises/concept/lasagna/.meta/config.json
+++ b/languages/swift/exercises/concept/lasagna/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/Lasagna/Lasagna.swift"],
-    "test_files": ["Tests/LasagnaTests/LasagnaTests.swift"]
+  "files": {
+    "solution": ["Sources/Lasagna/Lasagna.swift"],
+    "test": ["Tests/LasagnaTests/LasagnaTests.swift"]
   },
   "forked_from": ["fsharp/basics"],
   "language_versions": ">=4.0"

--- a/languages/swift/exercises/concept/lasagna/.meta/config.json
+++ b/languages/swift/exercises/concept/lasagna/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["Sources/Lasagna/Lasagna.swift"],
-    "test": ["Tests/LasagnaTests/LasagnaTests.swift"]
+    "test": ["Tests/LasagnaTests/LasagnaTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   },
   "forked_from": ["fsharp/basics"],
   "language_versions": ">=4.0"

--- a/languages/swift/exercises/concept/log-lines/.meta/config.json
+++ b/languages/swift/exercises/concept/log-lines/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["Sources/LogLines/LogLines.swift"],
-    "test": ["Tests/LogLinesTests/LogLinesTests.swift"]
+    "test": ["Tests/LogLinesTests/LogLinesTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   },
   "forked_from": ["csharp/enums"]
 }

--- a/languages/swift/exercises/concept/log-lines/.meta/config.json
+++ b/languages/swift/exercises/concept/log-lines/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/LogLines/LogLines.swift"],
-    "test_files": ["Tests/LogLinesTests/LogLinesTests.swift"]
+  "files": {
+    "solution": ["Sources/LogLines/LogLines.swift"],
+    "test": ["Tests/LogLinesTests/LogLinesTests.swift"]
   },
   "forked_from": ["csharp/enums"]
 }

--- a/languages/swift/exercises/concept/magician-in-training/.meta/config.json
+++ b/languages/swift/exercises/concept/magician-in-training/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["Sources/MagicianInTraining/MagicianInTraining.swift"],
-    "test": ["Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift"]
+    "test": ["Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   },
   "forked_from": ["go/basic-slices"]
 }

--- a/languages/swift/exercises/concept/magician-in-training/.meta/config.json
+++ b/languages/swift/exercises/concept/magician-in-training/.meta/config.json
@@ -5,11 +5,9 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/MagicianInTraining/MagicianInTraining.swift"],
-    "test_files": [
-      "Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift"
-    ]
+  "files": {
+    "solution": ["Sources/MagicianInTraining/MagicianInTraining.swift"],
+    "test": ["Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift"]
   },
   "forked_from": ["go/basic-slices"]
 }

--- a/languages/swift/exercises/concept/master-mixologist/.meta/config.json
+++ b/languages/swift/exercises/concept/master-mixologist/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["Sources/MasterMixologist/MasterMixologist.swift"],
-    "test": ["Tests/MasterMixologistTests/MasterMixologistTests.swift"]
+    "test": ["Tests/MasterMixologistTests/MasterMixologistTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   }
 }

--- a/languages/swift/exercises/concept/master-mixologist/.meta/config.json
+++ b/languages/swift/exercises/concept/master-mixologist/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/MasterMixologist/MasterMixologist.swift"],
-    "test_files": ["Tests/MasterMixologistTests/MasterMixologistTests.swift"]
+  "files": {
+    "solution": ["Sources/MasterMixologist/MasterMixologist.swift"],
+    "test": ["Tests/MasterMixologistTests/MasterMixologistTests.swift"]
   }
 }

--- a/languages/swift/exercises/concept/pizza-slices/.meta/config.json
+++ b/languages/swift/exercises/concept/pizza-slices/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/PizzaSlices/PizzaSlices.swift"],
-    "test_files": ["Tests/PizzaSlicesTests/PizzaSlicesTests.swift"]
+  "files": {
+    "solution": ["Sources/PizzaSlices/PizzaSlices.swift"],
+    "test": ["Tests/PizzaSlicesTests/PizzaSlicesTests.swift"]
   }
 }

--- a/languages/swift/exercises/concept/pizza-slices/.meta/config.json
+++ b/languages/swift/exercises/concept/pizza-slices/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["Sources/PizzaSlices/PizzaSlices.swift"],
-    "test": ["Tests/PizzaSlicesTests/PizzaSlicesTests.swift"]
+    "test": ["Tests/PizzaSlicesTests/PizzaSlicesTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   }
 }

--- a/languages/swift/exercises/concept/poetry-club/.meta/config.json
+++ b/languages/swift/exercises/concept/poetry-club/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["Sources/PoetryClub/PoetryClub.swift"],
-    "test": ["Tests/PoetryClubTests/PoetryClubTests.swift"]
+    "test": ["Tests/PoetryClubTests/PoetryClubTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   },
   "forked_from": ["javascript/strings"]
 }

--- a/languages/swift/exercises/concept/poetry-club/.meta/config.json
+++ b/languages/swift/exercises/concept/poetry-club/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/PoetryClub/PoetryClub.swift"],
-    "test_files": ["Tests/PoetryClubTests/PoetryClubTests.swift"]
+  "files": {
+    "solution": ["Sources/PoetryClub/PoetryClub.swift"],
+    "test": ["Tests/PoetryClubTests/PoetryClubTests.swift"]
   },
   "forked_from": ["javascript/strings"]
 }

--- a/languages/swift/exercises/concept/santas-helper/.meta/config.json
+++ b/languages/swift/exercises/concept/santas-helper/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/SantasHelper/SantasHelper.swift"],
-    "test_files": ["Tests/SantasHelperTests/SantasHelperTests.swift"]
+  "files": {
+    "solution": ["Sources/SantasHelper/SantasHelper.swift"],
+    "test": ["Tests/SantasHelperTests/SantasHelperTests.swift"]
   }
 }

--- a/languages/swift/exercises/concept/santas-helper/.meta/config.json
+++ b/languages/swift/exercises/concept/santas-helper/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["Sources/SantasHelper/SantasHelper.swift"],
-    "test": ["Tests/SantasHelperTests/SantasHelperTests.swift"]
+    "test": ["Tests/SantasHelperTests/SantasHelperTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   }
 }

--- a/languages/swift/exercises/concept/secret-agent/.meta/config.json
+++ b/languages/swift/exercises/concept/secret-agent/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/SecretAgent/SecretAgent.swift"],
-    "test_files": ["Tests/SecretAgentTests/SecretAgentTests.swift"]
+  "files": {
+    "solution": ["Sources/SecretAgent/SecretAgent.swift"],
+    "test": ["Tests/SecretAgentTests/SecretAgentTests.swift"]
   }
 }

--- a/languages/swift/exercises/concept/secret-agent/.meta/config.json
+++ b/languages/swift/exercises/concept/secret-agent/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["Sources/SecretAgent/SecretAgent.swift"],
-    "test": ["Tests/SecretAgentTests/SecretAgentTests.swift"]
+    "test": ["Tests/SecretAgentTests/SecretAgentTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   }
 }

--- a/languages/swift/exercises/concept/vehicle-purchase/.meta/config.json
+++ b/languages/swift/exercises/concept/vehicle-purchase/.meta/config.json
@@ -5,9 +5,9 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/VehiclePurchase/VehiclePurchase.swift"],
-    "test_files": ["Tests/VehiclePurchaseTests/VehiclePurchaseTests.swift"]
+  "files": {
+    "solution": ["Sources/VehiclePurchase/VehiclePurchase.swift"],
+    "test": ["Tests/VehiclePurchaseTests/VehiclePurchaseTests.swift"]
   },
   "contributors": [],
   "forked_from": []

--- a/languages/swift/exercises/concept/vehicle-purchase/.meta/config.json
+++ b/languages/swift/exercises/concept/vehicle-purchase/.meta/config.json
@@ -7,7 +7,8 @@
   ],
   "files": {
     "solution": ["Sources/VehiclePurchase/VehiclePurchase.swift"],
-    "test": ["Tests/VehiclePurchaseTests/VehiclePurchaseTests.swift"]
+    "test": ["Tests/VehiclePurchaseTests/VehiclePurchaseTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   },
   "contributors": [],
   "forked_from": []

--- a/languages/swift/exercises/concept/windowing-system/.meta/config.json
+++ b/languages/swift/exercises/concept/windowing-system/.meta/config.json
@@ -5,8 +5,8 @@
       "exercism_username": "wneumann"
     }
   ],
-  "editor": {
-    "solution_files": ["Sources/WindowingSystem/WindowingSystem.swift"],
-    "test_files": ["Tests/WindowingSystemTests/WindowingSystemTests.swift"]
+  "files": {
+    "solution": ["Sources/WindowingSystem/WindowingSystem.swift"],
+    "test": ["Tests/WindowingSystemTests/WindowingSystemTests.swift"]
   }
 }

--- a/languages/swift/exercises/concept/windowing-system/.meta/config.json
+++ b/languages/swift/exercises/concept/windowing-system/.meta/config.json
@@ -7,6 +7,7 @@
   ],
   "files": {
     "solution": ["Sources/WindowingSystem/WindowingSystem.swift"],
-    "test": ["Tests/WindowingSystemTests/WindowingSystemTests.swift"]
+    "test": ["Tests/WindowingSystemTests/WindowingSystemTests.swift"],
+    "exemplar": [".meta/Exemplar.swift"]
   }
 }

--- a/languages/x86-64-assembly/exercises/concept/basics/.meta/config.json
+++ b/languages/x86-64-assembly/exercises/concept/basics/.meta/config.json
@@ -5,5 +5,9 @@
       "exercism_username": "bergjohan"
     }
   ],
-  "forked_from": ["csharp/basics"]
+  "forked_from": ["csharp/basics"],
+  "files": {
+    "solution": [],
+    "test": []
+  }
 }

--- a/languages/x86-64-assembly/exercises/concept/basics/.meta/config.json
+++ b/languages/x86-64-assembly/exercises/concept/basics/.meta/config.json
@@ -8,6 +8,7 @@
   "forked_from": ["csharp/basics"],
   "files": {
     "solution": [],
-    "test": []
+    "test": [],
+    "exemplar": [".meta/exemplar.asm"]
   }
 }


### PR DESCRIPTION
We're renaming the "editor" field in the .meta/config.json file to "files", as their usage isn't just restricted to the editor (we can use them for the CLI too).

See https://github.com/exercism/v3-docs/pull/25/files

I've also taken the liberty of adding the "files" field when it wasn't yet specified in an exercise.

- Convert `editor` key to `files`
- Add missing `files` field to .meta/config.json files
- Add exemplar files to .meta/config.json
